### PR TITLE
Publish managed DSQL endpoint from deployment

### DIFF
--- a/docs/CUSTOMER_ONBOARDING.md
+++ b/docs/CUSTOMER_ONBOARDING.md
@@ -95,7 +95,7 @@ Configure these as Pulumi secrets:
 
 - `geminiApiKey`
 
-Aurora DSQL itself is created by the Pulumi blueprint. You do not supply an external `dsqlHost`, `dsqlEndpoint`, or `dsqlPassword` for managed deployments.
+Aurora DSQL itself is created by the Pulumi blueprint. You do not supply an external `dsqlHost`, `dsqlEndpoint`, or `dsqlPassword` for managed deployments. Bootstrap resolves the authoritative managed endpoint from AWS by using the Pulumi-exported `dsqlClusterIdentifier`, then publishes it to stack config as `dsqlEndpoint`.
 
 ## Step-By-Step Deployment
 
@@ -312,6 +312,8 @@ This orchestrates:
 - writing GitHub vars and secrets
 - initializing `devo` and `prod` Pulumi stacks
 
+This one-click path is still bootstrap-safe and configuration-only. It does not run a first full infrastructure apply and it does not reconcile `dsqlEndpoint` yet.
+
 ### 7. Manual bootstrap path
 
 If you want more control, run the steps individually.
@@ -403,7 +405,37 @@ This script will:
 - write Pulumi config for the `devo` stack
 - store `geminiApiKey` as a Pulumi secret
 
-#### 7.5 Bootstrap the `prod` stack
+This step is configuration-only. It does not run a full infrastructure apply and it does not publish `dsqlEndpoint` yet.
+
+#### 7.5 Run the first real infrastructure apply for `devo`
+
+After bootstrap finishes, run your normal preview and deploy flow for `devo` so the managed DSQL cluster actually exists.
+
+#### 7.6 Reconcile the managed DSQL endpoint after infrastructure exists
+
+After that first real infrastructure apply creates the managed DSQL cluster, run:
+
+```bash
+./scripts/reconcile-managed-dsql-endpoint.sh --env-file .env --stack devo --infra-dir infra
+```
+
+This script will:
+
+- read the Pulumi-exported `dsqlClusterIdentifier`
+- resolve the authoritative managed endpoint from AWS
+- publish the resolved endpoint into Pulumi stack config as `dsqlEndpoint`
+- reconcile existing managed stacks by overwriting stale or manually supplied values
+- remove any existing managed `dsqlEndpoint` stack config and fail closed if the authoritative lookup does not succeed
+
+Run the same reconciliation step for `prod` after the `prod` infrastructure exists:
+
+```bash
+./scripts/reconcile-managed-dsql-endpoint.sh --env-file .env --stack prod --infra-dir infra
+```
+
+After reconciliation publishes `dsqlEndpoint`, run the next preview/deploy cycle for that stack so the resolved endpoint is rolled into Lambda environment configuration.
+
+#### 7.7 Bootstrap the `prod` stack
 
 Run the same script for `prod`:
 
@@ -456,6 +488,10 @@ You do not need to rebuild application binaries in your repository.
 
 - The customer infra blueprint now creates the Aurora DSQL cluster as part of the managed deployment stack.
 - For managed deployments, do not set external `dsqlHost`, `dsqlEndpoint`, or `dsqlPassword` values.
+- `bootstrap-all.sh` and `bootstrap-deployment-repo.sh` prepare stack config only; they do not do the first authoritative managed endpoint publish.
+- `reconcile-managed-dsql-endpoint.sh` is the authoritative publisher for managed `dsqlEndpoint` stack config after infrastructure exists.
+- During reconciliation, the script resolves `dsqlEndpoint` from AWS with `dsqlClusterIdentifier` and overwrites stale or manually supplied values.
+- If that authoritative lookup fails, the reconcile step removes any existing managed `dsqlEndpoint` stack config and exits before publishing replacement managed config.
 - Use the documented stack config inputs for `DSQL_DB`, `DSQL_USER`, `DSQL_PORT`, and `DSQL_PROJECT_SCHEMA` instead.
 - If you are migrating from an older private deployment setup that expected external DSQL connection settings, align the application/runtime contract before reusing an existing stack.
 

