### PR TITLE
[codex] add evaluate-and-continue bootstrap recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ Important files and scripts:
 - `scripts/bootstrap-pulumi-backend.sh`
 - `scripts/bootstrap-deployment-repo.sh`
 - `scripts/bootstrap-all.sh`
+- `scripts/evaluate-and-continue.sh`
+
+Preferred recovery-aware bootstrap entrypoint:
+
+推荐的可恢复 bootstrap 入口：
+
+- `./scripts/evaluate-and-continue.sh --env-file .env --scope bootstrap`
+- `./scripts/evaluate-and-continue.sh --env-file .env --scope bootstrap --force`
 
 ## Deployment Principles / 部署原则
 

--- a/env.template
+++ b/env.template
@@ -1,13 +1,17 @@
 # Copy this file to a local .env file and fill in real values.
 # Do not commit populated .env files.
 
+STACKS=devo,prod
+PROMOTION_PATH=devo,prod
+
 TEMPLATE_REPO=Lychee-Technology/ltbase-private-deployment
 GITHUB_OWNER=customer-org
 DEPLOYMENT_REPO_NAME=customer-ltbase
 DEPLOYMENT_REPO_VISIBILITY=private
 DEPLOYMENT_REPO_DESCRIPTION="Customer LTBase deployment repo"
-PROD_ENVIRONMENT_NAME=prod
-DEPLOYMENT_REPO=customer-org/customer-ltbase
+
+# Optional override. Defaults to ${GITHUB_OWNER}/${DEPLOYMENT_REPO_NAME}.
+# DEPLOYMENT_REPO=customer-org/customer-ltbase
 
 AWS_REGION_DEVO=ap-northeast-1
 AWS_REGION_PROD=us-west-2
@@ -15,29 +19,44 @@ AWS_ACCOUNT_ID_DEVO=123456789012
 AWS_ACCOUNT_ID_PROD=210987654321
 AWS_ROLE_NAME_DEVO=ltbase-deploy-devo
 AWS_ROLE_NAME_PROD=ltbase-deploy-prod
-AWS_ROLE_ARN_DEVO=arn:aws:iam::123456789012:role/ltbase-deploy-devo
-AWS_ROLE_ARN_PROD=arn:aws:iam::123456789012:role/ltbase-deploy-prod
+
+# Optional overrides for split-account bootstrap.
+# AWS_PROFILE_DEVO=customer-devo
+# AWS_PROFILE_PROD=customer-prod
 
 PULUMI_STATE_BUCKET=replace-with-pulumi-state-bucket
 PULUMI_KMS_ALIAS=alias/ltbase-pulumi-secrets
-PULUMI_BACKEND_URL=
-PULUMI_SECRETS_PROVIDER_DEVO=
-PULUMI_SECRETS_PROVIDER_PROD=
+
+# Optional overrides. These are derived by default.
+# PULUMI_BACKEND_URL=s3://replace-with-pulumi-state-bucket
+# PULUMI_SECRETS_PROVIDER_DEVO=awskms://alias/ltbase-pulumi-secrets?region=ap-northeast-1
+# PULUMI_SECRETS_PROVIDER_PROD=awskms://alias/ltbase-pulumi-secrets?region=us-west-2
 
 LTBASE_RELEASES_REPO=Lychee-Technology/ltbase-releases
 LTBASE_RELEASE_ID=v1.0.0
 
-API_DOMAIN=api.devo.customer.example.com
-CONTROL_DOMAIN=control.devo.customer.example.com
-AUTH_DOMAIN=auth.devo.customer.example.com
+API_DOMAIN_DEVO=api.devo.customer.example.com
+API_DOMAIN_PROD=api.customer.example.com
+CONTROL_DOMAIN_DEVO=control.devo.customer.example.com
+CONTROL_DOMAIN_PROD=control.customer.example.com
+AUTH_DOMAIN_DEVO=auth.devo.customer.example.com
+AUTH_DOMAIN_PROD=auth.customer.example.com
 CLOUDFLARE_ZONE_ID=replace-with-zone-id
-OIDC_ISSUER_URL=https://oidc.example.com/customer-devo
-JWKS_URL=https://oidc.example.com/customer-devo/.well-known/jwks.json
+OIDC_ISSUER_URL_DEVO=https://oidc.example.com/customer-devo
+OIDC_ISSUER_URL_PROD=https://oidc.example.com/customer-prod
+JWKS_URL_DEVO=https://oidc.example.com/customer-devo/.well-known/jwks.json
+JWKS_URL_PROD=https://oidc.example.com/customer-prod/.well-known/jwks.json
 
-RUNTIME_BUCKET=replace-with-runtime-bucket
-TABLE_NAME=replace-with-table-name
-GITHUB_ORG=customer-org
-GITHUB_REPO=ltbase-private-deployment
+# Optional overrides. Defaults are <DEPLOYMENT_REPO_NAME>-runtime-<stack> and <DEPLOYMENT_REPO_NAME>-<stack>.
+# RUNTIME_BUCKET_DEVO=customer-ltbase-runtime-devo
+# RUNTIME_BUCKET_PROD=customer-ltbase-runtime-prod
+# TABLE_NAME_DEVO=customer-ltbase-devo
+# TABLE_NAME_PROD=customer-ltbase-prod
+
+# Optional overrides. Defaults are derived from GITHUB_OWNER / DEPLOYMENT_REPO_NAME.
+# GITHUB_ORG=customer-org
+# GITHUB_REPO=customer-ltbase
+
 GEMINI_MODEL=gemini-3-flash-preview
 DSQL_PORT=5432
 DSQL_DB=postgres

--- a/scripts/bootstrap-all.sh
+++ b/scripts/bootstrap-all.sh
@@ -33,6 +33,9 @@ if [[ -z "${ENV_FILE}" ]]; then
 fi
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/lib/bootstrap-env.sh"
+bootstrap_env_load "${ENV_FILE}"
 
 if [[ "${MODE}" != "apply" ]]; then
   echo "unsupported mode: ${MODE}" >&2
@@ -42,5 +45,6 @@ fi
 create-deployment-repo.sh --env-file "${ENV_FILE}"
 render-bootstrap-policies.sh --env-file "${ENV_FILE}"
 bootstrap-aws-foundation.sh --env-file "${ENV_FILE}"
-bootstrap-deployment-repo.sh --env-file "${ENV_FILE}" --stack devo --infra-dir "${INFRA_DIR}"
-bootstrap-deployment-repo.sh --env-file "${ENV_FILE}" --stack prod --infra-dir "${INFRA_DIR}"
+while IFS= read -r stack; do
+  bootstrap-deployment-repo.sh --env-file "${ENV_FILE}" --stack "${stack}" --infra-dir "${INFRA_DIR}"
+done < <(bootstrap_env_each_stack)

--- a/scripts/bootstrap-aws-foundation.sh
+++ b/scripts/bootstrap-aws-foundation.sh
@@ -27,8 +27,10 @@ if [[ -z "${ENV_FILE}" ]]; then
   exit 1
 fi
 
-# shellcheck disable=SC1090
-source "${ENV_FILE}"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/lib/bootstrap-env.sh"
+bootstrap_env_load "${ENV_FILE}"
 
 required_vars=(DEPLOYMENT_REPO AWS_REGION_DEVO AWS_REGION_PROD AWS_ACCOUNT_ID_DEVO AWS_ACCOUNT_ID_PROD AWS_ROLE_NAME_DEVO AWS_ROLE_NAME_PROD PULUMI_STATE_BUCKET PULUMI_KMS_ALIAS)
 for name in "${required_vars[@]}"; do

--- a/scripts/bootstrap-deployment-repo.sh
+++ b/scripts/bootstrap-deployment-repo.sh
@@ -32,10 +32,17 @@ if [[ -z "${ENV_FILE}" ]]; then
   exit 1
 fi
 
-# shellcheck disable=SC1090
-source "${ENV_FILE}"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/lib/bootstrap-env.sh"
+bootstrap_env_load "${ENV_FILE}"
 
