### PR TITLE
[codex] bootstrap oidc discovery companion resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Important files and scripts:
 - `scripts/render-bootstrap-policies.sh`
 - `scripts/create-deployment-repo.sh`
 - `scripts/bootstrap-aws-foundation.sh`
+- `scripts/bootstrap-oidc-discovery-companion.sh`
 - `scripts/bootstrap-pulumi-backend.sh`
 - `scripts/bootstrap-deployment-repo.sh`
 - `scripts/bootstrap-all.sh`
@@ -82,6 +83,10 @@ Preferred recovery-aware bootstrap entrypoint:
 
 - `./scripts/evaluate-and-continue.sh --env-file .env --scope bootstrap`
 - `./scripts/evaluate-and-continue.sh --env-file .env --scope bootstrap --force`
+
+The bootstrap flow now also manages the customer-specific `*-oidc-discovery` companion repository, its Cloudflare Pages project and custom domain, and the per-stack read-only discovery roles that the companion publish workflow assumes.
+
+当前 bootstrap 流程还会自动管理客户专属的 `*-oidc-discovery` companion repo、对应的 Cloudflare Pages project 与自定义域名，以及 companion publish workflow 需要假设的每个 stack 的只读 discovery role。
 
 ## Deployment Principles / 部署原则
 

--- a/env.template
+++ b/env.template
@@ -9,6 +9,14 @@ GITHUB_OWNER=customer-org
 DEPLOYMENT_REPO_NAME=customer-ltbase
 DEPLOYMENT_REPO_VISIBILITY=private
 DEPLOYMENT_REPO_DESCRIPTION="Customer LTBase deployment repo"
+OIDC_DISCOVERY_DOMAIN=oidc.customer.example.com
+CLOUDFLARE_ACCOUNT_ID=replace-with-cloudflare-account-id
+
+# Optional overrides for the companion repo bootstrap.
+# OIDC_DISCOVERY_TEMPLATE_REPO=Lychee-Technology/ltbase-oidc-discovery-template
+# OIDC_DISCOVERY_REPO_NAME=customer-ltbase-oidc-discovery
+# OIDC_DISCOVERY_REPO=customer-org/customer-ltbase-oidc-discovery
+# OIDC_DISCOVERY_PAGES_PROJECT=customer-ltbase-oidc-discovery
 
 # Optional override. Defaults to ${GITHUB_OWNER}/${DEPLOYMENT_REPO_NAME}.
 # DEPLOYMENT_REPO=customer-org/customer-ltbase
@@ -42,16 +50,24 @@ CONTROL_DOMAIN_PROD=control.customer.example.com
 AUTH_DOMAIN_DEVO=auth.devo.customer.example.com
 AUTH_DOMAIN_PROD=auth.customer.example.com
 CLOUDFLARE_ZONE_ID=replace-with-zone-id
-OIDC_ISSUER_URL_DEVO=https://oidc.example.com/customer-devo
-OIDC_ISSUER_URL_PROD=https://oidc.example.com/customer-prod
-JWKS_URL_DEVO=https://oidc.example.com/customer-devo/.well-known/jwks.json
-JWKS_URL_PROD=https://oidc.example.com/customer-prod/.well-known/jwks.json
+
+# Optional overrides. These default to:
+#   https://${OIDC_DISCOVERY_DOMAIN}/<stack>
+#   https://${OIDC_DISCOVERY_DOMAIN}/<stack>/.well-known/jwks.json
+# OIDC_ISSUER_URL_DEVO=https://oidc.customer.example.com/devo
+# OIDC_ISSUER_URL_PROD=https://oidc.customer.example.com/prod
+# JWKS_URL_DEVO=https://oidc.customer.example.com/devo/.well-known/jwks.json
+# JWKS_URL_PROD=https://oidc.customer.example.com/prod/.well-known/jwks.json
 
 # Optional overrides. Defaults are <DEPLOYMENT_REPO_NAME>-runtime-<stack> and <DEPLOYMENT_REPO_NAME>-<stack>.
 # RUNTIME_BUCKET_DEVO=customer-ltbase-runtime-devo
 # RUNTIME_BUCKET_PROD=customer-ltbase-runtime-prod
 # TABLE_NAME_DEVO=customer-ltbase-devo
 # TABLE_NAME_PROD=customer-ltbase-prod
+
+# Optional overrides. Defaults are <DEPLOYMENT_REPO_NAME>-oidc-discovery-<stack>.
+# OIDC_DISCOVERY_AWS_ROLE_NAME_DEVO=customer-ltbase-oidc-discovery-devo
+# OIDC_DISCOVERY_AWS_ROLE_NAME_PROD=customer-ltbase-oidc-discovery-prod
 
 # Optional overrides. Defaults are derived from GITHUB_OWNER / DEPLOYMENT_REPO_NAME.
 # GITHUB_ORG=customer-org

--- a/scripts/bootstrap-all.sh
+++ b/scripts/bootstrap-all.sh
@@ -45,6 +45,7 @@ fi
 create-deployment-repo.sh --env-file "${ENV_FILE}"
 render-bootstrap-policies.sh --env-file "${ENV_FILE}"
 bootstrap-aws-foundation.sh --env-file "${ENV_FILE}"
+bootstrap-oidc-discovery-companion.sh --env-file "${ENV_FILE}"
 while IFS= read -r stack; do
   bootstrap-deployment-repo.sh --env-file "${ENV_FILE}" --stack "${stack}" --infra-dir "${INFRA_DIR}"
 done < <(bootstrap_env_each_stack)