--- a/env.template
+++ b/env.template
@@ -40,9 +40,12 @@ GITHUB_ORG=customer-org
 GITHUB_REPO=ltbase-private-deployment
 GEMINI_MODEL=gemini-3-flash-preview
 DSQL_PORT=5432
-DSQL_DB=ltbase
-DSQL_USER=ltbase
+DSQL_DB=postgres
+DSQL_USER=admin
 DSQL_PROJECT_SCHEMA=ltbase
+
+# Managed deployments resolve and publish DSQL_ENDPOINT automatically during bootstrap.
+# Do not set DSQL_ENDPOINT manually in .env.
 
 GEMINI_API_KEY=replace-with-gemini-api-key
 CLOUDFLARE_API_TOKEN=replace-with-cloudflare-api-token

--- a/infra/internal/config/config.go
+++ b/infra/internal/config/config.go
@@ -27,6 +27,7 @@ type StackConfig struct {
 	ReleaseID                string
 	FormaCdcSchedule         string
 	DSQLPort                 string
+	DSQLEndpoint             string
 	DSQLDB                   string
 	DSQLUser                 string
 	DSQLProjectSchema        string
@@ -60,6 +61,7 @@ func Load(ctx *pulumi.Context) (StackConfig, error) {
 		ReleaseID:                cfg.Require("releaseId"),
 		FormaCdcSchedule:         valueOrDefault(cfg.Get("formaCdcSchedule"), "rate(15 minutes)"),
 		DSQLPort:                 valueOrDefault(cfg.Get("dsqlPort"), "5432"),
+		DSQLEndpoint:             strings.TrimSpace(cfg.Get("dsqlEndpoint")),
 		DSQLDB:                   valueOrDefault(cfg.Get("dsqlDB"), "postgres"),
 		DSQLUser:                 valueOrDefault(cfg.Get("dsqlUser"), "admin"),
 		DSQLProjectSchema:        valueOrDefault(cfg.Get("dsqlProjectSchema"), "ltbase"),

--- a/infra/internal/config/config_test.go
+++ b/infra/internal/config/config_test.go
@@ -41,3 +41,13 @@ func TestValueOrDefaultKeepsManagedDSQLDefaults(t *testing.T) {
 		t.Fatalf("default user = %q", got)
 	}
 }
+
+func TestValidateAllowsOptionalDSQLEndpoint(t *testing.T) {
+	cfg := StackConfig{
+		ManageGitHubOIDCProvider: true,
+		DSQLEndpoint:             "",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() unexpected error: %v", err)
+	}
+}

--- a/infra/internal/services/lambda.go
+++ b/infra/internal/services/lambda.go
@@ -103,6 +103,9 @@ func NewLambdaServices(ctx *pulumi.Context, cfg config.StackConfig, runtime *Run
 		"FORMA_SCHEMA_DIR":    pulumi.String("/var/task/schemas"),
 		"S3_BUCKET_NAME":      runtime.RuntimeBucket.Bucket,
 	}
+	for key, value := range optionalDSQLEnv(cfg) {
+		commonEnv[key] = pulumi.String(value)
+	}
 	commonEnv["DSQL_PROJECT_SCHEMA"] = pulumi.String(cfg.DSQLProjectSchema)
 	dataPlane, err := newLambdaService(ctx, cfg, providers, lambdaSpec{
 		Name:         "data-plane",
@@ -372,6 +375,14 @@ func mergeEnv(parts ...pulumi.StringMap) pulumi.StringMap {
 		for key, value := range part {
 			out[key] = value
 		}
+	}
+	return out
+}
+
+func optionalDSQLEnv(cfg config.StackConfig) map[string]string {
+	out := map[string]string{}
+	if cfg.DSQLEndpoint != "" {
+		out["DSQL_ENDPOINT"] = cfg.DSQLEndpoint
 	}
 	return out
 }

--- a/infra/internal/services/lambda_test.go
+++ b/infra/internal/services/lambda_test.go
@@ -1,0 +1,21 @@
+package services
+
+import (
+	"testing"
+
+	"lychee.technology/ltbase/infra/internal/config"
+)
+
+func TestOptionalDSQLEnvOmitsEndpointWhenUnset(t *testing.T) {
+	env := optionalDSQLEnv(config.StackConfig{})
+	if _, ok := env["DSQL_ENDPOINT"]; ok {
+		t.Fatal("optionalDSQLEnv() unexpectedly set DSQL_ENDPOINT")
+	}
+}
+
+func TestOptionalDSQLEnvIncludesExplicitEndpoint(t *testing.T) {
+	env := optionalDSQLEnv(config.StackConfig{DSQLEndpoint: "db.example.internal"})
+	if got := env["DSQL_ENDPOINT"]; got != "db.example.internal" {
+		t.Fatalf("optionalDSQLEnv() DSQL_ENDPOINT = %q", got)
+	}
+}

--- a/scripts/reconcile-managed-dsql-endpoint.sh
+++ b/scripts/reconcile-managed-dsql-endpoint.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ENV_FILE=""
+STACK="devo"
+INFRA_DIR="infra"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env-file)
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --stack)
+      STACK="$2"
+      shift 2
+      ;;
+    --infra-dir)
+      INFRA_DIR="$2"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${ENV_FILE}" ]]; then
+  echo "--env-file is required" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "${ENV_FILE}"
+
+required_vars=(PULUMI_BACKEND_URL AWS_REGION_DEVO AWS_REGION_PROD)
+for name in "${required_vars[@]}"; do
+  if [[ -z "${!name:-}" ]]; then
+    echo "${name} is required" >&2
+    exit 1
+  fi
+done
+
+selected_region="${AWS_REGION_DEVO}"
+if [[ "${STACK}" == "prod" ]]; then
+  selected_region="${AWS_REGION_PROD}"
+fi
+
+resolve_dsql_cluster_identifier() {
+  pulumi stack output dsqlClusterIdentifier --stack "${STACK}" 2>/dev/null
+}
+
+clear_managed_dsql_endpoint() {
+  pulumi config rm dsqlEndpoint --stack "${STACK}" >/dev/null 2>&1 || true
+}
+
+pulumi login "${PULUMI_BACKEND_URL}"
+pushd "${INFRA_DIR}" >/dev/null
+pulumi stack select "${STACK}" >/dev/null
+
+dsql_cluster_identifier="$(resolve_dsql_cluster_identifier || true)"
+if [[ -z "${dsql_cluster_identifier}" ]]; then
+  clear_managed_dsql_endpoint
+  echo "failed to resolve dsqlClusterIdentifier for stack ${STACK}" >&2
+  popd >/dev/null
+  exit 1
+fi
+
+if ! dsql_endpoint="$(aws dsql get-cluster --identifier "${dsql_cluster_identifier}" --region "${selected_region}" --query endpoint --output text)"; then
+  clear_managed_dsql_endpoint
+  echo "failed to resolve managed DSQL endpoint for stack ${STACK}" >&2
+  popd >/dev/null
+  exit 1
+fi
+
+if [[ -z "${dsql_endpoint}" || "${dsql_endpoint}" == "None" || "${dsql_endpoint}" == "null" ]]; then
+  clear_managed_dsql_endpoint
+  echo "managed DSQL endpoint was empty for stack ${STACK}" >&2
+  popd >/dev/null
+  exit 1
+fi
+
+pulumi config set dsqlEndpoint "${dsql_endpoint}" --stack "${STACK}"
+popd >/dev/null