-required_vars=(DEPLOYMENT_REPO AWS_REGION_DEVO AWS_REGION_PROD PULUMI_BACKEND_URL PULUMI_SECRETS_PROVIDER_DEVO PULUMI_SECRETS_PROVIDER_PROD LTBASE_RELEASES_REPO LTBASE_RELEASE_ID AWS_ROLE_ARN_DEVO AWS_ROLE_ARN_PROD LTBASE_RELEASES_TOKEN CLOUDFLARE_API_TOKEN GEMINI_API_KEY API_DOMAIN CONTROL_DOMAIN AUTH_DOMAIN CLOUDFLARE_ZONE_ID OIDC_ISSUER_URL JWKS_URL RUNTIME_BUCKET TABLE_NAME GITHUB_ORG GITHUB_REPO GEMINI_MODEL DSQL_PORT DSQL_DB DSQL_USER DSQL_PROJECT_SCHEMA)
+if ! bootstrap_env_has_stack "${STACK}"; then
+  echo "unknown stack: ${STACK}" >&2
+  exit 1
+fi
+
+required_vars=(DEPLOYMENT_REPO PULUMI_BACKEND_URL LTBASE_RELEASES_REPO LTBASE_RELEASE_ID LTBASE_RELEASES_TOKEN CLOUDFLARE_API_TOKEN GEMINI_API_KEY CLOUDFLARE_ZONE_ID GITHUB_ORG GITHUB_REPO GEMINI_MODEL DSQL_PORT DSQL_DB DSQL_USER DSQL_PROJECT_SCHEMA)
 for name in "${required_vars[@]}"; do
   if [[ -z "${!name:-}" ]]; then
     echo "${name} is required" >&2
@@ -43,25 +50,37 @@ for name in "${required_vars[@]}"; do
   fi
 done
 
-gh variable set AWS_REGION_DEVO --repo "${DEPLOYMENT_REPO}" --body "${AWS_REGION_DEVO}"
-gh variable set AWS_REGION_PROD --repo "${DEPLOYMENT_REPO}" --body "${AWS_REGION_PROD}"
+if ! bootstrap_env_require_stack_values "${STACK}" AWS_REGION AWS_ROLE_ARN PULUMI_SECRETS_PROVIDER API_DOMAIN CONTROL_DOMAIN AUTH_DOMAIN OIDC_ISSUER_URL JWKS_URL RUNTIME_BUCKET TABLE_NAME; then
+  exit 1
+fi
+
+while IFS= read -r target_stack; do
+  target_upper="$(bootstrap_env_stack_upper "${target_stack}")"
+  target_region="$(bootstrap_env_resolve_stack_value AWS_REGION "${target_stack}")"
+  target_secrets_provider="$(bootstrap_env_resolve_stack_value PULUMI_SECRETS_PROVIDER "${target_stack}")"
+  target_role_arn="$(bootstrap_env_resolve_stack_value AWS_ROLE_ARN "${target_stack}")"
+
+  gh variable set "AWS_REGION_${target_upper}" --repo "${DEPLOYMENT_REPO}" --body "${target_region}"
+  gh variable set "PULUMI_SECRETS_PROVIDER_${target_upper}" --repo "${DEPLOYMENT_REPO}" --body "${target_secrets_provider}"
+  gh secret set "AWS_ROLE_ARN_${target_upper}" --repo "${DEPLOYMENT_REPO}" --body "${target_role_arn}"
+done < <(bootstrap_env_each_stack)
+
 gh variable set PULUMI_BACKEND_URL --repo "${DEPLOYMENT_REPO}" --body "${PULUMI_BACKEND_URL}"
-gh variable set PULUMI_SECRETS_PROVIDER_DEVO --repo "${DEPLOYMENT_REPO}" --body "${PULUMI_SECRETS_PROVIDER_DEVO}"
-gh variable set PULUMI_SECRETS_PROVIDER_PROD --repo "${DEPLOYMENT_REPO}" --body "${PULUMI_SECRETS_PROVIDER_PROD}"
 gh variable set LTBASE_RELEASES_REPO --repo "${DEPLOYMENT_REPO}" --body "${LTBASE_RELEASES_REPO}"
 gh variable set LTBASE_RELEASE_ID --repo "${DEPLOYMENT_REPO}" --body "${LTBASE_RELEASE_ID}"
 
-gh secret set AWS_ROLE_ARN_DEVO --repo "${DEPLOYMENT_REPO}" --body "${AWS_ROLE_ARN_DEVO}"
-gh secret set AWS_ROLE_ARN_PROD --repo "${DEPLOYMENT_REPO}" --body "${AWS_ROLE_ARN_PROD}"
 gh secret set LTBASE_RELEASES_TOKEN --repo "${DEPLOYMENT_REPO}" --body "${LTBASE_RELEASES_TOKEN}"
 gh secret set CLOUDFLARE_API_TOKEN --repo "${DEPLOYMENT_REPO}" --body "${CLOUDFLARE_API_TOKEN}"
 
-selected_region="${AWS_REGION_DEVO}"
-selected_secrets_provider="${PULUMI_SECRETS_PROVIDER_DEVO}"
-if [[ "${STACK}" == "prod" ]]; then
-  selected_region="${AWS_REGION_PROD}"
-  selected_secrets_provider="${PULUMI_SECRETS_PROVIDER_PROD}"
-fi
+selected_region="$(bootstrap_env_resolve_stack_value AWS_REGION "${STACK}")"
+selected_secrets_provider="$(bootstrap_env_resolve_stack_value PULUMI_SECRETS_PROVIDER "${STACK}")"
+selected_runtime_bucket="$(bootstrap_env_resolve_stack_value RUNTIME_BUCKET "${STACK}")"
+selected_table_name="$(bootstrap_env_resolve_stack_value TABLE_NAME "${STACK}")"
+selected_api_domain="$(bootstrap_env_resolve_stack_value API_DOMAIN "${STACK}")"
+selected_control_domain="$(bootstrap_env_resolve_stack_value CONTROL_DOMAIN "${STACK}")"
+selected_auth_domain="$(bootstrap_env_resolve_stack_value AUTH_DOMAIN "${STACK}")"
+selected_oidc_issuer_url="$(bootstrap_env_resolve_stack_value OIDC_ISSUER_URL "${STACK}")"
+selected_jwks_url="$(bootstrap_env_resolve_stack_value JWKS_URL "${STACK}")"
 
 pulumi login "${PULUMI_BACKEND_URL}"
 if ! pulumi stack select "${STACK}" >/dev/null 2>&1; then
@@ -70,14 +89,14 @@ fi
 
 pushd "${INFRA_DIR}" >/dev/null
 pulumi config set awsRegion "${selected_region}" --stack "${STACK}"
-pulumi config set runtimeBucket "${RUNTIME_BUCKET}" --stack "${STACK}"
-pulumi config set tableName "${TABLE_NAME}" --stack "${STACK}"
-pulumi config set apiDomain "${API_DOMAIN}" --stack "${STACK}"
-pulumi config set controlPlaneDomain "${CONTROL_DOMAIN}" --stack "${STACK}"
-pulumi config set authDomain "${AUTH_DOMAIN}" --stack "${STACK}"
+pulumi config set runtimeBucket "${selected_runtime_bucket}" --stack "${STACK}"
+pulumi config set tableName "${selected_table_name}" --stack "${STACK}"
+pulumi config set apiDomain "${selected_api_domain}" --stack "${STACK}"
+pulumi config set controlPlaneDomain "${selected_control_domain}" --stack "${STACK}"
+pulumi config set authDomain "${selected_auth_domain}" --stack "${STACK}"
 pulumi config set cloudflareZoneId "${CLOUDFLARE_ZONE_ID}" --stack "${STACK}"
-pulumi config set oidcIssuerUrl "${OIDC_ISSUER_URL}" --stack "${STACK}"
-pulumi config set jwksUrl "${JWKS_URL}" --stack "${STACK}"
+pulumi config set oidcIssuerUrl "${selected_oidc_issuer_url}" --stack "${STACK}"
+pulumi config set jwksUrl "${selected_jwks_url}" --stack "${STACK}"
 pulumi config set githubOrg "${GITHUB_ORG}" --stack "${STACK}"
 pulumi config set githubRepo "${GITHUB_REPO}" --stack "${STACK}"
 pulumi config set releaseId "${LTBASE_RELEASE_ID}" --stack "${STACK}"

--- a/scripts/create-deployment-repo.sh
+++ b/scripts/create-deployment-repo.sh
@@ -22,8 +22,10 @@ if [[ -z "${ENV_FILE}" ]]; then
   exit 1
 fi
 
