### PR TITLE
chore: sync template provenance binary flow

### DIFF
--- a/.github/workflows/deploy-devo.yml
+++ b/.github/workflows/deploy-devo.yml
@@ -17,9 +17,10 @@ jobs:
     uses: Lychee-Technology/ltbase-deploy-workflows/.github/workflows/deploy-devo.yml@v1
     with:
       pulumi_stack: devo
-      aws_region: ${{ vars.AWS_REGION || 'ap-northeast-1' }}
+      aws_region: ${{ vars.AWS_REGION_DEVO || 'ap-northeast-1' }}
       release_id: ${{ inputs.release_id }}
       pulumi_backend_url: ${{ vars.PULUMI_BACKEND_URL }}
+      pulumi_secrets_provider: ${{ vars.PULUMI_SECRETS_PROVIDER_DEVO }}
       releases_repo: ${{ vars.LTBASE_RELEASES_REPO || 'Lychee-Technology/ltbase-releases' }}
       working_directory: infra
     secrets:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,9 +17,10 @@ jobs:
     uses: Lychee-Technology/ltbase-deploy-workflows/.github/workflows/preview.yml@v1
     with:
       pulumi_stack: devo
-      aws_region: ${{ vars.AWS_REGION || 'ap-northeast-1' }}
+      aws_region: ${{ vars.AWS_REGION_DEVO || 'ap-northeast-1' }}
       release_id: ${{ inputs.release_id || vars.LTBASE_RELEASE_ID }}
       pulumi_backend_url: ${{ vars.PULUMI_BACKEND_URL }}
+      pulumi_secrets_provider: ${{ vars.PULUMI_SECRETS_PROVIDER_DEVO }}
       releases_repo: ${{ vars.LTBASE_RELEASES_REPO || 'Lychee-Technology/ltbase-releases' }}
       working_directory: infra
     secrets:

--- a/.github/workflows/promote-prod.yml
+++ b/.github/workflows/promote-prod.yml
@@ -25,9 +25,10 @@ jobs:
     uses: Lychee-Technology/ltbase-deploy-workflows/.github/workflows/promote-prod.yml@v1
     with:
       pulumi_stack: prod
-      aws_region: ${{ vars.AWS_REGION || 'ap-northeast-1' }}
+      aws_region: ${{ vars.AWS_REGION_PROD || 'ap-northeast-1' }}
       release_id: ${{ inputs.release_id }}
       pulumi_backend_url: ${{ vars.PULUMI_BACKEND_URL }}
+      pulumi_secrets_provider: ${{ vars.PULUMI_SECRETS_PROVIDER_PROD }}
       releases_repo: ${{ vars.LTBASE_RELEASES_REPO || 'Lychee-Technology/ltbase-releases' }}
       working_directory: infra
     secrets:

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -22,9 +22,11 @@ The standalone customer repository should contain:
 
 ## Required Variables
 
-- `AWS_REGION`
+- `AWS_REGION_DEVO`
+- `AWS_REGION_PROD`
 - `PULUMI_BACKEND_URL`
-- `PULUMI_SECRETS_PROVIDER`
+- `PULUMI_SECRETS_PROVIDER_DEVO`
+- `PULUMI_SECRETS_PROVIDER_PROD`
 - `LTBASE_RELEASES_REPO`
 - `LTBASE_RELEASE_ID`
 
@@ -44,7 +46,8 @@ The standalone customer repository should contain:
 
 - `LTBASE_RELEASES_TOKEN` must be a customer-specific fine-grained token with read-only access to `ltbase-releases`.
 - Local `.env` files are ignored by git and should never be committed.
-- `PULUMI_BACKEND_URL` controls where Pulumi state is stored; `PULUMI_SECRETS_PROVIDER` controls how Pulumi secrets are encrypted.
+- `PULUMI_BACKEND_URL` controls where Pulumi state is stored; the `PULUMI_SECRETS_PROVIDER_*` values control how Pulumi secrets are encrypted for each environment.
+- `env.template` separates `AWS_REGION_DEVO` and `AWS_REGION_PROD` so you can bootstrap split-region deployments.
 - `env.template` separates `AWS_ACCOUNT_ID_DEVO` and `AWS_ACCOUNT_ID_PROD` so you can bootstrap split-account deployments.
 - This template repository keeps preview as a manual workflow because the template itself does not ship with live customer secrets or AWS roles.
 - Revoking that token stops future updates but does not stop an already deployed customer environment.