--- a/test/bootstrap-all-test.sh
+++ b/test/bootstrap-all-test.sh
@@ -18,6 +18,14 @@ assert_log_contains() {
   fi
 }
 
+assert_log_not_contains() {
+  local path="$1"
+  local needle="$2"
+  if grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to not contain: ${needle}"
+  fi
+}
+
 temp_dir="$(mktemp -d)"
 fake_bin="${temp_dir}/bin"
 log_file="${temp_dir}/commands.log"
@@ -58,15 +66,15 @@ GITHUB_ORG=customer-org
 GITHUB_REPO=customer-ltbase
 GEMINI_MODEL=gemini-3-flash-preview
 DSQL_PORT=5432
-DSQL_DB=ltbase
-DSQL_USER=ltbase
+DSQL_DB=postgres
+DSQL_USER=admin
 DSQL_PROJECT_SCHEMA=ltbase
 GEMINI_API_KEY=test-gemini-key
 CLOUDFLARE_API_TOKEN=test-cloudflare-token
 LTBASE_RELEASES_TOKEN=test-release-token
 EOF
 
-for name in render-bootstrap-policies.sh create-deployment-repo.sh bootstrap-aws-foundation.sh bootstrap-deployment-repo.sh; do
+for name in render-bootstrap-policies.sh create-deployment-repo.sh bootstrap-aws-foundation.sh bootstrap-deployment-repo.sh reconcile-managed-dsql-endpoint.sh; do
   cat >"${fake_bin}/${name}" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