-# shellcheck disable=SC1090
-source "${ENV_FILE}"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/lib/bootstrap-env.sh"
+bootstrap_env_load "${ENV_FILE}"
 
 required_vars=(TEMPLATE_REPO GITHUB_OWNER DEPLOYMENT_REPO_NAME DEPLOYMENT_REPO_VISIBILITY DEPLOYMENT_REPO_DESCRIPTION DEPLOYMENT_REPO)
 for name in "${required_vars[@]}"; do
@@ -40,6 +42,14 @@ fi
 
 gh repo create "${DEPLOYMENT_REPO}" --template "${TEMPLATE_REPO}" ${visibility_flag} --description "${DEPLOYMENT_REPO_DESCRIPTION}" --clone=false
 
-if [[ -n "${PROD_ENVIRONMENT_NAME:-}" ]]; then
+promotion_index=0
+while IFS= read -r stack; do
+  if [[ "${promotion_index}" -gt 0 ]]; then
+    gh api "repos/${DEPLOYMENT_REPO}/environments/${stack}" --method PUT >/dev/null
+  fi
+  promotion_index=$((promotion_index + 1))
+done < <(bootstrap_env_each_stack "${PROMOTION_PATH}")
+
+if [[ "${promotion_index}" -eq 0 && -n "${PROD_ENVIRONMENT_NAME:-}" ]]; then
   gh api "repos/${DEPLOYMENT_REPO}/environments/${PROD_ENVIRONMENT_NAME}" --method PUT >/dev/null
 fi

--- a/scripts/evaluate-and-continue.sh
+++ b/scripts/evaluate-and-continue.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ENV_FILE=""
+FORCE="false"
+INFRA_DIR="infra"
+REPORT_DIR="dist/evaluate-and-continue"
+SCOPE="all"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env-file)
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --force)
+      FORCE="true"
+      shift
+      ;;
+    --infra-dir)
+      INFRA_DIR="$2"
+      shift 2
+      ;;
+    --report-dir)
+      REPORT_DIR="$2"
+      shift 2
+      ;;
+    --scope)
+      SCOPE="$2"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${ENV_FILE}" ]]; then
+  echo "--env-file is required" >&2
+  exit 1
+fi
+
+case "${SCOPE}" in
+  foundation|bootstrap|all)
+    ;;
+  *)
+    echo "unsupported scope: ${SCOPE}" >&2
+    exit 1
+    ;;
+esac
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/lib/bootstrap-env.sh"
+bootstrap_env_load "${ENV_FILE}"
+
+required_vars=(TEMPLATE_REPO GITHUB_OWNER DEPLOYMENT_REPO_NAME DEPLOYMENT_REPO_VISIBILITY DEPLOYMENT_REPO_DESCRIPTION DEPLOYMENT_REPO PULUMI_STATE_BUCKET PULUMI_KMS_ALIAS PULUMI_BACKEND_URL LTBASE_RELEASES_REPO LTBASE_RELEASE_ID LTBASE_RELEASES_TOKEN CLOUDFLARE_API_TOKEN GEMINI_API_KEY CLOUDFLARE_ZONE_ID GITHUB_ORG GITHUB_REPO GEMINI_MODEL DSQL_PORT DSQL_DB DSQL_USER DSQL_PROJECT_SCHEMA)
+bootstrap_env_require_vars "${required_vars[@]}"
+while IFS= read -r stack; do
+  bootstrap_env_require_stack_values "${stack}" AWS_REGION AWS_ACCOUNT_ID AWS_ROLE_NAME AWS_ROLE_ARN PULUMI_SECRETS_PROVIDER API_DOMAIN CONTROL_DOMAIN AUTH_DOMAIN OIDC_ISSUER_URL JWKS_URL RUNTIME_BUCKET TABLE_NAME
+done < <(bootstrap_env_each_stack)
+
+mkdir -p "${REPORT_DIR}"
+
+report_file="${REPORT_DIR}/report.json"
+actions_log="${REPORT_DIR}/actions.log"
+state_file="${REPORT_DIR}/stack-status.tsv"
+: >"${actions_log}"
+: >"${state_file}"
+
+run_logged() {
+  printf '%s\n' "$*" >>"${actions_log}"
+  "$@"
+}
+
+json_name_list_contains() {
+  local json_input="$1"
+  local needle="$2"
+  python3 - "${needle}" <<'PY' <<<"${json_input}"
+import json
+import sys
+
+needle = sys.argv[1]
+raw = sys.stdin.read().strip()
+if not raw:
+    sys.exit(1)
+
+names = {item.get("name", "") for item in json.loads(raw)}
+sys.exit(0 if needle in names else 1)
+PY
+}
+
+aws_command_for_stack() {
+  local stack="$1"
+  shift
+  local command=(aws)
+  while IFS= read -r token; do
+    command+=("${token}")
+  done < <(bootstrap_env_stack_profile_args "${stack}")
+  command+=("$@")
+  "${command[@]}"
+}
+
+foundation_present_for_stack() {
+  local stack="$1"
+  local region account_id role_name provider_arn alias_json
+
+  region="$(bootstrap_env_resolve_stack_value AWS_REGION "${stack}")"
+  account_id="$(bootstrap_env_resolve_stack_value AWS_ACCOUNT_ID "${stack}")"
+  role_name="$(bootstrap_env_resolve_stack_value AWS_ROLE_NAME "${stack}")"
+  provider_arn="arn:aws:iam::${account_id}:oidc-provider/token.actions.githubusercontent.com"
+
+  if ! aws_command_for_stack "${stack}" iam get-open-id-connect-provider --open-id-connect-provider-arn "${provider_arn}" >/dev/null 2>&1; then
+    return 1
+  fi
+  if ! aws_command_for_stack "${stack}" iam get-role --role-name "${role_name}" >/dev/null 2>&1; then
+    return 1
+  fi
+  alias_json="$(aws_command_for_stack "${stack}" kms list-aliases --region "${region}" --output json)"
+  python3 - "${PULUMI_KMS_ALIAS}" <<'PY' <<<"${alias_json}"
+import json
+import sys
+
+target = sys.argv[1]
+aliases = json.load(sys.stdin).get("Aliases", [])
+sys.exit(0 if any(item.get("AliasName") == target and item.get("TargetKeyId") for item in aliases) else 1)
+PY
+}
+
+shared_foundation_present() {
+  local first_stack
+  first_stack="$(bootstrap_env_csv_first "${STACKS}")"
+  if [[ -z "${first_stack}" ]]; then
+    return 1
+  fi
+  aws_command_for_stack "${first_stack}" s3api head-bucket --bucket "${PULUMI_STATE_BUCKET}" >/dev/null 2>&1
+}
+
+repo_exists() {
+  gh repo view "${DEPLOYMENT_REPO}" >/dev/null 2>&1
+}
+
+repo_config_present() {
+  local variable_json secret_json stack upper_name
+
+  if ! repo_exists; then
+    return 1
+  fi
+
+  variable_json="$(gh variable list --repo "${DEPLOYMENT_REPO}" --json name)"
+  secret_json="$(gh secret list --repo "${DEPLOYMENT_REPO}" --json name)"
+
+  for required_var in PULUMI_BACKEND_URL LTBASE_RELEASES_REPO LTBASE_RELEASE_ID; do
+    if ! json_name_list_contains "${variable_json}" "${required_var}"; then
+      return 1
+    fi
+  done
+
+  for required_secret in LTBASE_RELEASES_TOKEN CLOUDFLARE_API_TOKEN; do
+    if ! json_name_list_contains "${secret_json}" "${required_secret}"; then
+      return 1
+    fi
+  done
+
+  while IFS= read -r stack; do
+    upper_name="$(bootstrap_env_stack_upper "${stack}")"
+    if ! json_name_list_contains "${variable_json}" "AWS_REGION_${upper_name}"; then
+      return 1
+    fi
+    if ! json_name_list_contains "${variable_json}" "PULUMI_SECRETS_PROVIDER_${upper_name}"; then
+      return 1
+    fi
+    if ! json_name_list_contains "${secret_json}" "AWS_ROLE_ARN_${upper_name}"; then
+      return 1
+    fi
+  done < <(bootstrap_env_each_stack)
+
+  return 0
+}
+
+stack_bootstrap_present() {
+  local stack="$1"
+  if [[ ! -f "${INFRA_DIR}/Pulumi.${stack}.yaml" ]]; then
+    return 1
+  fi
+
+  (
+    cd "${INFRA_DIR}"
+    pulumi stack select "${stack}" >/dev/null 2>&1
+  )
+}
+
+stack_rollout_status() {
+  local stack="$1"
+  local dsql_cluster_identifier dsql_endpoint
+
+  dsql_cluster_identifier="$(
+    (
+      cd "${INFRA_DIR}"
+      pulumi stack output dsqlClusterIdentifier --stack "${stack}" 2>/dev/null
+    ) || true
+  )"
+  if [[ -z "${dsql_cluster_identifier}" ]]; then
+    printf 'needs_rollout'
+    return 0
+  fi
+
+  dsql_endpoint="$(
+    (
+      cd "${INFRA_DIR}"
+      pulumi config get dsqlEndpoint --stack "${stack}" 2>/dev/null
+    ) || true
+  )"
+  if [[ -z "${dsql_endpoint}" ]]; then
+    printf 'needs_dsql_reconcile'
+    return 0
+  fi
+
+  printf 'complete'
+}
+
+scan_state() {
+  local repo_present repo_config_ok shared_foundation_ok stack foundation_ok status rollout_status
+
+  if repo_exists; then
+    repo_present="true"
+  else
+    repo_present="false"
+  fi
+
+  if repo_config_present; then
+    repo_config_ok="true"
+  else
+    repo_config_ok="false"
+  fi
+
+  if shared_foundation_present; then
+    shared_foundation_ok="true"
+  else
+    shared_foundation_ok="false"
+  fi
+
+  if [[ "${SCOPE}" != "foundation" ]]; then
+    pulumi login "${PULUMI_BACKEND_URL}" >/dev/null 2>&1 || true
+  fi
+
+  while IFS= read -r stack; do
+    foundation_ok="false"
+    status="needs_foundation"
+
+    if [[ "${shared_foundation_ok}" == "true" ]] && foundation_present_for_stack "${stack}" >/dev/null 2>&1; then
+      foundation_ok="true"
+      status="needs_repo_config"
+    fi
+
+    if [[ "${foundation_ok}" == "true" && "${repo_present}" == "true" && "${repo_config_ok}" == "true" ]]; then
+      status="needs_stack_bootstrap"
+      if stack_bootstrap_present "${stack}"; then
+        if [[ "${SCOPE}" == "bootstrap" ]]; then
+          status="complete"
+        elif [[ "${SCOPE}" == "all" ]]; then
+          rollout_status="$(stack_rollout_status "${stack}")"
+          status="${rollout_status}"
+        else
+          status="complete"
+        fi
+      fi
+    fi
+
+    printf '%s\t%s\n' "${stack}" "${status}" >>"${state_file}"
+  done < <(bootstrap_env_each_stack)
+}
+
+write_report() {
+  python3 - "${state_file}" "${report_file}" "${DEPLOYMENT_REPO}" "${STACKS}" "${PROMOTION_PATH}" "${SCOPE}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state_path = Path(sys.argv[1])
+report_path = Path(sys.argv[2])
+deployment_repo = sys.argv[3]
+stacks = [item for item in sys.argv[4].split(",") if item]
+promotion_path = [item for item in sys.argv[5].split(",") if item]
+scope = sys.argv[6]
+
+items = []
+with state_path.open() as handle:
+    for line in handle:
+        line = line.strip()
+        if not line:
+            continue
+        stack, status = line.split("\t", 1)
+        items.append({"stack": stack, "status": status})
+
+report = {
+    "deploymentRepo": deployment_repo,
+    "scope": scope,
+    "stacks": stacks,
+    "promotionPath": promotion_path,
+    "results": items,
+}
+
+report_path.write_text(json.dumps(report, indent=2) + "\n")
+PY
+}
+
+has_non_complete_status() {
+  if grep -Fv $'\tcomplete' "${state_file}" >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
+}
+
+run_force_actions() {
+  local needs_foundation="false"
+  local needs_repo="false"
+  local stack status
+
+  while IFS=$'\t' read -r stack status; do
+    case "${status}" in
+      needs_foundation)
+        needs_foundation="true"
+        needs_repo="true"
+        ;;
+      needs_repo_config|needs_stack_bootstrap)
+        needs_repo="true"
+        ;;
+    esac
+  done <"${state_file}"
+
+  if [[ "${needs_foundation}" == "true" ]]; then
+    run_logged "${script_dir}/render-bootstrap-policies.sh" --env-file "${ENV_FILE}"
+    run_logged "${script_dir}/bootstrap-aws-foundation.sh" --env-file "${ENV_FILE}"
+  fi
+
+  if [[ "${needs_repo}" == "true" ]]; then
+    if ! repo_exists; then
+      run_logged "${script_dir}/create-deployment-repo.sh" --env-file "${ENV_FILE}"
+    fi
+
+    while IFS=$'\t' read -r stack status; do
+      case "${status}" in
+        needs_foundation|needs_repo_config|needs_stack_bootstrap)
+          if [[ "${SCOPE}" != "foundation" ]]; then
+            run_logged "${script_dir}/bootstrap-deployment-repo.sh" --env-file "${ENV_FILE}" --stack "${stack}" --infra-dir "${INFRA_DIR}"
+          fi
+          ;;
+      esac
+    done <"${state_file}"
+  fi
+}
+
+scan_state
+write_report
+
+while IFS=$'\t' read -r stack status; do
+  printf '%s: %s\n' "${stack}" "${status}"
+done <"${state_file}"
+printf 'report: %s\n' "${report_file}"
+
+if [[ "${FORCE}" == "true" ]]; then
+  run_force_actions
+  exit 0
+fi
+
+if has_non_complete_status; then
+  exit 2
+fi
+
+exit 0