--- a/scripts/bootstrap-oidc-discovery-companion.sh
+++ b/scripts/bootstrap-oidc-discovery-companion.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ENV_FILE=""
+OUTPUT_DIR="dist"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env-file)
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${ENV_FILE}" ]]; then
+  echo "--env-file is required" >&2
+  exit 1
+fi
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/lib/bootstrap-env.sh"
+bootstrap_env_load "${ENV_FILE}"
+
+required_vars=(GITHUB_OWNER DEPLOYMENT_REPO_NAME DEPLOYMENT_REPO_VISIBILITY OIDC_DISCOVERY_DOMAIN CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN OIDC_DISCOVERY_TEMPLATE_REPO OIDC_DISCOVERY_REPO_NAME OIDC_DISCOVERY_REPO OIDC_DISCOVERY_PAGES_PROJECT)
+bootstrap_env_require_vars "${required_vars[@]}"
+while IFS= read -r stack; do
+  bootstrap_env_require_stack_values "${stack}" AWS_REGION AWS_ACCOUNT_ID OIDC_DISCOVERY_AWS_ROLE_NAME OIDC_DISCOVERY_AWS_ROLE_ARN OIDC_ISSUER_URL JWKS_URL
+done < <(bootstrap_env_each_stack)
+
+mkdir -p "${OUTPUT_DIR}"
+companion_summary="${OUTPUT_DIR}/oidc-discovery-companion.env"
+oidc_stack_config="$(bootstrap_env_oidc_discovery_stack_config_json)"
+
+visibility_flag="--private"
+if [[ "${DEPLOYMENT_REPO_VISIBILITY}" == "public" ]]; then
+  visibility_flag="--public"
+fi
+
+cloudflare_headers=(
+  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}"
+  -H "Content-Type: application/json"
+)
+
+pages_project_url="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${OIDC_DISCOVERY_PAGES_PROJECT}"
+pages_projects_url="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects"
+pages_domain_url="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${OIDC_DISCOVERY_PAGES_PROJECT}/domains/${OIDC_DISCOVERY_DOMAIN}"
+pages_domains_url="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${OIDC_DISCOVERY_PAGES_PROJECT}/domains"
+
+if ! gh repo view "${OIDC_DISCOVERY_REPO}" >/dev/null 2>&1; then
+  gh repo create "${OIDC_DISCOVERY_REPO}" --template "${OIDC_DISCOVERY_TEMPLATE_REPO}" ${visibility_flag} --description "LTBase OIDC discovery companion for ${DEPLOYMENT_REPO_NAME}" --clone=false
+fi
+
+repo_metadata="$(gh api "repos/${OIDC_DISCOVERY_REPO}")"
+default_branch="$(python3 - <<'PY' <<<"${repo_metadata}"
+import json
+import sys
+
+data = json.load(sys.stdin)
+print(data.get("default_branch", "main"))
+PY
+)"
+
+if ! curl -fsS "${cloudflare_headers[@]}" "${pages_project_url}" >/dev/null 2>&1; then
+  project_payload="$(python3 - "${OIDC_DISCOVERY_PAGES_PROJECT}" "${GITHUB_OWNER}" "${OIDC_DISCOVERY_REPO_NAME}" "${default_branch}" <<'PY'
+import json
+import sys
+
+print(json.dumps({
+    "name": sys.argv[1],
+    "production_branch": sys.argv[4],
+    "source": {
+        "type": "github",
+        "config": {
+            "owner": sys.argv[2],
+            "repo_name": sys.argv[3],
+            "production_branch": sys.argv[4],
+            "preview_deployment_setting": "none",
+            "production_deployments_enabled": True,
+        },
+    },
+}, separators=(",", ":")))
+PY
+)"
+  curl -fsS -X POST "${cloudflare_headers[@]}" "${pages_projects_url}" --data "${project_payload}" >/dev/null
+fi
+
+if ! curl -fsS "${cloudflare_headers[@]}" "${pages_domain_url}" >/dev/null 2>&1; then
+  domain_payload="$(python3 - "${OIDC_DISCOVERY_DOMAIN}" <<'PY'
+import json
+import sys
+
+print(json.dumps({"name": sys.argv[1]}, separators=(",", ":")))
+PY
+)"
+  curl -fsS -X POST "${cloudflare_headers[@]}" "${pages_domains_url}" --data "${domain_payload}" >/dev/null
+fi
+
+gh variable set OIDC_DISCOVERY_DOMAIN --repo "${OIDC_DISCOVERY_REPO}" --body "${OIDC_DISCOVERY_DOMAIN}"
+gh variable set OIDC_DISCOVERY_STACK_CONFIG --repo "${OIDC_DISCOVERY_REPO}" --body "${oidc_stack_config}"
+
+create_or_update_discovery_role() {
+  local stack="$1"
+  local upper_name account_id region role_name role_arn provider_arn
+  local trust_policy_path role_policy_path
+
+  upper_name="$(bootstrap_env_stack_upper "${stack}")"
+  account_id="$(bootstrap_env_resolve_stack_value AWS_ACCOUNT_ID "${stack}")"
+  region="$(bootstrap_env_resolve_stack_value AWS_REGION "${stack}")"
+  role_name="$(bootstrap_env_resolve_stack_value OIDC_DISCOVERY_AWS_ROLE_NAME "${stack}")"
+  role_arn="$(bootstrap_env_resolve_stack_value OIDC_DISCOVERY_AWS_ROLE_ARN "${stack}")"
+  provider_arn="arn:aws:iam::${account_id}:oidc-provider/token.actions.githubusercontent.com"
+  trust_policy_path="${OUTPUT_DIR}/oidc-discovery-${stack}-trust-policy.json"
+  role_policy_path="${OUTPUT_DIR}/oidc-discovery-${stack}-role-policy.json"
+
+  cat >"${trust_policy_path}" <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "${provider_arn}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": [
+            "repo:${OIDC_DISCOVERY_REPO}:ref:refs/heads/${default_branch}"
+          ]
+        }
+      }
+    }
+  ]
+}
+EOF
+
+  cat >"${role_policy_path}" <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "kms:GetPublicKey",
+        "kms:DescribeKey"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+
+  if ! bootstrap_env_aws_command_for_stack "${stack}" iam get-open-id-connect-provider --open-id-connect-provider-arn "${provider_arn}" >/dev/null 2>&1; then
+    bootstrap_env_aws_command_for_stack "${stack}" iam create-open-id-connect-provider --url https://token.actions.githubusercontent.com --client-id-list sts.amazonaws.com >/dev/null
+  fi
+
+  if ! bootstrap_env_aws_command_for_stack "${stack}" iam get-role --role-name "${role_name}" >/dev/null 2>&1; then
+    bootstrap_env_aws_command_for_stack "${stack}" iam create-role --role-name "${role_name}" --assume-role-policy-document "file://${trust_policy_path}" >/dev/null
+  fi
+
+  bootstrap_env_aws_command_for_stack "${stack}" iam update-assume-role-policy --role-name "${role_name}" --policy-document "file://${trust_policy_path}" >/dev/null
+  bootstrap_env_aws_command_for_stack "${stack}" iam put-role-policy --role-name "${role_name}" --policy-name LTBaseOIDCDiscoveryAccess --policy-document "file://${role_policy_path}" >/dev/null
+
+  cat >>"${companion_summary}" <<EOF
+OIDC_DISCOVERY_AWS_ROLE_ARN_${upper_name}=${role_arn}
+EOF
+}
+
+: >"${companion_summary}"
+cat >>"${companion_summary}" <<EOF
+OIDC_DISCOVERY_REPO=${OIDC_DISCOVERY_REPO}
+OIDC_DISCOVERY_REPO_NAME=${OIDC_DISCOVERY_REPO_NAME}
+OIDC_DISCOVERY_PAGES_PROJECT=${OIDC_DISCOVERY_PAGES_PROJECT}
+OIDC_DISCOVERY_DOMAIN=${OIDC_DISCOVERY_DOMAIN}
+EOF
+
+while IFS= read -r stack; do
+  upper_name="$(bootstrap_env_stack_upper "${stack}")"
+  create_or_update_discovery_role "${stack}"
+  cat >>"${companion_summary}" <<EOF
+OIDC_ISSUER_URL_${upper_name}=$(bootstrap_env_resolve_stack_value OIDC_ISSUER_URL "${stack}")
+JWKS_URL_${upper_name}=$(bootstrap_env_resolve_stack_value JWKS_URL "${stack}")
+EOF
+done < <(bootstrap_env_each_stack)