--- a/docs/CUSTOMER_ONBOARDING.md
+++ b/docs/CUSTOMER_ONBOARDING.md
@@ -18,11 +18,24 @@ Your deployment repository does not build LTBase application source code. It dow
 ## What You Need Before Starting
 
 - A GitHub organization or account that can host a private repository.
-- An AWS account for deployment.
-- A Cloudflare zone for the customer domains you will use.
-- A Pulumi backend bucket in your AWS account.
-- An AWS KMS key for Pulumi stack secret encryption, or permission for the bootstrap script to create one.
+- A devo AWS account and, optionally, a separate prod AWS account.
+- A Cloudflare zone for the domains you will use.
+- Permission to create or update IAM roles, IAM OIDC providers, S3 buckets, and KMS keys in the target AWS accounts.
 - A customer-specific `LTBASE_RELEASES_TOKEN` issued by LTBase.
+- A Gemini API key for runtime summarization features.
+
+## End State
+
+When setup is complete, you will have:
+
+- one private deployment repository created from `ltbase-private-deployment`
+- one GitHub OIDC trust relationship per AWS account used for deployment
+- one deploy role for `devo` and one deploy role for `prod`
+- one Pulumi state bucket
+- one AWS KMS key alias used for Pulumi stack secret encryption
+- repository secrets and variables populated through the bootstrap scripts
+- a `devo` stack ready for preview and deploy
+- a `prod` stack ready for promotion after `devo` is validated
 
 ## Required Repository Secrets
 
@@ -56,7 +69,6 @@ Recommended initial values:
 - `LTBASE_RELEASE_ID=v1.0.0`
 
 `env.template` includes these values as placeholders. Copy it to a local `.env` file, fill in the real values, and keep that file private.
-Use separate account identifiers for `AWS_ACCOUNT_ID_DEVO` and `AWS_ACCOUNT_ID_PROD` when devo and prod live in different AWS accounts.
 
 ## Required Pulumi Configuration
 
@@ -74,7 +86,6 @@ For each stack, configure these non-secret values:
 - `githubOrg`
 - `githubRepo`
 - `releaseId`
-- `dsqlHost` or `dsqlEndpoint`
 - `dsqlPort`
 - `dsqlDB`
 - `dsqlUser`
@@ -82,31 +93,269 @@ For each stack, configure these non-secret values:
 
 Configure these as Pulumi secrets:
 
-- `dsqlPassword`
 - `geminiApiKey`
 
-## Initial Setup
+Aurora DSQL itself is created by the Pulumi blueprint. You do not supply an external `dsqlHost`, `dsqlEndpoint`, or `dsqlPassword` for managed deployments.
+
+## Step-By-Step Deployment
+
+### 1. Create the deployment repository
 
 1. Create a private repository from the public `ltbase-private-deployment` template.
-2. Copy `env.template` to a local `.env` file and fill in the real deployment values.
-3. Run `./scripts/bootstrap-pulumi-backend.sh --env-file .env`.
-4. Review and apply the generated IAM/KMS policy if your deploy role still needs access to the Pulumi secrets key.
-5. Run `./scripts/bootstrap-deployment-repo.sh --env-file .env --stack devo --infra-dir infra`.
-6. Copy or update `Pulumi.devo.yaml` and `Pulumi.prod.yaml` from the template examples if you want file-based stack config in addition to the scripted setup.
-7. Confirm your deploy roles can be assumed through GitHub OIDC.
-8. Confirm `LTBASE_RELEASES_TOKEN` can read the LTBase private releases repository.
+2. Clone that repository locally.
+3. Confirm the repository contains:
+   - `infra/`
+   - `.github/workflows/`
+   - `env.template`
+   - `scripts/bootstrap-pulumi-backend.sh`
+   - `scripts/bootstrap-deployment-repo.sh`
 
-## First Deployment
+### 2. Create or confirm the GitHub OIDC provider
 