--- a/scripts/lib/bootstrap-env.sh
+++ b/scripts/lib/bootstrap-env.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+bootstrap_env_normalize_csv() {
+  printf '%s' "${1:-}" | tr -d '[:space:]'
+}
+
+bootstrap_env_csv_first() {
+  local csv
+  csv="$(bootstrap_env_normalize_csv "${1:-}")"
+  if [[ "${csv}" == *,* ]]; then
+    printf '%s' "${csv%%,*}"
+    return 0
+  fi
+  printf '%s' "${csv}"
+}
+
+bootstrap_env_stack_upper() {
+  printf '%s' "${1}" | tr '[:lower:]-' '[:upper:]_'
+}
+
+bootstrap_env_each_stack() {
+  local csv old_ifs
+  csv="$(bootstrap_env_normalize_csv "${1:-${STACKS:-devo,prod}}")"
+  old_ifs="${IFS}"
+  IFS=','
+  # shellcheck disable=SC2086
+  set -- ${csv}
+  IFS="${old_ifs}"
+  for stack in "$@"; do
+    if [[ -n "${stack}" ]]; then
+      printf '%s\n' "${stack}"
+    fi
+  done
+}
+
+bootstrap_env_has_stack() {
+  local needle="$1"
+  local stack
+  while IFS= read -r stack; do
+    if [[ "${stack}" == "${needle}" ]]; then
+      return 0
+    fi
+  done < <(bootstrap_env_each_stack)
+  return 1
+}
+
+bootstrap_env_resolve_stack_value() {
+  local base_name="$1"
+  local stack="$2"
+  local default_value="${3:-}"
+  local upper_name specific_name
+
+  upper_name="$(bootstrap_env_stack_upper "${stack}")"
+  specific_name="${base_name}_${upper_name}"
+
+  if [[ -n "${!specific_name:-}" ]]; then
+    printf '%s' "${!specific_name}"
+    return 0
+  fi
+  if [[ -n "${!base_name:-}" ]]; then
+    printf '%s' "${!base_name}"
+    return 0
+  fi
+  printf '%s' "${default_value}"
+}
+
+bootstrap_env_stack_profile_args() {
+  local stack="$1"
+  local upper_name profile_var_name
+
+  upper_name="$(bootstrap_env_stack_upper "${stack}")"
+  profile_var_name="AWS_PROFILE_${upper_name}"
+
+  if [[ -n "${!profile_var_name:-}" ]]; then
+    printf '%s\n' "--profile"
+    printf '%s\n' "${!profile_var_name}"
+  fi
+}
+
+bootstrap_env_require_vars() {
+  local name
+  for name in "$@"; do
+    if [[ -z "${!name:-}" ]]; then
+      printf '%s is required\n' "${name}" >&2
+      return 1
+    fi
+  done
+}
+
+bootstrap_env_require_stack_values() {
+  local stack="$1"
+  shift
+  local name value upper_name
+
+  upper_name="$(bootstrap_env_stack_upper "${stack}")"
+  for name in "$@"; do
+    value="$(bootstrap_env_resolve_stack_value "${name}" "${stack}")"
+    if [[ -z "${value}" ]]; then
+      printf '%s_%s or %s is required\n' "${name}" "${upper_name}" "${name}" >&2
+      return 1
+    fi
+  done
+}
+
+bootstrap_env_apply_derivations() {
+  local stack upper_name region account_id role_name
+  local role_arn_var provider_var runtime_bucket_var table_name_var
+
+  if [[ -z "${DEPLOYMENT_REPO:-}" && -n "${GITHUB_OWNER:-}" && -n "${DEPLOYMENT_REPO_NAME:-}" ]]; then
+    DEPLOYMENT_REPO="${GITHUB_OWNER}/${DEPLOYMENT_REPO_NAME}"
+    export DEPLOYMENT_REPO
+  fi
+  if [[ -z "${GITHUB_ORG:-}" && -n "${GITHUB_OWNER:-}" ]]; then
+    GITHUB_ORG="${GITHUB_OWNER}"
+    export GITHUB_ORG
+  fi
+  if [[ -z "${GITHUB_REPO:-}" && -n "${DEPLOYMENT_REPO_NAME:-}" ]]; then
+    GITHUB_REPO="${DEPLOYMENT_REPO_NAME}"
+    export GITHUB_REPO
+  fi
+  if [[ -z "${PULUMI_BACKEND_URL:-}" && -n "${PULUMI_STATE_BUCKET:-}" ]]; then
+    PULUMI_BACKEND_URL="s3://${PULUMI_STATE_BUCKET}"
+    export PULUMI_BACKEND_URL
+  fi
+
+  while IFS= read -r stack; do
+    upper_name="$(bootstrap_env_stack_upper "${stack}")"
+    region="$(bootstrap_env_resolve_stack_value AWS_REGION "${stack}")"
+    account_id="$(bootstrap_env_resolve_stack_value AWS_ACCOUNT_ID "${stack}")"
+    role_name="$(bootstrap_env_resolve_stack_value AWS_ROLE_NAME "${stack}")"
+
+    role_arn_var="AWS_ROLE_ARN_${upper_name}"
+    if [[ -z "${!role_arn_var:-}" && -n "${account_id}" && -n "${role_name}" ]]; then
+      printf -v "${role_arn_var}" 'arn:aws:iam::%s:role/%s' "${account_id}" "${role_name}"
+      export "${role_arn_var}"
+    fi
+
+    provider_var="PULUMI_SECRETS_PROVIDER_${upper_name}"
+    if [[ -z "${!provider_var:-}" && -n "${PULUMI_KMS_ALIAS:-}" && -n "${region}" ]]; then
+      printf -v "${provider_var}" 'awskms://%s?region=%s' "${PULUMI_KMS_ALIAS}" "${region}"
+      export "${provider_var}"
+    fi
+
+    runtime_bucket_var="RUNTIME_BUCKET_${upper_name}"
+    if [[ -z "${!runtime_bucket_var:-}" && -z "${RUNTIME_BUCKET:-}" && -n "${DEPLOYMENT_REPO_NAME:-}" ]]; then
+      printf -v "${runtime_bucket_var}" '%s-runtime-%s' "${DEPLOYMENT_REPO_NAME}" "${stack}"
+      export "${runtime_bucket_var}"
+    fi
+
+    table_name_var="TABLE_NAME_${upper_name}"
+    if [[ -z "${!table_name_var:-}" && -z "${TABLE_NAME:-}" && -n "${DEPLOYMENT_REPO_NAME:-}" ]]; then
+      printf -v "${table_name_var}" '%s-%s' "${DEPLOYMENT_REPO_NAME}" "${stack}"
+      export "${table_name_var}"
+    fi
+  done < <(bootstrap_env_each_stack)
+
+  if [[ -z "${PROMOTION_PATH:-}" ]]; then
+    PROMOTION_PATH="${STACKS}"
+    export PROMOTION_PATH
+  fi
+  if [[ -z "${PREVIEW_DEFAULT_STACK:-}" ]]; then
+    PREVIEW_DEFAULT_STACK="$(bootstrap_env_csv_first "${PROMOTION_PATH}")"
+    export PREVIEW_DEFAULT_STACK
+  fi
+}
+
+bootstrap_env_load() {
+  local env_file="$1"
+  if [[ ! -f "${env_file}" ]]; then
+    printf 'missing env file: %s\n' "${env_file}" >&2
+    return 1
+  fi
+
+  # shellcheck disable=SC1090
+  source "${env_file}"
+
+  STACKS="$(bootstrap_env_normalize_csv "${STACKS:-devo,prod}")"
+  export STACKS
+
+  PROMOTION_PATH="$(bootstrap_env_normalize_csv "${PROMOTION_PATH:-${STACKS}}")"
+  export PROMOTION_PATH
+
+  bootstrap_env_apply_derivations
+}