@@ -86,6 +94,8 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
   assert_log_contains "${log_file}" "bootstrap-aws-foundation.sh --env-file ${temp_dir}/.env"
   assert_log_contains "${log_file}" "bootstrap-deployment-repo.sh --env-file ${temp_dir}/.env --stack devo --infra-dir ${temp_dir}/infra"
   assert_log_contains "${log_file}" "bootstrap-deployment-repo.sh --env-file ${temp_dir}/.env --stack prod --infra-dir ${temp_dir}/infra"
+  assert_log_not_contains "${log_file}" "reconcile-managed-dsql-endpoint.sh --env-file ${temp_dir}/.env --stack devo --infra-dir ${temp_dir}/infra"
+  assert_log_not_contains "${log_file}" "reconcile-managed-dsql-endpoint.sh --env-file ${temp_dir}/.env --stack prod --infra-dir ${temp_dir}/infra"
 else
   fail "missing executable script: ${SCRIPT_PATH}"
 fi

--- a/test/bootstrap-deployment-repo-test.sh
+++ b/test/bootstrap-deployment-repo-test.sh
@@ -18,6 +18,14 @@ assert_log_contains() {
   fi
 }
 
+assert_log_not_contains() {
+  local path="$1"
+  local needle="$2"
+  if grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to not contain: ${needle}"
+  fi
+}
+
 temp_dir="$(mktemp -d)"
 fake_bin="${temp_dir}/bin"
 log_file="${temp_dir}/commands.log"
@@ -50,8 +58,8 @@ GITHUB_ORG=Lychee-Technology
 GITHUB_REPO=ltbase-private-deployment
 GEMINI_MODEL=gemini-3-flash-preview
 DSQL_PORT=5432
-DSQL_DB=ltbase
-DSQL_USER=ltbase
+DSQL_DB=postgres
+DSQL_USER=admin
 DSQL_PROJECT_SCHEMA=ltbase
 EOF
 
@@ -83,7 +91,14 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
   assert_log_contains "${log_file}" "gh variable set AWS_REGION_PROD --repo Lychee-Technology/ltbase-private-deployment --body us-west-2"
   assert_log_contains "${log_file}" "gh secret set AWS_ROLE_ARN_DEVO --repo Lychee-Technology/ltbase-private-deployment --body arn:aws:iam::123456789012:role/test-deploy-role"
   assert_log_contains "${log_file}" "pulumi stack init devo --secrets-provider awskms://alias/test-pulumi-secrets?region=ap-northeast-1"
+  assert_log_contains "${log_file}" "pulumi config set runtimeBucket runtime-bucket --stack devo"
+  assert_log_contains "${log_file}" "pulumi config set dsqlDB postgres --stack devo"
+  assert_log_contains "${log_file}" "pulumi config set dsqlUser admin --stack devo"
   assert_log_contains "${log_file}" "pulumi config set --secret geminiApiKey test-gemini-key --stack devo"
+  assert_log_not_contains "${log_file}" "pulumi stack output dsqlClusterIdentifier"
+  assert_log_not_contains "${log_file}" "pulumi up --stack devo --yes --skip-preview"
+  assert_log_not_contains "${log_file}" "pulumi config set dsqlEndpoint"
+  assert_log_not_contains "${log_file}" "aws dsql get-cluster"
 else
   fail "missing executable script: ${SCRIPT_PATH}"
 fi

--- a/test/managed-dsql-consistency-test.sh
+++ b/test/managed-dsql-consistency-test.sh
@@ -31,7 +31,9 @@ assert_not_contains "${ROOT_DIR}/docs/CUSTOMER_ONBOARDING.md" "DSQL_DB=ltbase"
 assert_not_contains "${ROOT_DIR}/docs/CUSTOMER_ONBOARDING.md" "DSQL_USER=ltbase"
 
 assert_not_contains "${ROOT_DIR}/infra/README.md" 'injects its derived `DSQL_ENDPOINT`'