--- a/scripts/evaluate-and-continue.sh
+++ b/scripts/evaluate-and-continue.sh
@@ -56,10 +56,10 @@ script_dir="$(cd "$(dirname "$0")" && pwd)"
 source "${script_dir}/lib/bootstrap-env.sh"
 bootstrap_env_load "${ENV_FILE}"
 
-required_vars=(TEMPLATE_REPO GITHUB_OWNER DEPLOYMENT_REPO_NAME DEPLOYMENT_REPO_VISIBILITY DEPLOYMENT_REPO_DESCRIPTION DEPLOYMENT_REPO PULUMI_STATE_BUCKET PULUMI_KMS_ALIAS PULUMI_BACKEND_URL LTBASE_RELEASES_REPO LTBASE_RELEASE_ID LTBASE_RELEASES_TOKEN CLOUDFLARE_API_TOKEN GEMINI_API_KEY CLOUDFLARE_ZONE_ID GITHUB_ORG GITHUB_REPO GEMINI_MODEL DSQL_PORT DSQL_DB DSQL_USER DSQL_PROJECT_SCHEMA)
+required_vars=(TEMPLATE_REPO GITHUB_OWNER DEPLOYMENT_REPO_NAME DEPLOYMENT_REPO_VISIBILITY DEPLOYMENT_REPO_DESCRIPTION DEPLOYMENT_REPO PULUMI_STATE_BUCKET PULUMI_KMS_ALIAS PULUMI_BACKEND_URL LTBASE_RELEASES_REPO LTBASE_RELEASE_ID LTBASE_RELEASES_TOKEN CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID OIDC_DISCOVERY_DOMAIN OIDC_DISCOVERY_TEMPLATE_REPO OIDC_DISCOVERY_REPO OIDC_DISCOVERY_PAGES_PROJECT GEMINI_API_KEY CLOUDFLARE_ZONE_ID GITHUB_ORG GITHUB_REPO GEMINI_MODEL DSQL_PORT DSQL_DB DSQL_USER DSQL_PROJECT_SCHEMA)
 bootstrap_env_require_vars "${required_vars[@]}"
 while IFS= read -r stack; do
-  bootstrap_env_require_stack_values "${stack}" AWS_REGION AWS_ACCOUNT_ID AWS_ROLE_NAME AWS_ROLE_ARN PULUMI_SECRETS_PROVIDER API_DOMAIN CONTROL_DOMAIN AUTH_DOMAIN OIDC_ISSUER_URL JWKS_URL RUNTIME_BUCKET TABLE_NAME
+  bootstrap_env_require_stack_values "${stack}" AWS_REGION AWS_ACCOUNT_ID AWS_ROLE_NAME AWS_ROLE_ARN PULUMI_SECRETS_PROVIDER API_DOMAIN CONTROL_DOMAIN AUTH_DOMAIN OIDC_DISCOVERY_AWS_ROLE_NAME OIDC_DISCOVERY_AWS_ROLE_ARN OIDC_ISSUER_URL JWKS_URL RUNTIME_BUCKET TABLE_NAME
 done < <(bootstrap_env_each_stack)
 
 mkdir -p "${REPORT_DIR}"
@@ -67,8 +67,10 @@ mkdir -p "${REPORT_DIR}"
 report_file="${REPORT_DIR}/report.json"
 actions_log="${REPORT_DIR}/actions.log"
 state_file="${REPORT_DIR}/stack-status.tsv"
+oidc_status_file="${REPORT_DIR}/oidc-status.env"
 : >"${actions_log}"
 : >"${state_file}"
+: >"${oidc_status_file}"
 
 run_logged() {
   printf '%s\n' "$*" >>"${actions_log}"
@@ -92,17 +94,6 @@ sys.exit(0 if needle in names else 1)
 PY
 }
 