--- a/scripts/render-bootstrap-policies.sh
+++ b/scripts/render-bootstrap-policies.sh
@@ -27,8 +27,10 @@ if [[ -z "${ENV_FILE}" ]]; then
   exit 1
 fi
 
-# shellcheck disable=SC1090
-source "${ENV_FILE}"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/lib/bootstrap-env.sh"
+bootstrap_env_load "${ENV_FILE}"
 
 required_vars=(GITHUB_OWNER DEPLOYMENT_REPO_NAME DEPLOYMENT_REPO AWS_REGION_DEVO AWS_REGION_PROD AWS_ACCOUNT_ID_DEVO AWS_ACCOUNT_ID_PROD AWS_ROLE_NAME_DEVO AWS_ROLE_NAME_PROD AWS_ROLE_ARN_DEVO AWS_ROLE_ARN_PROD PULUMI_STATE_BUCKET PULUMI_KMS_ALIAS)
 for name in "${required_vars[@]}"; do

--- a/test/bootstrap-all-test.sh
+++ b/test/bootstrap-all-test.sh
@@ -33,37 +33,42 @@ mkdir -p "${fake_bin}" "${temp_dir}/infra"
 touch "${log_file}"
 
 cat >"${temp_dir}/.env" <<'EOF'
+STACKS=devo,staging,prod
+PROMOTION_PATH=devo,staging,prod
 TEMPLATE_REPO=Lychee-Technology/ltbase-private-deployment
 GITHUB_OWNER=customer-org
 DEPLOYMENT_REPO_NAME=customer-ltbase
 DEPLOYMENT_REPO_VISIBILITY=private
-DEPLOYMENT_REPO_DESCRIPTION=Customer LTBase deployment repo
-DEPLOYMENT_REPO=customer-org/customer-ltbase
+DEPLOYMENT_REPO_DESCRIPTION="Customer LTBase deployment repo"
 AWS_REGION_DEVO=ap-northeast-1
+AWS_REGION_STAGING=us-east-1
 AWS_REGION_PROD=us-west-2
 AWS_ACCOUNT_ID_DEVO=123456789012
+AWS_ACCOUNT_ID_STAGING=123456789012
 AWS_ACCOUNT_ID_PROD=210987654321
 AWS_ROLE_NAME_DEVO=ltbase-deploy-devo
+AWS_ROLE_NAME_STAGING=ltbase-deploy-staging
 AWS_ROLE_NAME_PROD=ltbase-deploy-prod
-AWS_ROLE_ARN_DEVO=arn:aws:iam::123456789012:role/ltbase-deploy-devo
-AWS_ROLE_ARN_PROD=arn:aws:iam::210987654321:role/ltbase-deploy-prod
 PULUMI_STATE_BUCKET=test-pulumi-state
 PULUMI_KMS_ALIAS=alias/test-pulumi-secrets