+assert_contains "${ROOT_DIR}/infra/internal/config/config.go" "DSQLEndpoint"
 assert_not_contains "${ROOT_DIR}/infra/cmd/ltbase-infra/main.go" "ctx.Export(\"dsqlEndpoint\""
-assert_not_contains "${ROOT_DIR}/infra/internal/services/lambda.go" "\"DSQL_ENDPOINT\""
+assert_contains "${ROOT_DIR}/infra/internal/services/lambda.go" "\"DSQL_ENDPOINT\""
+assert_not_contains "${ROOT_DIR}/infra/internal/services/lambda.go" "VpcEndpointServiceName"
 
 printf 'PASS: managed DSQL consistency tests\n'

--- a/test/reconcile-managed-dsql-endpoint-test.sh
+++ b/test/reconcile-managed-dsql-endpoint-test.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/scripts/reconcile-managed-dsql-endpoint.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_log_contains() {
+  local path="$1"
+  local needle="$2"
+  if ! grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+assert_log_not_contains() {
+  local path="$1"
+  local needle="$2"
+  if grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to not contain: ${needle}"
+  fi
+}
+
+write_env_file() {
+  local path="$1"
+  cat >"${path}" <<'EOF'
+PULUMI_BACKEND_URL=s3://test-pulumi-state
+AWS_REGION_DEVO=ap-northeast-1
+AWS_REGION_PROD=us-west-2
+EOF
+}
+
+write_fake_pulumi_success() {
+  local path="$1"
+  local log_file="$2"
+  cat >"${path}" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'pulumi %s\n' "\$*" >>"${log_file}"
+if [[ "\$1 \$2" == "stack output" ]]; then
+  printf 'abcdefghijklmnopqrstuvwx12\n'
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "${path}"
+}
+
+write_fake_pulumi_missing_identifier() {
+  local path="$1"
+  local log_file="$2"
+  cat >"${path}" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'pulumi %s\n' "\$*" >>"${log_file}"
+if [[ "\$1 \$2" == "stack output" ]]; then
+  printf 'error: no output value named dsqlClusterIdentifier\n' >&2
+  exit 1
+fi
+exit 0
+EOF
+  chmod +x "${path}"
+}
+
+write_fake_aws_success() {
+  local path="$1"
+  local log_file="$2"
+  cat >"${path}" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'aws %s\n' "\$*" >>"${log_file}"
+if [[ "\$1 \$2" == "dsql get-cluster" ]]; then
+  printf 'managed.cluster.endpoint.example.com\n'
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "${path}"
+}
+
+write_fake_aws_failure() {
+  local path="$1"
+  local log_file="$2"
+  cat >"${path}" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'aws %s\n' "\$*" >>"${log_file}"
+if [[ "\$1 \$2" == "dsql get-cluster" ]]; then
+  printf 'lookup failed\n' >&2
+  exit 1
+fi
+exit 0
+EOF
+  chmod +x "${path}"
+}
+
+run_success_case() {
+  local temp_dir fake_bin log_file output
+  temp_dir="$(mktemp -d)"
+  fake_bin="${temp_dir}/bin"
+  log_file="${temp_dir}/commands.log"
+  mkdir -p "${fake_bin}" "${temp_dir}/infra"
+  touch "${log_file}"
+
+  write_env_file "${temp_dir}/.env"
+  write_fake_pulumi_success "${fake_bin}/pulumi" "${log_file}"
+  write_fake_aws_success "${fake_bin}/aws" "${log_file}"
+
+  if ! output="$(PATH="${fake_bin}:$PATH" "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --stack devo --infra-dir "${temp_dir}/infra" 2>&1)"; then
+    rm -rf "${temp_dir}"
+    fail "expected reconcile script to succeed, got: ${output}"
+  fi
+
+  assert_log_contains "${log_file}" "pulumi login s3://test-pulumi-state"
+  assert_log_contains "${log_file}" "pulumi stack select devo"
+  assert_log_contains "${log_file}" "pulumi stack output dsqlClusterIdentifier --stack devo"
+  assert_log_contains "${log_file}" "aws dsql get-cluster --identifier abcdefghijklmnopqrstuvwx12 --region ap-northeast-1 --query endpoint --output text"
+  assert_log_contains "${log_file}" "pulumi config set dsqlEndpoint managed.cluster.endpoint.example.com --stack devo"
+
+  rm -rf "${temp_dir}"
+}
+
+run_missing_identifier_case() {
+  local temp_dir fake_bin log_file output
+  temp_dir="$(mktemp -d)"
+  fake_bin="${temp_dir}/bin"
+  log_file="${temp_dir}/commands.log"
+  mkdir -p "${fake_bin}" "${temp_dir}/infra"
+  touch "${log_file}"
+
+  write_env_file "${temp_dir}/.env"
+  write_fake_pulumi_missing_identifier "${fake_bin}/pulumi" "${log_file}"
+  write_fake_aws_success "${fake_bin}/aws" "${log_file}"
+
+  if output="$(PATH="${fake_bin}:$PATH" "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --stack devo --infra-dir "${temp_dir}/infra" 2>&1)"; then
+    rm -rf "${temp_dir}"
+    fail "expected reconcile script to fail when identifier is missing"
+  fi
+
+  assert_log_contains "${log_file}" "pulumi config rm dsqlEndpoint --stack devo"
+  assert_log_not_contains "${log_file}" "pulumi config set dsqlEndpoint"
+  assert_log_not_contains "${log_file}" "aws dsql get-cluster"
+
+  rm -rf "${temp_dir}"
+}
+
+run_lookup_failure_case() {
+  local temp_dir fake_bin log_file output
+  temp_dir="$(mktemp -d)"
+  fake_bin="${temp_dir}/bin"
+  log_file="${temp_dir}/commands.log"
+  mkdir -p "${fake_bin}" "${temp_dir}/infra"
+  touch "${log_file}"
+
+  write_env_file "${temp_dir}/.env"
+  write_fake_pulumi_success "${fake_bin}/pulumi" "${log_file}"
+  write_fake_aws_failure "${fake_bin}/aws" "${log_file}"
+
+  if output="$(PATH="${fake_bin}:$PATH" "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --stack devo --infra-dir "${temp_dir}/infra" 2>&1)"; then
+    rm -rf "${temp_dir}"
+    fail "expected reconcile script to fail when lookup fails"
+  fi
+
+  assert_log_contains "${log_file}" "aws dsql get-cluster --identifier abcdefghijklmnopqrstuvwx12 --region ap-northeast-1 --query endpoint --output text"
+  assert_log_contains "${log_file}" "pulumi config rm dsqlEndpoint --stack devo"
+  assert_log_not_contains "${log_file}" "pulumi config set dsqlEndpoint"
+
+  rm -rf "${temp_dir}"
+}
+
+if [[ -x "${SCRIPT_PATH}" ]]; then
+  run_success_case
+  run_missing_identifier_case
+  run_lookup_failure_case
+else
+  fail "missing executable script: ${SCRIPT_PATH}"
+fi
+
+printf 'PASS: reconcile-managed-dsql-endpoint tests\n'


### PR DESCRIPTION
## Summary
- add deployment-owned managed DSQL endpoint publication through `reconcile-managed-dsql-endpoint.sh`, using Pulumi `dsqlClusterIdentifier` plus authoritative AWS lookup
- keep bootstrap bootstrap-safe by leaving `bootstrap-all.sh` and `bootstrap-deployment-repo.sh` config-only before infra exists
- wire optional `dsqlEndpoint` stack config into Lambda env and document the post-deploy reconciliation lifecycle with focused test coverage

## Test Plan
- [x] `bash test/managed-dsql-consistency-test.sh`
- [x] `bash test/render-bootstrap-policies-test.sh`
- [x] `bash test/create-deployment-repo-test.sh`
- [x] `bash test/bootstrap-aws-foundation-test.sh`
- [x] `bash test/bootstrap-pulumi-backend-test.sh`
- [x] `bash test/bootstrap-deployment-repo-test.sh`
- [x] `bash test/reconcile-managed-dsql-endpoint-test.sh`
- [x] `bash test/bootstrap-all-test.sh`