-1. Set `LTBASE_RELEASE_ID` to `v1.0.0`.
-2. Run the preview workflow manually after the repository secrets and variables are configured.
+You need a GitHub OIDC provider in each AWS account used by deployment. If it already exists, reuse it.
+
+Typical provider ARN:
+
+```text
+arn:aws:iam::<account-id>:oidc-provider/token.actions.githubusercontent.com
+```
+
+If you need to create it, create it once per account with the standard GitHub issuer:
+
+- URL: `https://token.actions.githubusercontent.com`
+- audience: `sts.amazonaws.com`
+
+### 3. Create the deploy roles
+
+Create one IAM role for `devo` and one for `prod`. If `devo` and `prod` live in different AWS accounts, create one role in each account.
+
+The bootstrap scripts do **not** create these IAM roles. They consume the role ARNs you provide in `.env` and write them into GitHub Actions secrets.
+
+#### 3.1 Trust policy template
+
+Use this trust policy as a starting point for each deploy role. Replace the placeholders:
+
+- `<github-org>`
+- `<repo-name>`
+- `<default-branch>`
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowGitHubActionsOidc",
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<account-id>:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": [
+            "repo:<github-org>/<repo-name>:ref:refs/heads/<default-branch>",
+            "repo:<github-org>/<repo-name>:ref:refs/heads/feature/*",
+            "repo:<github-org>/<repo-name>:pull_request"
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+If you want to tighten this later, reduce the allowed `sub` patterns after your deployment process stabilizes.
+
+#### 3.2 Permissions policy guidance
+
+For the first successful deployment, the simplest path is to give the deploy role an administrator-scoped policy in the target account or an organization-approved equivalent broad deployment role. This is the fastest way to avoid chasing missing service permissions during the first bootstrap.
+
+After the first deployment works, you can replace that with a tighter policy.
+
+At minimum, the deploy role must be able to:
+
+- read and write the Pulumi state bucket
+- use the Pulumi KMS key
+- create and update the AWS resources managed by the LTBase blueprint
+- pass any IAM roles created during deployment if the blueprint requires it
+
+#### 3.3 Minimal backend and KMS policy template
+
+This is a useful baseline policy fragment for the Pulumi state bucket and secrets key. Replace the placeholders:
+
+- `<state-bucket>`
+- `<kms-key-arn>`
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowPulumiStateBucket",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket"
+      ],
+      "Resource": "arn:aws:s3:::<state-bucket>"
+    },
+    {
+      "Sid": "AllowPulumiStateObjects",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": "arn:aws:s3:::<state-bucket>/*"
+    },
+    {
+      "Sid": "AllowPulumiSecretsKey",
+      "Effect": "Allow",
+      "Action": [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:GenerateDataKey",
+        "kms:DescribeKey"
+      ],
+      "Resource": "<kms-key-arn>"
+    }
+  ]
+}
+```
+
+The bootstrap script also generates `dist/pulumi-kms-policy.json`, which you can use as a role-specific KMS access template.
+
+### 4. Prepare the local `.env` file
+
+1. Copy `env.template` to `.env`.
+2. Fill in the real values.
+3. Do not commit `.env`.
+
+Minimum values you must provide:
+
+```bash
+DEPLOYMENT_REPO=<github-org>/<repo-name>
+
+AWS_REGION_DEVO=<devo-region>
+AWS_REGION_PROD=<prod-region>
+AWS_ACCOUNT_ID_DEVO=<devo-account-id>
+AWS_ACCOUNT_ID_PROD=<prod-account-id>
+AWS_ROLE_ARN_DEVO=arn:aws:iam::<devo-account-id>:role/<devo-role>
+AWS_ROLE_ARN_PROD=arn:aws:iam::<prod-account-id>:role/<prod-role>
+
+PULUMI_STATE_BUCKET=<global-unique-state-bucket>
+PULUMI_KMS_ALIAS=alias/ltbase-pulumi-secrets
+
+LTBASE_RELEASES_REPO=Lychee-Technology/ltbase-releases
+LTBASE_RELEASE_ID=v1.0.0
+
+API_DOMAIN=api.devo.example.com
+CONTROL_DOMAIN=control.devo.example.com
+AUTH_DOMAIN=auth.devo.example.com
+CLOUDFLARE_ZONE_ID=<cloudflare-zone-id>
+OIDC_ISSUER_URL=https://<issuer>
+JWKS_URL=https://<issuer>/.well-known/jwks.json
+
+RUNTIME_BUCKET=<global-unique-runtime-bucket>
+TABLE_NAME=<devo-table-name>
+GITHUB_ORG=<github-org>
+GITHUB_REPO=<repo-name>
+GEMINI_MODEL=gemini-3-flash-preview
+DSQL_PORT=5432
+DSQL_DB=ltbase
+DSQL_USER=ltbase
+DSQL_PROJECT_SCHEMA=ltbase
+
+GEMINI_API_KEY=<gemini-api-key>
+CLOUDFLARE_API_TOKEN=<cloudflare-api-token>
+LTBASE_RELEASES_TOKEN=<ltbase-releases-token>
+```
+
+### 5. Bootstrap the Pulumi backend and KMS configuration
+
+Run:
+
+```bash
+./scripts/bootstrap-pulumi-backend.sh --env-file .env
+```
+
+This script will:
+
+- create or reuse the Pulumi state bucket
+- create or reuse the Pulumi KMS alias
+- generate `dist/pulumi-backend.env`
+- generate `dist/pulumi-kms-policy.json`
+
+Review the outputs:
+
+- `dist/pulumi-backend.env`
+- `dist/pulumi-kms-policy.json`
+
+If needed, merge the generated values back into `.env`:
+
+```bash
+source dist/pulumi-backend.env
+```
+
+### 6. Bootstrap the repository configuration and the `devo` stack
+
+Run:
+
+```bash
+./scripts/bootstrap-deployment-repo.sh --env-file .env --stack devo --infra-dir infra
+```
+
+This script will:
+
+- write GitHub Actions variables
+- write GitHub Actions secrets
+- log into the Pulumi backend
+- initialize the `devo` stack if it does not exist
+- write Pulumi config for the `devo` stack
+- store `geminiApiKey` as a Pulumi secret
+
+### 7. Bootstrap the `prod` stack
+
+Run the same script for `prod`:
+
+```bash
+./scripts/bootstrap-deployment-repo.sh --env-file .env --stack prod --infra-dir infra
+```
+
+This will reuse the same repository secrets and variables, but apply the `prod` region and `prod` Pulumi secrets provider when configuring the `prod` stack.
+
+### 8. Confirm repository configuration
+
+Before running any deployment workflow, confirm the repository contains:
+
+- secrets
+  - `AWS_ROLE_ARN_DEVO`
+  - `AWS_ROLE_ARN_PROD`
+  - `LTBASE_RELEASES_TOKEN`
+  - `CLOUDFLARE_API_TOKEN`
+- variables
+  - `AWS_REGION_DEVO`
+  - `AWS_REGION_PROD`
+  - `PULUMI_BACKEND_URL`
+  - `PULUMI_SECRETS_PROVIDER_DEVO`
+  - `PULUMI_SECRETS_PROVIDER_PROD`
+  - `LTBASE_RELEASES_REPO`
+  - `LTBASE_RELEASE_ID`
+
+### 9. First deployment
+
+1. Set `LTBASE_RELEASE_ID` to the release you want, such as `v1.0.0`.
+2. Run the `preview` workflow manually.
 3. Review the Pulumi preview output.
-4. Run the devo deployment workflow.
-5. Verify the devo environment.
-6. Run the prod promotion workflow.
+4. Run the `devo` deployment workflow.
+5. Verify the `devo` environment.
+6. Run the `prod` promotion workflow.
 7. Approve the `prod` environment when GitHub asks for approval.
 
-## Day-2 Upgrades
+### 10. Day-2 upgrades
 
 To adopt a new LTBase application version:
 

--- a/docs/CUSTOMER_ONBOARDING.md
+++ b/docs/CUSTOMER_ONBOARDING.md
@@ -37,17 +37,21 @@ Set these GitHub Actions secrets in your deployment repository:
 
 Set these GitHub Actions variables in your deployment repository:
 
-- `AWS_REGION`
+- `AWS_REGION_DEVO`
+- `AWS_REGION_PROD`
 - `PULUMI_BACKEND_URL`
-- `PULUMI_SECRETS_PROVIDER`
+- `PULUMI_SECRETS_PROVIDER_DEVO`
+- `PULUMI_SECRETS_PROVIDER_PROD`
 - `LTBASE_RELEASES_REPO`
 - `LTBASE_RELEASE_ID`
 
 Recommended initial values:
 
-- `AWS_REGION=ap-northeast-1`
+- `AWS_REGION_DEVO=ap-northeast-1`
+- `AWS_REGION_PROD=us-west-2`
 - `PULUMI_BACKEND_URL=s3://ltbase-pulumi-state`
-- `PULUMI_SECRETS_PROVIDER=awskms://alias/ltbase-pulumi-secrets?region=ap-northeast-1`
+- `PULUMI_SECRETS_PROVIDER_DEVO=awskms://alias/ltbase-pulumi-secrets?region=ap-northeast-1`
+- `PULUMI_SECRETS_PROVIDER_PROD=awskms://alias/ltbase-pulumi-secrets?region=us-west-2`
 - `LTBASE_RELEASES_REPO=Lychee-Technology/ltbase-releases`
 - `LTBASE_RELEASE_ID=v1.0.0`
 

--- a/env.template
+++ b/env.template
@@ -3,7 +3,8 @@
 
 DEPLOYMENT_REPO=Lychee-Technology/ltbase-private-deployment
 
-AWS_REGION=ap-northeast-1
+AWS_REGION_DEVO=ap-northeast-1
+AWS_REGION_PROD=us-west-2
 AWS_ACCOUNT_ID_DEVO=123456789012
 AWS_ACCOUNT_ID_PROD=210987654321
 AWS_ROLE_ARN_DEVO=arn:aws:iam::123456789012:role/ltbase-deploy-devo
@@ -12,7 +13,8 @@ AWS_ROLE_ARN_PROD=arn:aws:iam::123456789012:role/ltbase-deploy-prod
 PULUMI_STATE_BUCKET=replace-with-pulumi-state-bucket
 PULUMI_KMS_ALIAS=alias/ltbase-pulumi-secrets
 PULUMI_BACKEND_URL=
-PULUMI_SECRETS_PROVIDER=
+PULUMI_SECRETS_PROVIDER_DEVO=
+PULUMI_SECRETS_PROVIDER_PROD=
 
 LTBASE_RELEASES_REPO=Lychee-Technology/ltbase-releases
 LTBASE_RELEASE_ID=v1.0.0

--- a/scripts/bootstrap-deployment-repo.sh
+++ b/scripts/bootstrap-deployment-repo.sh
@@ -35,7 +35,7 @@ fi
 # shellcheck disable=SC1090
 source "${ENV_FILE}"
 
-required_vars=(DEPLOYMENT_REPO AWS_REGION PULUMI_BACKEND_URL PULUMI_SECRETS_PROVIDER LTBASE_RELEASES_REPO LTBASE_RELEASE_ID AWS_ROLE_ARN_DEVO AWS_ROLE_ARN_PROD LTBASE_RELEASES_TOKEN CLOUDFLARE_API_TOKEN GEMINI_API_KEY API_DOMAIN CONTROL_DOMAIN AUTH_DOMAIN CLOUDFLARE_ZONE_ID OIDC_ISSUER_URL JWKS_URL RUNTIME_BUCKET TABLE_NAME GITHUB_ORG GITHUB_REPO GEMINI_MODEL DSQL_PORT DSQL_DB DSQL_USER DSQL_PROJECT_SCHEMA)
+required_vars=(DEPLOYMENT_REPO AWS_REGION_DEVO AWS_REGION_PROD PULUMI_BACKEND_URL PULUMI_SECRETS_PROVIDER_DEVO PULUMI_SECRETS_PROVIDER_PROD LTBASE_RELEASES_REPO LTBASE_RELEASE_ID AWS_ROLE_ARN_DEVO AWS_ROLE_ARN_PROD LTBASE_RELEASES_TOKEN CLOUDFLARE_API_TOKEN GEMINI_API_KEY API_DOMAIN CONTROL_DOMAIN AUTH_DOMAIN CLOUDFLARE_ZONE_ID OIDC_ISSUER_URL JWKS_URL RUNTIME_BUCKET TABLE_NAME GITHUB_ORG GITHUB_REPO GEMINI_MODEL DSQL_PORT DSQL_DB DSQL_USER DSQL_PROJECT_SCHEMA)
 for name in "${required_vars[@]}"; do
   if [[ -z "${!name:-}" ]]; then
     echo "${name} is required" >&2
@@ -43,9 +43,11 @@ for name in "${required_vars[@]}"; do
   fi
 done
 
-gh variable set AWS_REGION --repo "${DEPLOYMENT_REPO}" --body "${AWS_REGION}"
+gh variable set AWS_REGION_DEVO --repo "${DEPLOYMENT_REPO}" --body "${AWS_REGION_DEVO}"
+gh variable set AWS_REGION_PROD --repo "${DEPLOYMENT_REPO}" --body "${AWS_REGION_PROD}"
 gh variable set PULUMI_BACKEND_URL --repo "${DEPLOYMENT_REPO}" --body "${PULUMI_BACKEND_URL}"
-gh variable set PULUMI_SECRETS_PROVIDER --repo "${DEPLOYMENT_REPO}" --body "${PULUMI_SECRETS_PROVIDER}"
+gh variable set PULUMI_SECRETS_PROVIDER_DEVO --repo "${DEPLOYMENT_REPO}" --body "${PULUMI_SECRETS_PROVIDER_DEVO}"
+gh variable set PULUMI_SECRETS_PROVIDER_PROD --repo "${DEPLOYMENT_REPO}" --body "${PULUMI_SECRETS_PROVIDER_PROD}"
 gh variable set LTBASE_RELEASES_REPO --repo "${DEPLOYMENT_REPO}" --body "${LTBASE_RELEASES_REPO}"
 gh variable set LTBASE_RELEASE_ID --repo "${DEPLOYMENT_REPO}" --body "${LTBASE_RELEASE_ID}"
 
@@ -54,13 +56,20 @@ gh secret set AWS_ROLE_ARN_PROD --repo "${DEPLOYMENT_REPO}" --body "${AWS_ROLE_A
 gh secret set LTBASE_RELEASES_TOKEN --repo "${DEPLOYMENT_REPO}" --body "${LTBASE_RELEASES_TOKEN}"
 gh secret set CLOUDFLARE_API_TOKEN --repo "${DEPLOYMENT_REPO}" --body "${CLOUDFLARE_API_TOKEN}"
 
+selected_region="${AWS_REGION_DEVO}"
+selected_secrets_provider="${PULUMI_SECRETS_PROVIDER_DEVO}"
+if [[ "${STACK}" == "prod" ]]; then
+  selected_region="${AWS_REGION_PROD}"
+  selected_secrets_provider="${PULUMI_SECRETS_PROVIDER_PROD}"
+fi
+
 pulumi login "${PULUMI_BACKEND_URL}"
 if ! pulumi stack select "${STACK}" >/dev/null 2>&1; then
-  pulumi stack init "${STACK}" --secrets-provider "${PULUMI_SECRETS_PROVIDER}"
+  pulumi stack init "${STACK}" --secrets-provider "${selected_secrets_provider}"
 fi
 
 pushd "${INFRA_DIR}" >/dev/null
-pulumi config set awsRegion "${AWS_REGION}" --stack "${STACK}"
+pulumi config set awsRegion "${selected_region}" --stack "${STACK}"
 pulumi config set runtimeBucket "${RUNTIME_BUCKET}" --stack "${STACK}"
 pulumi config set tableName "${TABLE_NAME}" --stack "${STACK}"
 pulumi config set apiDomain "${API_DOMAIN}" --stack "${STACK}"

--- a/scripts/bootstrap-pulumi-backend.sh
+++ b/scripts/bootstrap-pulumi-backend.sh
@@ -30,7 +30,7 @@ fi
 # shellcheck disable=SC1090
 source "${ENV_FILE}"
 
-required_vars=(AWS_REGION AWS_ACCOUNT_ID_DEVO AWS_ACCOUNT_ID_PROD PULUMI_STATE_BUCKET PULUMI_KMS_ALIAS AWS_ROLE_ARN_DEVO AWS_ROLE_ARN_PROD)
+required_vars=(AWS_REGION_DEVO AWS_REGION_PROD AWS_ACCOUNT_ID_DEVO AWS_ACCOUNT_ID_PROD PULUMI_STATE_BUCKET PULUMI_KMS_ALIAS AWS_ROLE_ARN_DEVO AWS_ROLE_ARN_PROD)
 for name in "${required_vars[@]}"; do
   if [[ -z "${!name:-}" ]]; then
     echo "${name} is required" >&2
@@ -41,10 +41,10 @@ done
 mkdir -p "${OUTPUT_DIR}"
 
 if ! aws s3api head-bucket --bucket "${PULUMI_STATE_BUCKET}" >/dev/null 2>&1; then
-  if [[ "${AWS_REGION}" == "us-east-1" ]]; then
+  if [[ "${AWS_REGION_DEVO}" == "us-east-1" ]]; then
     aws s3api create-bucket --bucket "${PULUMI_STATE_BUCKET}" >/dev/null
   else
-    aws s3api create-bucket --bucket "${PULUMI_STATE_BUCKET}" --region "${AWS_REGION}" --create-bucket-configuration "LocationConstraint=${AWS_REGION}" >/dev/null
+    aws s3api create-bucket --bucket "${PULUMI_STATE_BUCKET}" --region "${AWS_REGION_DEVO}" --create-bucket-configuration "LocationConstraint=${AWS_REGION_DEVO}" >/dev/null
   fi
 fi
 
@@ -52,20 +52,22 @@ aws s3api put-bucket-versioning --bucket "${PULUMI_STATE_BUCKET}" --versioning-c
 aws s3api put-bucket-encryption --bucket "${PULUMI_STATE_BUCKET}" --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' >/dev/null
 aws s3api put-public-access-block --bucket "${PULUMI_STATE_BUCKET}" --public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true >/dev/null
 
-alias_json="$(aws kms list-aliases --region "${AWS_REGION}" --output json)"
+alias_json="$(aws kms list-aliases --region "${AWS_REGION_DEVO}" --output json)"
 key_id="$(python3 -c 'import json,sys; aliases=json.load(sys.stdin).get("Aliases", []); target="'"${PULUMI_KMS_ALIAS}"'"; match=next((a for a in aliases if a.get("AliasName")==target and a.get("TargetKeyId")), None); print(match.get("TargetKeyId", "") if match else "")' <<<"${alias_json}")"
 
 if [[ -z "${key_id}" ]]; then
-  key_id="$(aws kms create-key --region "${AWS_REGION}" --description "Pulumi secrets for LTBase private deployment" --query 'KeyMetadata.KeyId' --output text)"
-  aws kms create-alias --region "${AWS_REGION}" --alias-name "${PULUMI_KMS_ALIAS}" --target-key-id "${key_id}" >/dev/null
+  key_id="$(aws kms create-key --region "${AWS_REGION_DEVO}" --description "Pulumi secrets for LTBase private deployment" --query 'KeyMetadata.KeyId' --output text)"
+  aws kms create-alias --region "${AWS_REGION_DEVO}" --alias-name "${PULUMI_KMS_ALIAS}" --target-key-id "${key_id}" >/dev/null
 fi
 
 pulumi_backend_url="s3://${PULUMI_STATE_BUCKET}"
-pulumi_secrets_provider="awskms://${PULUMI_KMS_ALIAS}?region=${AWS_REGION}"
+pulumi_secrets_provider_devo="awskms://${PULUMI_KMS_ALIAS}?region=${AWS_REGION_DEVO}"
+pulumi_secrets_provider_prod="awskms://${PULUMI_KMS_ALIAS}?region=${AWS_REGION_PROD}"
 
 cat >"${OUTPUT_DIR}/pulumi-backend.env" <<EOF
 PULUMI_BACKEND_URL=${pulumi_backend_url}
-PULUMI_SECRETS_PROVIDER=${pulumi_secrets_provider}
+PULUMI_SECRETS_PROVIDER_DEVO=${pulumi_secrets_provider_devo}
+PULUMI_SECRETS_PROVIDER_PROD=${pulumi_secrets_provider_prod}
 EOF
 
 cat >"${OUTPUT_DIR}/pulumi-kms-policy.json" <<EOF
@@ -94,4 +96,5 @@ cat >"${OUTPUT_DIR}/pulumi-kms-policy.json" <<EOF
 EOF
 
 printf 'PULUMI_BACKEND_URL=%s\n' "${pulumi_backend_url}"
-printf 'PULUMI_SECRETS_PROVIDER=%s\n' "${pulumi_secrets_provider}"
+printf 'PULUMI_SECRETS_PROVIDER_DEVO=%s\n' "${pulumi_secrets_provider_devo}"
+printf 'PULUMI_SECRETS_PROVIDER_PROD=%s\n' "${pulumi_secrets_provider_prod}"

--- a/test/bootstrap-deployment-repo-test.sh
+++ b/test/bootstrap-deployment-repo-test.sh
@@ -26,9 +26,11 @@ touch "${log_file}"
 
 cat >"${temp_dir}/.env" <<'EOF'
 DEPLOYMENT_REPO=Lychee-Technology/ltbase-private-deployment
-AWS_REGION=ap-northeast-1
+AWS_REGION_DEVO=ap-northeast-1
+AWS_REGION_PROD=us-west-2
 PULUMI_BACKEND_URL=s3://test-pulumi-state
-PULUMI_SECRETS_PROVIDER=awskms://alias/test-pulumi-secrets?region=ap-northeast-1
+PULUMI_SECRETS_PROVIDER_DEVO=awskms://alias/test-pulumi-secrets?region=ap-northeast-1
+PULUMI_SECRETS_PROVIDER_PROD=awskms://alias/test-pulumi-secrets?region=us-west-2
 LTBASE_RELEASES_REPO=Lychee-Technology/ltbase-releases
 LTBASE_RELEASE_ID=v1.0.0
 AWS_ROLE_ARN_DEVO=arn:aws:iam::123456789012:role/test-deploy-role
@@ -77,7 +79,8 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
     fail "expected script to succeed when implemented, got: ${output}"
   fi
 
-  assert_log_contains "${log_file}" "gh variable set AWS_REGION --repo Lychee-Technology/ltbase-private-deployment --body ap-northeast-1"
+  assert_log_contains "${log_file}" "gh variable set AWS_REGION_DEVO --repo Lychee-Technology/ltbase-private-deployment --body ap-northeast-1"
+  assert_log_contains "${log_file}" "gh variable set AWS_REGION_PROD --repo Lychee-Technology/ltbase-private-deployment --body us-west-2"
   assert_log_contains "${log_file}" "gh secret set AWS_ROLE_ARN_DEVO --repo Lychee-Technology/ltbase-private-deployment --body arn:aws:iam::123456789012:role/test-deploy-role"
   assert_log_contains "${log_file}" "pulumi stack init devo --secrets-provider awskms://alias/test-pulumi-secrets?region=ap-northeast-1"
   assert_log_contains "${log_file}" "pulumi config set --secret geminiApiKey test-gemini-key --stack devo"

--- a/test/bootstrap-pulumi-backend-test.sh
+++ b/test/bootstrap-pulumi-backend-test.sh
@@ -26,7 +26,8 @@ fake_bin="${temp_dir}/bin"
 mkdir -p "${fake_bin}"
 
 cat >"${temp_dir}/.env" <<'EOF'
-AWS_REGION=ap-northeast-1
+AWS_REGION_DEVO=ap-northeast-1
+AWS_REGION_PROD=us-west-2
 AWS_ACCOUNT_ID_DEVO=123456789012
 AWS_ACCOUNT_ID_PROD=210987654321
 PULUMI_STATE_BUCKET=test-pulumi-state
@@ -60,7 +61,8 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
   fi
 
   assert_file_contains "${temp_dir}/dist/pulumi-backend.env" "PULUMI_BACKEND_URL=s3://test-pulumi-state"
-  assert_file_contains "${temp_dir}/dist/pulumi-backend.env" "PULUMI_SECRETS_PROVIDER=awskms://alias/test-pulumi-secrets?region=ap-northeast-1"
+  assert_file_contains "${temp_dir}/dist/pulumi-backend.env" "PULUMI_SECRETS_PROVIDER_DEVO=awskms://alias/test-pulumi-secrets?region=ap-northeast-1"
+  assert_file_contains "${temp_dir}/dist/pulumi-backend.env" "PULUMI_SECRETS_PROVIDER_PROD=awskms://alias/test-pulumi-secrets?region=us-west-2"
   assert_file_contains "${temp_dir}/dist/pulumi-kms-policy.json" "kms:Decrypt"
   assert_file_contains "${temp_dir}/dist/pulumi-kms-policy.json" "arn:aws:iam::123456789012:role/test-deploy-role"
   assert_file_contains "${temp_dir}/dist/pulumi-kms-policy.json" "arn:aws:iam::210987654321:role/test-prod-role"


### PR DESCRIPTION
## Summary
- sync upstream template changes for provenance-based infra binary resolution
- keep the checked-in template provenance fixture at its default placeholder state until the next real sync
- update customer docs and tests to match the upstream-only prebuilt binary contract