-PULUMI_BACKEND_URL=s3://test-pulumi-state
-PULUMI_SECRETS_PROVIDER_DEVO=awskms://alias/test-pulumi-secrets?region=ap-northeast-1
-PULUMI_SECRETS_PROVIDER_PROD=awskms://alias/test-pulumi-secrets?region=us-west-2
 LTBASE_RELEASES_REPO=Lychee-Technology/ltbase-releases
 LTBASE_RELEASE_ID=v1.0.0
-API_DOMAIN=api.devo.example.com
-CONTROL_DOMAIN=control.devo.example.com
-AUTH_DOMAIN=auth.devo.example.com
+API_DOMAIN_DEVO=api.devo.example.com
+API_DOMAIN_STAGING=api.staging.example.com
+API_DOMAIN_PROD=api.example.com
+CONTROL_DOMAIN_DEVO=control.devo.example.com
+CONTROL_DOMAIN_STAGING=control.staging.example.com
+CONTROL_DOMAIN_PROD=control.example.com
+AUTH_DOMAIN_DEVO=auth.devo.example.com
+AUTH_DOMAIN_STAGING=auth.staging.example.com
+AUTH_DOMAIN_PROD=auth.example.com
 CLOUDFLARE_ZONE_ID=zone-123
-OIDC_ISSUER_URL=https://issuer.example.com
-JWKS_URL=https://issuer.example.com/jwks.json
-RUNTIME_BUCKET=runtime-bucket
-TABLE_NAME=ltbase-devo
-GITHUB_ORG=customer-org
-GITHUB_REPO=customer-ltbase
+OIDC_ISSUER_URL_DEVO=https://issuer.example.com/devo
+OIDC_ISSUER_URL_STAGING=https://issuer.example.com/staging
+OIDC_ISSUER_URL_PROD=https://issuer.example.com/prod
+JWKS_URL_DEVO=https://issuer.example.com/devo/jwks.json
+JWKS_URL_STAGING=https://issuer.example.com/staging/jwks.json
+JWKS_URL_PROD=https://issuer.example.com/prod/jwks.json
 GEMINI_MODEL=gemini-3-flash-preview
 DSQL_PORT=5432
 DSQL_DB=postgres
@@ -93,8 +98,10 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
   assert_log_contains "${log_file}" "render-bootstrap-policies.sh --env-file ${temp_dir}/.env"
   assert_log_contains "${log_file}" "bootstrap-aws-foundation.sh --env-file ${temp_dir}/.env"
   assert_log_contains "${log_file}" "bootstrap-deployment-repo.sh --env-file ${temp_dir}/.env --stack devo --infra-dir ${temp_dir}/infra"
+  assert_log_contains "${log_file}" "bootstrap-deployment-repo.sh --env-file ${temp_dir}/.env --stack staging --infra-dir ${temp_dir}/infra"
   assert_log_contains "${log_file}" "bootstrap-deployment-repo.sh --env-file ${temp_dir}/.env --stack prod --infra-dir ${temp_dir}/infra"
   assert_log_not_contains "${log_file}" "reconcile-managed-dsql-endpoint.sh --env-file ${temp_dir}/.env --stack devo --infra-dir ${temp_dir}/infra"
+  assert_log_not_contains "${log_file}" "reconcile-managed-dsql-endpoint.sh --env-file ${temp_dir}/.env --stack staging --infra-dir ${temp_dir}/infra"
   assert_log_not_contains "${log_file}" "reconcile-managed-dsql-endpoint.sh --env-file ${temp_dir}/.env --stack prod --infra-dir ${temp_dir}/infra"
 else
   fail "missing executable script: ${SCRIPT_PATH}"

--- a/test/bootstrap-deployment-repo-test.sh
+++ b/test/bootstrap-deployment-repo-test.sh
@@ -33,29 +33,33 @@ mkdir -p "${fake_bin}" "${temp_dir}/infra"
 touch "${log_file}"
 
 cat >"${temp_dir}/.env" <<'EOF'
-DEPLOYMENT_REPO=Lychee-Technology/ltbase-private-deployment
+STACKS=devo,prod
+GITHUB_OWNER=Lychee-Technology
+DEPLOYMENT_REPO_NAME=ltbase-private-deployment
 AWS_REGION_DEVO=ap-northeast-1
 AWS_REGION_PROD=us-west-2
-PULUMI_BACKEND_URL=s3://test-pulumi-state
-PULUMI_SECRETS_PROVIDER_DEVO=awskms://alias/test-pulumi-secrets?region=ap-northeast-1
-PULUMI_SECRETS_PROVIDER_PROD=awskms://alias/test-pulumi-secrets?region=us-west-2
+AWS_ACCOUNT_ID_DEVO=123456789012
+AWS_ACCOUNT_ID_PROD=123456789012
+AWS_ROLE_NAME_DEVO=test-deploy-role
+AWS_ROLE_NAME_PROD=test-prod-role
+PULUMI_STATE_BUCKET=test-pulumi-state
+PULUMI_KMS_ALIAS=alias/test-pulumi-secrets
 LTBASE_RELEASES_REPO=Lychee-Technology/ltbase-releases
 LTBASE_RELEASE_ID=v1.0.0
-AWS_ROLE_ARN_DEVO=arn:aws:iam::123456789012:role/test-deploy-role
-AWS_ROLE_ARN_PROD=arn:aws:iam::123456789012:role/test-prod-role
 LTBASE_RELEASES_TOKEN=test-release-token
 CLOUDFLARE_API_TOKEN=test-cloudflare-token
 GEMINI_API_KEY=test-gemini-key
-API_DOMAIN=api.devo.example.com
-CONTROL_DOMAIN=control.devo.example.com
-AUTH_DOMAIN=auth.devo.example.com
+API_DOMAIN_DEVO=api.devo.example.com
+API_DOMAIN_PROD=api.example.com
+CONTROL_DOMAIN_DEVO=control.devo.example.com
+CONTROL_DOMAIN_PROD=control.example.com
+AUTH_DOMAIN_DEVO=auth.devo.example.com
+AUTH_DOMAIN_PROD=auth.example.com
 CLOUDFLARE_ZONE_ID=zone-123
-OIDC_ISSUER_URL=https://issuer.example.com
-JWKS_URL=https://issuer.example.com/jwks.json
-RUNTIME_BUCKET=runtime-bucket
-TABLE_NAME=ltbase-devo
-GITHUB_ORG=Lychee-Technology
-GITHUB_REPO=ltbase-private-deployment
+OIDC_ISSUER_URL_DEVO=https://issuer.example.com/devo
+OIDC_ISSUER_URL_PROD=https://issuer.example.com/prod
+JWKS_URL_DEVO=https://issuer.example.com/devo/jwks.json
+JWKS_URL_PROD=https://issuer.example.com/prod/jwks.json
 GEMINI_MODEL=gemini-3-flash-preview
 DSQL_PORT=5432
 DSQL_DB=postgres
@@ -82,7 +86,7 @@ EOF
 chmod +x "${fake_bin}/pulumi"
 
 if [[ -x "${SCRIPT_PATH}" ]]; then
-  if ! output="$(PATH="${fake_bin}:$PATH" "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --stack devo --infra-dir "${temp_dir}/infra" 2>&1)"; then
+  if ! output="$(PATH="${fake_bin}:$PATH" "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --stack prod --infra-dir "${temp_dir}/infra" 2>&1)"; then
     rm -rf "${temp_dir}"
     fail "expected script to succeed when implemented, got: ${output}"
   fi
@@ -90,13 +94,17 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
   assert_log_contains "${log_file}" "gh variable set AWS_REGION_DEVO --repo Lychee-Technology/ltbase-private-deployment --body ap-northeast-1"
   assert_log_contains "${log_file}" "gh variable set AWS_REGION_PROD --repo Lychee-Technology/ltbase-private-deployment --body us-west-2"
   assert_log_contains "${log_file}" "gh secret set AWS_ROLE_ARN_DEVO --repo Lychee-Technology/ltbase-private-deployment --body arn:aws:iam::123456789012:role/test-deploy-role"