-aws_command_for_stack() {
-  local stack="$1"
-  shift
-  local command=(aws)
-  while IFS= read -r token; do
-    command+=("${token}")
-  done < <(bootstrap_env_stack_profile_args "${stack}")
-  command+=("$@")
-  "${command[@]}"
-}
-
 foundation_present_for_stack() {
   local stack="$1"
   local region account_id role_name provider_arn alias_json
@@ -112,13 +103,13 @@ foundation_present_for_stack() {
   role_name="$(bootstrap_env_resolve_stack_value AWS_ROLE_NAME "${stack}")"
   provider_arn="arn:aws:iam::${account_id}:oidc-provider/token.actions.githubusercontent.com"
 
-  if ! aws_command_for_stack "${stack}" iam get-open-id-connect-provider --open-id-connect-provider-arn "${provider_arn}" >/dev/null 2>&1; then
+  if ! bootstrap_env_aws_command_for_stack "${stack}" iam get-open-id-connect-provider --open-id-connect-provider-arn "${provider_arn}" >/dev/null 2>&1; then
     return 1
   fi
-  if ! aws_command_for_stack "${stack}" iam get-role --role-name "${role_name}" >/dev/null 2>&1; then
+  if ! bootstrap_env_aws_command_for_stack "${stack}" iam get-role --role-name "${role_name}" >/dev/null 2>&1; then
     return 1
   fi
-  alias_json="$(aws_command_for_stack "${stack}" kms list-aliases --region "${region}" --output json)"
+  alias_json="$(bootstrap_env_aws_command_for_stack "${stack}" kms list-aliases --region "${region}" --output json)"
   python3 - "${PULUMI_KMS_ALIAS}" <<'PY' <<<"${alias_json}"
 import json
 import sys
@@ -135,11 +126,15 @@ shared_foundation_present() {
   if [[ -z "${first_stack}" ]]; then
     return 1
   fi
-  aws_command_for_stack "${first_stack}" s3api head-bucket --bucket "${PULUMI_STATE_BUCKET}" >/dev/null 2>&1
+  bootstrap_env_aws_command_for_stack "${first_stack}" s3api head-bucket --bucket "${PULUMI_STATE_BUCKET}" >/dev/null 2>&1
 }
 
 repo_exists() {
   gh repo view "${DEPLOYMENT_REPO}" >/dev/null 2>&1
+}
+
+oidc_companion_repo_exists() {
+  gh repo view "${OIDC_DISCOVERY_REPO}" >/dev/null 2>&1
 }
 
 repo_config_present() {
@@ -178,6 +173,91 @@ repo_config_present() {
   done < <(bootstrap_env_each_stack)
 
   return 0
+}
+
+oidc_companion_repo_config_present() {
+  local variable_json
+
+  if ! oidc_companion_repo_exists; then
+    return 1
+  fi
+
+  variable_json="$(gh variable list --repo "${OIDC_DISCOVERY_REPO}" --json name)"
+  if ! json_name_list_contains "${variable_json}" "OIDC_DISCOVERY_DOMAIN"; then
+    return 1
+  fi
+  if ! json_name_list_contains "${variable_json}" "OIDC_DISCOVERY_STACK_CONFIG"; then
+    return 1
+  fi
+
+  return 0
+}
+
+cloudflare_pages_project_present() {
+  curl -fsS \
+    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${OIDC_DISCOVERY_PAGES_PROJECT}" >/dev/null 2>&1
+}
+
+cloudflare_pages_domain_present() {
+  curl -fsS \
+    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${OIDC_DISCOVERY_PAGES_PROJECT}/domains/${OIDC_DISCOVERY_DOMAIN}" >/dev/null 2>&1
+}
+
+oidc_discovery_roles_present() {
+  local stack role_name
+  while IFS= read -r stack; do
+    role_name="$(bootstrap_env_resolve_stack_value OIDC_DISCOVERY_AWS_ROLE_NAME "${stack}")"
+    if ! bootstrap_env_aws_command_for_stack "${stack}" iam get-role --role-name "${role_name}" >/dev/null 2>&1; then
+      return 1
+    fi
+  done < <(bootstrap_env_each_stack)
+  return 0
+}
+
+scan_oidc_discovery_state() {
+  local repo_present="false"
+  local repo_config_present="false"
+  local pages_project_present="false"
+  local pages_domain_present="false"
+  local roles_present="false"
+  local status="needs_oidc_companion"
+
+  if [[ "${SCOPE}" == "foundation" ]]; then
+    status="skipped"
+  else
+    if oidc_companion_repo_exists; then
+      repo_present="true"
+    fi
+    if oidc_companion_repo_config_present; then
+      repo_config_present="true"
+    fi
+    if cloudflare_pages_project_present; then
+      pages_project_present="true"
+    fi
+    if cloudflare_pages_domain_present; then
+      pages_domain_present="true"
+    fi
+    if oidc_discovery_roles_present; then
+      roles_present="true"
+    fi
+
+    if [[ "${repo_present}" == "true" && "${repo_config_present}" == "true" && "${pages_project_present}" == "true" && "${pages_domain_present}" == "true" && "${roles_present}" == "true" ]]; then
+      status="complete"
+    fi
+  fi
+
+  cat >"${oidc_status_file}" <<EOF
+OIDC_DISCOVERY_STATUS=${status}
+OIDC_DISCOVERY_REPO_PRESENT=${repo_present}
+OIDC_DISCOVERY_REPO_CONFIG_PRESENT=${repo_config_present}
+OIDC_DISCOVERY_PAGES_PROJECT_PRESENT=${pages_project_present}
+OIDC_DISCOVERY_PAGES_DOMAIN_PRESENT=${pages_domain_present}
+OIDC_DISCOVERY_ROLES_PRESENT=${roles_present}
+EOF
 }
 
 stack_bootstrap_present() {
@@ -271,20 +351,27 @@ scan_state() {
 
     printf '%s\t%s\n' "${stack}" "${status}" >>"${state_file}"
   done < <(bootstrap_env_each_stack)
+
+  scan_oidc_discovery_state
 }
 
 write_report() {
-  python3 - "${state_file}" "${report_file}" "${DEPLOYMENT_REPO}" "${STACKS}" "${PROMOTION_PATH}" "${SCOPE}" <<'PY'
+  python3 - "${state_file}" "${oidc_status_file}" "${report_file}" "${DEPLOYMENT_REPO}" "${OIDC_DISCOVERY_REPO}" "${OIDC_DISCOVERY_PAGES_PROJECT}" "${OIDC_DISCOVERY_DOMAIN}" "${STACKS}" "${PROMOTION_PATH}" "${SCOPE}" <<'PY'
 import json
+import os
 import sys
 from pathlib import Path
 
 state_path = Path(sys.argv[1])
-report_path = Path(sys.argv[2])
-deployment_repo = sys.argv[3]
-stacks = [item for item in sys.argv[4].split(",") if item]
-promotion_path = [item for item in sys.argv[5].split(",") if item]
-scope = sys.argv[6]
+oidc_state_path = Path(sys.argv[2])
+report_path = Path(sys.argv[3])
+deployment_repo = sys.argv[4]
+oidc_repo = sys.argv[5]
+oidc_pages_project = sys.argv[6]
+oidc_domain = sys.argv[7]
+stacks = [item for item in sys.argv[8].split(",") if item]
+promotion_path = [item for item in sys.argv[9].split(",") if item]
+scope = sys.argv[10]
 
 items = []
 with state_path.open() as handle:
@@ -295,8 +382,28 @@ with state_path.open() as handle:
         stack, status = line.split("\t", 1)
         items.append({"stack": stack, "status": status})
 
+oidc_values = {}
+with oidc_state_path.open() as handle:
+    for line in handle:
+        line = line.strip()
+        if not line or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        oidc_values[key] = value
+
 report = {
     "deploymentRepo": deployment_repo,
+    "oidcDiscovery": {
+        "repo": oidc_repo,
+        "pagesProject": oidc_pages_project,
+        "domain": oidc_domain,
+        "status": oidc_values.get("OIDC_DISCOVERY_STATUS", "needs_oidc_companion"),
+        "repoPresent": oidc_values.get("OIDC_DISCOVERY_REPO_PRESENT", "false") == "true",
+        "repoConfigPresent": oidc_values.get("OIDC_DISCOVERY_REPO_CONFIG_PRESENT", "false") == "true",
+        "pagesProjectPresent": oidc_values.get("OIDC_DISCOVERY_PAGES_PROJECT_PRESENT", "false") == "true",
+        "pagesDomainPresent": oidc_values.get("OIDC_DISCOVERY_PAGES_DOMAIN_PRESENT", "false") == "true",
+        "rolesPresent": oidc_values.get("OIDC_DISCOVERY_ROLES_PRESENT", "false") == "true",
+    },
     "scope": scope,
     "stacks": stacks,
     "promotionPath": promotion_path,
@@ -311,12 +418,18 @@ has_non_complete_status() {
   if grep -Fv $'\tcomplete' "${state_file}" >/dev/null 2>&1; then
     return 0
   fi
+  # shellcheck disable=SC1090
+  source "${oidc_status_file}"
+  if [[ "${OIDC_DISCOVERY_STATUS}" != "complete" && "${OIDC_DISCOVERY_STATUS}" != "skipped" ]]; then
+    return 0
+  fi
   return 1
 }
 
 run_force_actions() {
   local needs_foundation="false"
   local needs_repo="false"
+  local needs_oidc_companion="false"
   local stack status
 
   while IFS=$'\t' read -r stack status; do
@@ -330,6 +443,11 @@ run_force_actions() {
         ;;
     esac
   done <"${state_file}"
+  # shellcheck disable=SC1090
+  source "${oidc_status_file}"
+  if [[ "${OIDC_DISCOVERY_STATUS}" != "complete" && "${OIDC_DISCOVERY_STATUS}" != "skipped" ]]; then
+    needs_oidc_companion="true"
+  fi
 
   if [[ "${needs_foundation}" == "true" ]]; then
     run_logged "${script_dir}/render-bootstrap-policies.sh" --env-file "${ENV_FILE}"
@@ -351,6 +469,10 @@ run_force_actions() {
       esac
     done <"${state_file}"
   fi
+
+  if [[ "${needs_oidc_companion}" == "true" && "${SCOPE}" != "foundation" ]]; then
+    run_logged "${script_dir}/bootstrap-oidc-discovery-companion.sh" --env-file "${ENV_FILE}"
+  fi
 }
 
 scan_state
@@ -359,6 +481,9 @@ write_report
 while IFS=$'\t' read -r stack status; do
   printf '%s: %s\n' "${stack}" "${status}"
 done <"${state_file}"
+# shellcheck disable=SC1090
+source "${oidc_status_file}"
+printf 'oidc-discovery: %s\n' "${OIDC_DISCOVERY_STATUS}"
 printf 'report: %s\n' "${report_file}"
 
 if [[ "${FORCE}" == "true" ]]; then

--- a/scripts/lib/bootstrap-env.sh
+++ b/scripts/lib/bootstrap-env.sh
@@ -79,6 +79,17 @@ bootstrap_env_stack_profile_args() {
   fi
 }
 
+bootstrap_env_aws_command_for_stack() {
+  local stack="$1"
+  shift
+  local command=(aws)
+  while IFS= read -r token; do
+    command+=("${token}")
+  done < <(bootstrap_env_stack_profile_args "${stack}")
+  command+=("$@")
+  "${command[@]}"
+}
+
 bootstrap_env_require_vars() {
   local name
   for name in "$@"; do
@@ -107,6 +118,7 @@ bootstrap_env_require_stack_values() {
 bootstrap_env_apply_derivations() {
   local stack upper_name region account_id role_name
   local role_arn_var provider_var runtime_bucket_var table_name_var
+  local discovery_role_name_var discovery_role_arn_var issuer_var jwks_var
 
   if [[ -z "${DEPLOYMENT_REPO:-}" && -n "${GITHUB_OWNER:-}" && -n "${DEPLOYMENT_REPO_NAME:-}" ]]; then
     DEPLOYMENT_REPO="${GITHUB_OWNER}/${DEPLOYMENT_REPO_NAME}"
@@ -123,6 +135,22 @@ bootstrap_env_apply_derivations() {
   if [[ -z "${PULUMI_BACKEND_URL:-}" && -n "${PULUMI_STATE_BUCKET:-}" ]]; then
     PULUMI_BACKEND_URL="s3://${PULUMI_STATE_BUCKET}"
     export PULUMI_BACKEND_URL
+  fi
+  if [[ -z "${OIDC_DISCOVERY_TEMPLATE_REPO:-}" ]]; then
+    OIDC_DISCOVERY_TEMPLATE_REPO="Lychee-Technology/ltbase-oidc-discovery-template"
+    export OIDC_DISCOVERY_TEMPLATE_REPO
+  fi
+  if [[ -z "${OIDC_DISCOVERY_REPO_NAME:-}" && -n "${DEPLOYMENT_REPO_NAME:-}" ]]; then
+    OIDC_DISCOVERY_REPO_NAME="${DEPLOYMENT_REPO_NAME}-oidc-discovery"
+    export OIDC_DISCOVERY_REPO_NAME
+  fi
+  if [[ -z "${OIDC_DISCOVERY_REPO:-}" && -n "${GITHUB_OWNER:-}" && -n "${OIDC_DISCOVERY_REPO_NAME:-}" ]]; then
+    OIDC_DISCOVERY_REPO="${GITHUB_OWNER}/${OIDC_DISCOVERY_REPO_NAME}"
+    export OIDC_DISCOVERY_REPO
+  fi
+  if [[ -z "${OIDC_DISCOVERY_PAGES_PROJECT:-}" && -n "${OIDC_DISCOVERY_REPO_NAME:-}" ]]; then
+    OIDC_DISCOVERY_PAGES_PROJECT="${OIDC_DISCOVERY_REPO_NAME}"
+    export OIDC_DISCOVERY_PAGES_PROJECT
   fi
 
   while IFS= read -r stack; do
@@ -154,6 +182,30 @@ bootstrap_env_apply_derivations() {
       printf -v "${table_name_var}" '%s-%s' "${DEPLOYMENT_REPO_NAME}" "${stack}"
       export "${table_name_var}"
     fi
+
+    discovery_role_name_var="OIDC_DISCOVERY_AWS_ROLE_NAME_${upper_name}"
+    if [[ -z "${!discovery_role_name_var:-}" && -n "${DEPLOYMENT_REPO_NAME:-}" ]]; then
+      printf -v "${discovery_role_name_var}" '%s-oidc-discovery-%s' "${DEPLOYMENT_REPO_NAME}" "${stack}"
+      export "${discovery_role_name_var}"
+    fi
+
+    discovery_role_arn_var="OIDC_DISCOVERY_AWS_ROLE_ARN_${upper_name}"
+    if [[ -z "${!discovery_role_arn_var:-}" && -n "${account_id}" && -n "${!discovery_role_name_var:-}" ]]; then
+      printf -v "${discovery_role_arn_var}" 'arn:aws:iam::%s:role/%s' "${account_id}" "${!discovery_role_name_var}"
+      export "${discovery_role_arn_var}"
+    fi
+
+    issuer_var="OIDC_ISSUER_URL_${upper_name}"
+    if [[ -z "${!issuer_var:-}" && -z "${OIDC_ISSUER_URL:-}" && -n "${OIDC_DISCOVERY_DOMAIN:-}" ]]; then
+      printf -v "${issuer_var}" 'https://%s/%s' "${OIDC_DISCOVERY_DOMAIN}" "${stack}"
+      export "${issuer_var}"
+    fi
+
+    jwks_var="JWKS_URL_${upper_name}"
+    if [[ -z "${!jwks_var:-}" && -z "${JWKS_URL:-}" && -n "${OIDC_DISCOVERY_DOMAIN:-}" ]]; then
+      printf -v "${jwks_var}" 'https://%s/%s/.well-known/jwks.json' "${OIDC_DISCOVERY_DOMAIN}" "${stack}"
+      export "${jwks_var}"
+    fi
   done < <(bootstrap_env_each_stack)
 
   if [[ -z "${PROMOTION_PATH:-}" ]]; then
@@ -183,4 +235,29 @@ bootstrap_env_load() {
   export PROMOTION_PATH
 
   bootstrap_env_apply_derivations
+}
+
+bootstrap_env_oidc_discovery_stack_config_json() {
+  while IFS= read -r stack; do
+    printf '%s\t%s\t%s\n' \
+      "${stack}" \
+      "$(bootstrap_env_resolve_stack_value AWS_REGION "${stack}")" \
+      "$(bootstrap_env_resolve_stack_value OIDC_DISCOVERY_AWS_ROLE_ARN "${stack}")"
+  done < <(bootstrap_env_each_stack) | python3 -c '
+import json
+import sys
+
+payload = {}
+for line in sys.stdin:
+    line = line.rstrip("\n")
+    if not line:
+        continue
+    stack, aws_region, aws_role_arn = line.split("\t", 2)
+    payload[stack] = {
+        "aws_region": aws_region,
+        "aws_role_arn": aws_role_arn,
+    }
+
+print(json.dumps(payload, separators=(",", ":")))
+'
 }

--- a/test/bootstrap-all-test.sh
+++ b/test/bootstrap-all-test.sh
@@ -40,6 +40,8 @@ GITHUB_OWNER=customer-org
 DEPLOYMENT_REPO_NAME=customer-ltbase
 DEPLOYMENT_REPO_VISIBILITY=private
 DEPLOYMENT_REPO_DESCRIPTION="Customer LTBase deployment repo"
+OIDC_DISCOVERY_DOMAIN=oidc.customer.example.com
+CLOUDFLARE_ACCOUNT_ID=cf-account-123
 AWS_REGION_DEVO=ap-northeast-1
 AWS_REGION_STAGING=us-east-1
 AWS_REGION_PROD=us-west-2
@@ -79,7 +81,7 @@ CLOUDFLARE_API_TOKEN=test-cloudflare-token
 LTBASE_RELEASES_TOKEN=test-release-token
 EOF
 
-for name in render-bootstrap-policies.sh create-deployment-repo.sh bootstrap-aws-foundation.sh bootstrap-deployment-repo.sh reconcile-managed-dsql-endpoint.sh; do
+for name in render-bootstrap-policies.sh create-deployment-repo.sh bootstrap-aws-foundation.sh bootstrap-oidc-discovery-companion.sh bootstrap-deployment-repo.sh reconcile-managed-dsql-endpoint.sh; do
   cat >"${fake_bin}/${name}" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
@@ -97,6 +99,7 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
   assert_log_contains "${log_file}" "create-deployment-repo.sh --env-file ${temp_dir}/.env"
   assert_log_contains "${log_file}" "render-bootstrap-policies.sh --env-file ${temp_dir}/.env"
   assert_log_contains "${log_file}" "bootstrap-aws-foundation.sh --env-file ${temp_dir}/.env"
+  assert_log_contains "${log_file}" "bootstrap-oidc-discovery-companion.sh --env-file ${temp_dir}/.env"
   assert_log_contains "${log_file}" "bootstrap-deployment-repo.sh --env-file ${temp_dir}/.env --stack devo --infra-dir ${temp_dir}/infra"
   assert_log_contains "${log_file}" "bootstrap-deployment-repo.sh --env-file ${temp_dir}/.env --stack staging --infra-dir ${temp_dir}/infra"
   assert_log_contains "${log_file}" "bootstrap-deployment-repo.sh --env-file ${temp_dir}/.env --stack prod --infra-dir ${temp_dir}/infra"

--- a/test/bootstrap-oidc-discovery-companion-test.sh
+++ b/test/bootstrap-oidc-discovery-companion-test.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/scripts/bootstrap-oidc-discovery-companion.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_log_contains() {
+  local path="$1"
+  local needle="$2"
+  if ! grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+assert_file_contains() {
+  local path="$1"
+  local needle="$2"
+  if [[ ! -f "${path}" ]]; then
+    fail "missing file: ${path}"
+  fi
+  if ! grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+fake_bin="${temp_dir}/bin"
+log_file="${temp_dir}/commands.log"
+mkdir -p "${fake_bin}"
+touch "${log_file}"
+
+cat >"${temp_dir}/.env" <<'EOF'
+STACKS=devo,prod
+PROMOTION_PATH=devo,prod
+TEMPLATE_REPO=Lychee-Technology/ltbase-private-deployment
+GITHUB_OWNER=customer-org
+DEPLOYMENT_REPO_NAME=customer-ltbase
+DEPLOYMENT_REPO_VISIBILITY=private
+DEPLOYMENT_REPO_DESCRIPTION="Customer LTBase deployment repo"
+OIDC_DISCOVERY_DOMAIN=oidc.customer.example.com
+CLOUDFLARE_ACCOUNT_ID=cf-account-123
+AWS_REGION_DEVO=ap-northeast-1
+AWS_REGION_PROD=us-west-2
+AWS_ACCOUNT_ID_DEVO=123456789012
+AWS_ACCOUNT_ID_PROD=210987654321
+AWS_PROFILE_DEVO=devo-profile
+AWS_PROFILE_PROD=prod-profile
+PULUMI_KMS_ALIAS=alias/ltbase-pulumi-secrets
+CLOUDFLARE_API_TOKEN=test-cloudflare-token
+EOF
+
+cat >"${fake_bin}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'gh %s\n' "$*" >>"${COMMAND_LOG}"
+cmd="${1:-}"
+sub="${2:-}"
+if [[ "${cmd} ${sub}" == "repo view" ]]; then
+  exit 1
+fi
+if [[ "${cmd} ${sub}" == "api repos/customer-org/customer-ltbase-oidc-discovery" ]]; then
+  printf '{"default_branch":"main"}'
+  exit 0
+fi
+exit 0
+EOF
+chmod +x "${fake_bin}/gh"
+
+cat >"${fake_bin}/aws" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'aws %s\n' "$*" >>"${COMMAND_LOG}"
+args=("$@")
+if [[ "${args[0]:-}" == "--profile" ]]; then
+  args=("${args[@]:2}")
+fi
+if [[ "${args[0]:-} ${args[1]:-}" == "iam get-role" ]]; then
+  exit 255
+fi
+exit 0
+EOF
+chmod +x "${fake_bin}/aws"
+
+cat >"${fake_bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'curl %s\n' "$*" >>"${COMMAND_LOG}"
+method="GET"
+url=""
+args=("$@")
+index=0
+while [[ ${index} -lt ${#args[@]} ]]; do
+  case "${args[${index}]}" in
+    -X)
+      method="${args[$((index + 1))]}"
+      index=$((index + 2))
+      ;;
+    http*)
+      url="${args[${index}]}"
+      index=$((index + 1))
+      ;;
+    *)
+      index=$((index + 1))
+      ;;
+  esac
+done
+
+if [[ "${method}" == "GET" && "${url}" == *"/pages/projects/customer-ltbase-oidc-discovery" ]]; then
+  exit 22
+fi
+if [[ "${method}" == "GET" && "${url}" == *"/pages/projects/customer-ltbase-oidc-discovery/domains/oidc.customer.example.com" ]]; then
+  exit 22
+fi
+
+printf '{"success":true}'
+EOF
+chmod +x "${fake_bin}/curl"
+
+if [[ ! -x "${SCRIPT_PATH}" ]]; then
+  fail "missing executable script: ${SCRIPT_PATH}"
+fi
+
+if ! output="$(PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --output-dir "${temp_dir}/dist" 2>&1)"; then
+  fail "expected script to succeed, got: ${output}"
+fi
+
+assert_log_contains "${log_file}" "gh repo create customer-org/customer-ltbase-oidc-discovery --template Lychee-Technology/ltbase-oidc-discovery-template --private --description LTBase OIDC discovery companion for customer-ltbase --clone=false"
+assert_log_contains "${log_file}" "https://api.cloudflare.com/client/v4/accounts/cf-account-123/pages/projects"
+assert_log_contains "${log_file}" "https://api.cloudflare.com/client/v4/accounts/cf-account-123/pages/projects/customer-ltbase-oidc-discovery/domains"
+assert_log_contains "${log_file}" "gh variable set OIDC_DISCOVERY_DOMAIN --repo customer-org/customer-ltbase-oidc-discovery --body oidc.customer.example.com"
+assert_log_contains "${log_file}" "gh variable set OIDC_DISCOVERY_STACK_CONFIG --repo customer-org/customer-ltbase-oidc-discovery --body {\"devo\":{\"aws_region\":\"ap-northeast-1\",\"aws_role_arn\":\"arn:aws:iam::123456789012:role/customer-ltbase-oidc-discovery-devo\"},\"prod\":{\"aws_region\":\"us-west-2\",\"aws_role_arn\":\"arn:aws:iam::210987654321:role/customer-ltbase-oidc-discovery-prod\"}}"
+assert_log_contains "${log_file}" "aws --profile devo-profile iam create-role --role-name customer-ltbase-oidc-discovery-devo"
+assert_log_contains "${log_file}" "aws --profile prod-profile iam create-role --role-name customer-ltbase-oidc-discovery-prod"
+assert_log_contains "${log_file}" "aws --profile devo-profile iam put-role-policy --role-name customer-ltbase-oidc-discovery-devo --policy-name LTBaseOIDCDiscoveryAccess"
+assert_log_contains "${log_file}" "aws --profile prod-profile iam put-role-policy --role-name customer-ltbase-oidc-discovery-prod --policy-name LTBaseOIDCDiscoveryAccess"
+
+assert_file_contains "${temp_dir}/dist/oidc-discovery-companion.env" "OIDC_DISCOVERY_REPO=customer-org/customer-ltbase-oidc-discovery"
+assert_file_contains "${temp_dir}/dist/oidc-discovery-companion.env" "OIDC_DISCOVERY_PAGES_PROJECT=customer-ltbase-oidc-discovery"
+assert_file_contains "${temp_dir}/dist/oidc-discovery-companion.env" "OIDC_ISSUER_URL_DEVO=https://oidc.customer.example.com/devo"
+assert_file_contains "${temp_dir}/dist/oidc-discovery-companion.env" "JWKS_URL_PROD=https://oidc.customer.example.com/prod/.well-known/jwks.json"
+
+printf 'PASS: bootstrap-oidc-discovery-companion tests\n'

--- a/test/evaluate-and-continue-test.sh
+++ b/test/evaluate-and-continue-test.sh
@@ -71,6 +71,8 @@ OIDC_ISSUER_URL_PROD=https://issuer.example.com/prod
 JWKS_URL_DEVO=https://issuer.example.com/devo/jwks.json
 JWKS_URL_STAGING=https://issuer.example.com/staging/jwks.json
 JWKS_URL_PROD=https://issuer.example.com/prod/jwks.json
+OIDC_DISCOVERY_DOMAIN=oidc.customer.example.com
+CLOUDFLARE_ACCOUNT_ID=cf-account-123
 GEMINI_MODEL=gemini-3-flash-preview
 DSQL_PORT=5432
 DSQL_DB=postgres
@@ -98,9 +100,20 @@ if [[ "${cmd} ${sub}" == "repo view" ]]; then
   if [[ "${SCENARIO}" == "repo_config_missing" || "${SCENARIO}" == "bootstrap_force" ]]; then
     exit 1
   fi
+  if [[ "${3:-}" == "customer-org/customer-ltbase-oidc-discovery" && "${SCENARIO}" == "oidc_companion_missing" ]]; then
+    exit 1
+  fi
   exit 0
 fi
 if [[ "${cmd} ${sub}" == "variable list" ]]; then
+  if [[ "${4:-}" == "customer-org/customer-ltbase-oidc-discovery" ]]; then
+    if [[ "${SCENARIO}" == "oidc_companion_missing" ]]; then
+      printf '[]'
+    else
+      printf '[{"name":"OIDC_DISCOVERY_DOMAIN"},{"name":"OIDC_DISCOVERY_STACK_CONFIG"}]'
+    fi
+    exit 0
+  fi
   if [[ "${SCENARIO}" == "repo_config_missing" ]]; then
     printf '[]'
   else
@@ -109,6 +122,10 @@ if [[ "${cmd} ${sub}" == "variable list" ]]; then
   exit 0
 fi
 if [[ "${cmd} ${sub}" == "secret list" ]]; then
+  if [[ "${4:-}" == "customer-org/customer-ltbase-oidc-discovery" ]]; then
+    printf '[]'
+    exit 0
+  fi
   if [[ "${SCENARIO}" == "repo_config_missing" ]]; then
     printf '[]'
   else
@@ -120,7 +137,7 @@ exit 0
 EOF
   chmod +x "${fake_bin}/gh"
 
-  cat >"${fake_bin}/aws" <<'EOF'
+cat >"${fake_bin}/aws" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'aws %s\n' "$*" >>"${COMMAND_LOG}"
@@ -150,6 +167,12 @@ case "${SCENARIO}:${command_key}" in
     printf '{"Aliases":[]}'
     exit 0
     ;;
+  oidc_companion_missing:iam\ get-role)
+    if printf '%s\n' "$*" | grep -Fq 'oidc-discovery'; then
+      exit 255
+    fi
+    exit 0
+    ;;
   bootstrap_force:kms\ create-key)
     printf 'key-123\n'
     exit 0
@@ -162,6 +185,39 @@ esac
 exit 0
 EOF
   chmod +x "${fake_bin}/aws"
+
+  cat >"${fake_bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'curl %s\n' "$*" >>"${COMMAND_LOG}"
+method="GET"
+url=""
+args=("$@")
+index=0
+while [[ ${index} -lt ${#args[@]} ]]; do
+  case "${args[${index}]}" in
+    -X)
+      method="${args[$((index + 1))]}"
+      index=$((index + 2))
+      ;;
+    http*)
+      url="${args[${index}]}"
+      index=$((index + 1))
+      ;;
+    *)
+      index=$((index + 1))
+      ;;
+  esac
+done
+if [[ "${SCENARIO}" == "oidc_companion_missing" && "${method}" == "GET" && "${url}" == *"/pages/projects/customer-ltbase-oidc-discovery" ]]; then
+  exit 22
+fi
+if [[ "${SCENARIO}" == "oidc_companion_missing" && "${method}" == "GET" && "${url}" == *"/pages/projects/customer-ltbase-oidc-discovery/domains/oidc.customer.example.com" ]]; then
+  exit 22
+fi
+printf '{"success":true}'
+EOF
+  chmod +x "${fake_bin}/curl"
 
   cat >"${fake_bin}/pulumi" <<'EOF'
 #!/usr/bin/env bash
@@ -301,6 +357,15 @@ assert_file_contains "${temp_dir}/report-rollout/report.json" '"status": "needs_
 assert_file_contains "${temp_dir}/report-rollout/report.json" '"stack": "prod"'
 assert_file_contains "${temp_dir}/report-rollout/report.json" '"status": "complete"'
 
+run_expect_exit_code 2 env \
+  PATH="${temp_dir}/bin:$PATH" \
+  COMMAND_LOG="${temp_dir}/commands.log" \
+  SCENARIO="oidc_companion_missing" \
+  "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-oidc"
+
+assert_file_contains "${temp_dir}/report-oidc/report.json" '"oidcDiscovery"'
+assert_file_contains "${temp_dir}/report-oidc/report.json" '"status": "needs_oidc_companion"'
+
 rm -rf "${temp_dir}/infra"
 mkdir -p "${temp_dir}/infra"
 run_expect_exit_code 0 env \
@@ -312,6 +377,8 @@ run_expect_exit_code 0 env \
 assert_log_contains "${temp_dir}/commands.log" "gh repo create customer-org/customer-ltbase"
 assert_log_contains "${temp_dir}/commands.log" "aws --profile devo-profile iam create-open-id-connect-provider"
 assert_log_contains "${temp_dir}/commands.log" "aws --profile prod-profile iam create-open-id-connect-provider"
+assert_log_contains "${temp_dir}/commands.log" "gh repo create customer-org/customer-ltbase-oidc-discovery"
+assert_log_contains "${temp_dir}/commands.log" "https://api.cloudflare.com/client/v4/accounts/cf-account-123/pages/projects"
 assert_log_contains "${temp_dir}/commands.log" "pulumi stack init devo --secrets-provider awskms://alias/test-pulumi-secrets?region=ap-northeast-1"
 assert_log_contains "${temp_dir}/commands.log" "pulumi stack init staging --secrets-provider awskms://alias/test-pulumi-secrets?region=us-east-1"
 assert_log_contains "${temp_dir}/commands.log" "pulumi stack init prod --secrets-provider awskms://alias/test-pulumi-secrets?region=us-west-2"


### PR DESCRIPTION
Refs #15
Refs #16
Depends on #17

## Summary
- add `bootstrap-oidc-discovery-companion.sh` to create the customer `*-oidc-discovery` repo, Cloudflare Pages project/custom domain, and per-stack discovery roles
- extend bootstrap env derivation and `evaluate-and-continue.sh` to detect and reconcile companion repo, Pages, and discovery-role gaps
- update the bootstrap entrypoints, env template, and shell coverage for the companion bootstrap flow

## Testing
- bash test/bootstrap-all-test.sh
- bash test/bootstrap-aws-foundation-test.sh
- bash test/bootstrap-pulumi-backend-test.sh
- bash test/bootstrap-deployment-repo-test.sh
- bash test/create-deployment-repo-test.sh
- bash test/render-bootstrap-policies-test.sh
- bash test/reconcile-managed-dsql-endpoint-test.sh
- bash test/evaluate-and-continue-test.sh
- bash test/bootstrap-oidc-discovery-companion-test.sh