-  assert_log_contains "${log_file}" "pulumi stack init devo --secrets-provider awskms://alias/test-pulumi-secrets?region=ap-northeast-1"
-  assert_log_contains "${log_file}" "pulumi config set runtimeBucket runtime-bucket --stack devo"
-  assert_log_contains "${log_file}" "pulumi config set dsqlDB postgres --stack devo"
-  assert_log_contains "${log_file}" "pulumi config set dsqlUser admin --stack devo"
-  assert_log_contains "${log_file}" "pulumi config set --secret geminiApiKey test-gemini-key --stack devo"
+  assert_log_contains "${log_file}" "gh secret set AWS_ROLE_ARN_PROD --repo Lychee-Technology/ltbase-private-deployment --body arn:aws:iam::123456789012:role/test-prod-role"
+  assert_log_contains "${log_file}" "pulumi stack init prod --secrets-provider awskms://alias/test-pulumi-secrets?region=us-west-2"
+  assert_log_contains "${log_file}" "pulumi config set runtimeBucket ltbase-private-deployment-runtime-prod --stack prod"
+  assert_log_contains "${log_file}" "pulumi config set apiDomain api.example.com --stack prod"
+  assert_log_contains "${log_file}" "pulumi config set oidcIssuerUrl https://issuer.example.com/prod --stack prod"
+  assert_log_contains "${log_file}" "pulumi config set tableName ltbase-private-deployment-prod --stack prod"
+  assert_log_contains "${log_file}" "pulumi config set dsqlDB postgres --stack prod"
+  assert_log_contains "${log_file}" "pulumi config set dsqlUser admin --stack prod"
+  assert_log_contains "${log_file}" "pulumi config set --secret geminiApiKey test-gemini-key --stack prod"
   assert_log_not_contains "${log_file}" "pulumi stack output dsqlClusterIdentifier"
-  assert_log_not_contains "${log_file}" "pulumi up --stack devo --yes --skip-preview"
+  assert_log_not_contains "${log_file}" "pulumi up --stack prod --yes --skip-preview"
   assert_log_not_contains "${log_file}" "pulumi config set dsqlEndpoint"
   assert_log_not_contains "${log_file}" "aws dsql get-cluster"
 else

--- a/test/create-deployment-repo-test.sh
+++ b/test/create-deployment-repo-test.sh
@@ -30,8 +30,7 @@ GITHUB_OWNER=customer-org
 DEPLOYMENT_REPO_NAME=customer-ltbase
 DEPLOYMENT_REPO_VISIBILITY=private
 DEPLOYMENT_REPO_DESCRIPTION="Customer LTBase deployment repo"
-DEPLOYMENT_REPO=customer-org/customer-ltbase
-PROD_ENVIRONMENT_NAME=prod
+PROMOTION_PATH=devo,prod
 EOF
 
 cat >"${fake_bin}/gh" <<EOF

--- a/test/evaluate-and-continue-test.sh
+++ b/test/evaluate-and-continue-test.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/scripts/evaluate-and-continue.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local path="$1"
+  local needle="$2"
+  if [[ ! -f "${path}" ]]; then
+    fail "missing file: ${path}"
+  fi
+  if ! grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+assert_log_contains() {
+  local path="$1"
+  local needle="$2"
+  if ! grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+write_env() {
+  local path="$1"
+  cat >"${path}" <<'EOF'
+STACKS=devo,staging,prod
+PROMOTION_PATH=devo,staging,prod
+TEMPLATE_REPO=Lychee-Technology/ltbase-private-deployment
+GITHUB_OWNER=customer-org
+DEPLOYMENT_REPO_NAME=customer-ltbase
+DEPLOYMENT_REPO_VISIBILITY=private
+DEPLOYMENT_REPO_DESCRIPTION="Customer LTBase deployment repo"
+AWS_REGION_DEVO=ap-northeast-1
+AWS_REGION_STAGING=us-east-1
+AWS_REGION_PROD=us-west-2
+AWS_ACCOUNT_ID_DEVO=123456789012
+AWS_ACCOUNT_ID_STAGING=123456789012
+AWS_ACCOUNT_ID_PROD=210987654321
+AWS_PROFILE_DEVO=devo-profile
+AWS_PROFILE_STAGING=staging-profile
+AWS_PROFILE_PROD=prod-profile
+AWS_ROLE_NAME_DEVO=ltbase-deploy-devo
+AWS_ROLE_NAME_STAGING=ltbase-deploy-staging
+AWS_ROLE_NAME_PROD=ltbase-deploy-prod
+PULUMI_STATE_BUCKET=test-pulumi-state
+PULUMI_KMS_ALIAS=alias/test-pulumi-secrets
+LTBASE_RELEASES_REPO=Lychee-Technology/ltbase-releases
+LTBASE_RELEASE_ID=v1.0.0
+API_DOMAIN_DEVO=api.devo.example.com
+API_DOMAIN_STAGING=api.staging.example.com
+API_DOMAIN_PROD=api.example.com
+CONTROL_DOMAIN_DEVO=control.devo.example.com
+CONTROL_DOMAIN_STAGING=control.staging.example.com
+CONTROL_DOMAIN_PROD=control.example.com
+AUTH_DOMAIN_DEVO=auth.devo.example.com
+AUTH_DOMAIN_STAGING=auth.staging.example.com
+AUTH_DOMAIN_PROD=auth.example.com
+CLOUDFLARE_ZONE_ID=zone-123
+OIDC_ISSUER_URL_DEVO=https://issuer.example.com/devo
+OIDC_ISSUER_URL_STAGING=https://issuer.example.com/staging
+OIDC_ISSUER_URL_PROD=https://issuer.example.com/prod
+JWKS_URL_DEVO=https://issuer.example.com/devo/jwks.json
+JWKS_URL_STAGING=https://issuer.example.com/staging/jwks.json
+JWKS_URL_PROD=https://issuer.example.com/prod/jwks.json
+GEMINI_MODEL=gemini-3-flash-preview
+DSQL_PORT=5432
+DSQL_DB=postgres
+DSQL_USER=admin
+DSQL_PROJECT_SCHEMA=ltbase
+GEMINI_API_KEY=test-gemini-key
+CLOUDFLARE_API_TOKEN=test-cloudflare-token
+LTBASE_RELEASES_TOKEN=test-release-token
+EOF
+}
+
+setup_fake_bin() {
+  local fake_bin="$1"
+  local log_file="$2"
+
+  mkdir -p "${fake_bin}"
+
+  cat >"${fake_bin}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'gh %s\n' "$*" >>"${COMMAND_LOG}"
+cmd="${1:-}"
+sub="${2:-}"
+if [[ "${cmd} ${sub}" == "repo view" ]]; then
+  if [[ "${SCENARIO}" == "repo_config_missing" || "${SCENARIO}" == "bootstrap_force" ]]; then
+    exit 1
+  fi
+  exit 0
+fi
+if [[ "${cmd} ${sub}" == "variable list" ]]; then
+  if [[ "${SCENARIO}" == "repo_config_missing" ]]; then
+    printf '[]'
+  else
+    printf '[{"name":"AWS_REGION_DEVO"},{"name":"AWS_REGION_STAGING"},{"name":"AWS_REGION_PROD"},{"name":"PULUMI_BACKEND_URL"},{"name":"PULUMI_SECRETS_PROVIDER_DEVO"},{"name":"PULUMI_SECRETS_PROVIDER_STAGING"},{"name":"PULUMI_SECRETS_PROVIDER_PROD"},{"name":"LTBASE_RELEASES_REPO"},{"name":"LTBASE_RELEASE_ID"}]'
+  fi
+  exit 0
+fi
+if [[ "${cmd} ${sub}" == "secret list" ]]; then
+  if [[ "${SCENARIO}" == "repo_config_missing" ]]; then
+    printf '[]'
+  else
+    printf '[{"name":"AWS_ROLE_ARN_DEVO"},{"name":"AWS_ROLE_ARN_STAGING"},{"name":"AWS_ROLE_ARN_PROD"},{"name":"LTBASE_RELEASES_TOKEN"},{"name":"CLOUDFLARE_API_TOKEN"}]'
+  fi
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "${fake_bin}/gh"
+
+  cat >"${fake_bin}/aws" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'aws %s\n' "$*" >>"${COMMAND_LOG}"
+args=("$@")
+if [[ "${args[0]:-}" == "--profile" ]]; then
+  args=("${args[@]:2}")
+fi
+command_key="${args[0]:-} ${args[1]:-}"
+case "${SCENARIO}:${command_key}" in
+  foundation_missing:iam\ get-open-id-connect-provider|foundation_missing:iam\ get-role)
+    exit 255
+    ;;
+  foundation_missing:s3api\ head-bucket)
+    exit 1
+    ;;
+  foundation_missing:kms\ list-aliases)
+    printf '{"Aliases":[]}'
+    exit 0
+    ;;
+  bootstrap_force:iam\ get-open-id-connect-provider|bootstrap_force:iam\ get-role)
+    exit 255
+    ;;
+  bootstrap_force:s3api\ head-bucket)
+    exit 1
+    ;;
+  bootstrap_force:kms\ list-aliases)
+    printf '{"Aliases":[]}'
+    exit 0
+    ;;
+  bootstrap_force:kms\ create-key)
+    printf 'key-123\n'
+    exit 0
+    ;;
+  *:kms\ list-aliases)
+    printf '{"Aliases":[{"AliasName":"alias/test-pulumi-secrets","TargetKeyId":"key-123"}]}'
+    exit 0
+    ;;
+esac
+exit 0
+EOF
+  chmod +x "${fake_bin}/aws"
+
+  cat >"${fake_bin}/pulumi" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'pulumi %s\n' "$*" >>"${COMMAND_LOG}"
+
+stack_name() {
+  local previous=""
+  for arg in "$@"; do
+    if [[ "${previous}" == "--stack" ]]; then
+      printf '%s' "${arg}"
+      return 0
+    fi
+    previous="${arg}"
+  done
+  printf '%s' "${STACK_HINT:-devo}"
+}
+
+if [[ "${1:-}" == "login" ]]; then
+  exit 0
+fi
+if [[ "${1:-} ${2:-}" == "stack select" ]]; then
+  if [[ "${SCENARIO}" == "bootstrap_force" ]]; then
+    exit 1
+  fi
+  exit 0
+fi
+if [[ "${1:-} ${2:-}" == "stack init" ]]; then
+  exit 0
+fi
+if [[ "${1:-} ${2:-} ${3:-} ${4:-}" == "stack output dsqlClusterIdentifier --stack" ]]; then
+  current_stack="$(stack_name "$@")"
+  case "${SCENARIO}:${current_stack}" in
+    rollout_mix:devo)
+      exit 1
+      ;;
+    rollout_mix:staging|rollout_mix:prod)
+      printf 'cluster-%s\n' "${current_stack}"
+      exit 0
+      ;;
+  esac
+  exit 1
+fi
+if [[ "${1:-} ${2:-} ${3:-} ${4:-}" == "config get dsqlEndpoint --stack" ]]; then
+  current_stack="$(stack_name "$@")"
+  case "${SCENARIO}:${current_stack}" in
+    rollout_mix:prod)
+      printf 'managed.prod.endpoint.example.com\n'
+      exit 0
+      ;;
+    rollout_mix:staging)
+      exit 1
+      ;;
+  esac
+  exit 1
+fi
+exit 0
+EOF
+  chmod +x "${fake_bin}/pulumi"
+
+  : >"${log_file}"
+}
+
+run_expect_exit_code() {
+  local expected="$1"
+  shift
+  set +e
+  "$@"
+  local status=$?
+  set -e
+  if [[ "${status}" -ne "${expected}" ]]; then
+    fail "expected exit code ${expected}, got ${status}"
+  fi
+}
+
+if [[ ! -x "${SCRIPT_PATH}" ]]; then
+  fail "missing executable script: ${SCRIPT_PATH}"
+fi
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+mkdir -p "${temp_dir}/infra"
+for stack in devo staging prod; do
+  cat >"${temp_dir}/infra/Pulumi.${stack}.yaml" <<EOF
+config:
+  ltbase-infra:awsRegion: test
+EOF
+done
+
+write_env "${temp_dir}/.env"
+setup_fake_bin "${temp_dir}/bin" "${temp_dir}/commands.log"
+
+run_expect_exit_code 2 env \
+  PATH="${temp_dir}/bin:$PATH" \
+  COMMAND_LOG="${temp_dir}/commands.log" \
+  SCENARIO="foundation_missing" \
+  "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-foundation"
+
+assert_file_contains "${temp_dir}/report-foundation/report.json" '"deploymentRepo": "customer-org/customer-ltbase"'
+assert_file_contains "${temp_dir}/report-foundation/report.json" '"status": "needs_foundation"'
+
+run_expect_exit_code 2 env \
+  PATH="${temp_dir}/bin:$PATH" \
+  COMMAND_LOG="${temp_dir}/commands.log" \
+  SCENARIO="repo_config_missing" \
+  "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-repo"
+
+assert_file_contains "${temp_dir}/report-repo/report.json" '"status": "needs_repo_config"'
+
+rm -f "${temp_dir}/infra/Pulumi.devo.yaml" "${temp_dir}/infra/Pulumi.staging.yaml" "${temp_dir}/infra/Pulumi.prod.yaml"
+run_expect_exit_code 2 env \
+  PATH="${temp_dir}/bin:$PATH" \
+  COMMAND_LOG="${temp_dir}/commands.log" \
+  SCENARIO="rollout_mix" \
+  "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-stack"
+
+assert_file_contains "${temp_dir}/report-stack/report.json" '"status": "needs_stack_bootstrap"'
+
+for stack in devo staging prod; do
+  cat >"${temp_dir}/infra/Pulumi.${stack}.yaml" <<EOF
+config:
+  ltbase-infra:awsRegion: test
+EOF
+done
+
+run_expect_exit_code 2 env \
+  PATH="${temp_dir}/bin:$PATH" \
+  COMMAND_LOG="${temp_dir}/commands.log" \
+  SCENARIO="rollout_mix" \
+  "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-rollout"
+
+assert_file_contains "${temp_dir}/report-rollout/report.json" '"stack": "devo"'
+assert_file_contains "${temp_dir}/report-rollout/report.json" '"status": "needs_rollout"'
+assert_file_contains "${temp_dir}/report-rollout/report.json" '"stack": "staging"'
+assert_file_contains "${temp_dir}/report-rollout/report.json" '"status": "needs_dsql_reconcile"'
+assert_file_contains "${temp_dir}/report-rollout/report.json" '"stack": "prod"'
+assert_file_contains "${temp_dir}/report-rollout/report.json" '"status": "complete"'
+
+rm -rf "${temp_dir}/infra"
+mkdir -p "${temp_dir}/infra"
+run_expect_exit_code 0 env \
+  PATH="${temp_dir}/bin:$PATH" \
+  COMMAND_LOG="${temp_dir}/commands.log" \
+  SCENARIO="bootstrap_force" \
+  "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --scope bootstrap --force --report-dir "${temp_dir}/report-force"
+
+assert_log_contains "${temp_dir}/commands.log" "gh repo create customer-org/customer-ltbase"
+assert_log_contains "${temp_dir}/commands.log" "aws --profile devo-profile iam create-open-id-connect-provider"
+assert_log_contains "${temp_dir}/commands.log" "aws --profile prod-profile iam create-open-id-connect-provider"
+assert_log_contains "${temp_dir}/commands.log" "pulumi stack init devo --secrets-provider awskms://alias/test-pulumi-secrets?region=ap-northeast-1"
+assert_log_contains "${temp_dir}/commands.log" "pulumi stack init staging --secrets-provider awskms://alias/test-pulumi-secrets?region=us-east-1"
+assert_log_contains "${temp_dir}/commands.log" "pulumi stack init prod --secrets-provider awskms://alias/test-pulumi-secrets?region=us-west-2"
+
+printf 'PASS: evaluate-and-continue tests\n'


### PR DESCRIPTION
Closes #12
Refs #16

## Summary
- add a shared bootstrap env normalization layer with derived repo, role, Pulumi, and per-stack config values
- add `evaluate-and-continue.sh` to scan GitHub/AWS/Pulumi bootstrap state, emit a machine-readable report, and fill missing bootstrap gaps with `--force`
- update the existing bootstrap scripts, template env file, and shell coverage to use stack-aware configuration resolution

## Testing
- bash test/bootstrap-all-test.sh
- bash test/bootstrap-aws-foundation-test.sh
- bash test/bootstrap-pulumi-backend-test.sh
- bash test/bootstrap-deployment-repo-test.sh
- bash test/create-deployment-repo-test.sh
- bash test/render-bootstrap-policies-test.sh
- bash test/reconcile-managed-dsql-endpoint-test.sh
- bash test/evaluate-and-continue-test.sh