### PR TITLE
[codex] persist rollout topology repo vars

### DIFF
--- a/docs/superpowers/plans/2026-03-31-issue-22-stack-vars.md
+++ b/docs/superpowers/plans/2026-03-31-issue-22-stack-vars.md
@@ -1,0 +1,105 @@
+# Persist STACKS And PROMOTION_PATH Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist `STACKS`, `PROMOTION_PATH`, and the derived preview default into customer deployment repo variables so rollout workflows never fall back to `devo,prod` after bootstrap.
+
+**Architecture:** Extend the deployment-repo bootstrap script to write the rollout topology variables, then tighten `evaluate-and-continue` repo-config validation to require them. Lock the behavior with shell tests that fail when those vars are missing and pass once bootstrap writes them.
+
+**Tech Stack:** Bash, GitHub CLI, shell tests
+
+---
+
+### Task 1: Add regression coverage for missing rollout topology vars
+
+**Files:**
+- Modify: `test/bootstrap-deployment-repo-test.sh`
+- Modify: `test/evaluate-and-continue-test.sh`
+
+- [ ] **Step 1: Write the failing bootstrap regression**
+
+Add assertions to `test/bootstrap-deployment-repo-test.sh` that require:
+
+```bash
+assert_log_contains "${log_file}" "gh variable set STACKS --repo customer-org/customer-ltbase --body devo,staging,prod"
+assert_log_contains "${log_file}" "gh variable set PROMOTION_PATH --repo customer-org/customer-ltbase --body devo,staging,prod"
+assert_log_contains "${log_file}" "gh variable set PREVIEW_DEFAULT_STACK --repo customer-org/customer-ltbase --body devo"
+```
+
+- [ ] **Step 2: Run the bootstrap test to verify it fails**
+
+Run: `bash test/bootstrap-deployment-repo-test.sh`
+Expected: FAIL because the script does not write those repo variables yet.
+
+- [ ] **Step 3: Write the failing recovery regression**
+
+Adjust `test/evaluate-and-continue-test.sh` so the fake `gh variable list` output for the healthy repo case includes `STACKS`, `PROMOTION_PATH`, and `PREVIEW_DEFAULT_STACK`, then add a `repo_config_missing` expectation that missing topology vars still yields `"status": "needs_repo_config"`.
+
+- [ ] **Step 4: Run the recovery test to verify it still fails for the right reason**
+
+Run: `bash test/evaluate-and-continue-test.sh`
+Expected: FAIL because `repo_config_present()` does not require the rollout topology vars yet.
+
+### Task 2: Persist rollout topology vars during bootstrap
+
+**Files:**
+- Modify: `scripts/bootstrap-deployment-repo.sh`
+
+- [ ] **Step 1: Write the minimal implementation**
+
+In `scripts/bootstrap-deployment-repo.sh`, add:
+
+```bash
+gh variable set STACKS --repo "${DEPLOYMENT_REPO}" --body "${STACKS}"
+gh variable set PROMOTION_PATH --repo "${DEPLOYMENT_REPO}" --body "${PROMOTION_PATH}"
+gh variable set PREVIEW_DEFAULT_STACK --repo "${DEPLOYMENT_REPO}" --body "${PREVIEW_DEFAULT_STACK}"
+```
+
+Place them with the other shared repo variables before secrets are written.
+
+- [ ] **Step 2: Run the focused bootstrap test**
+
+Run: `bash test/bootstrap-deployment-repo-test.sh`
+Expected: PASS
+
+### Task 3: Require the new vars in recovery checks
+
+**Files:**
+- Modify: `scripts/evaluate-and-continue.sh`
+
+- [ ] **Step 1: Tighten repo config validation**
+
+Update the required repo variables list in `repo_config_present()` to include:
+
+```bash
+for required_var in PULUMI_BACKEND_URL LTBASE_RELEASES_REPO LTBASE_RELEASE_ID STACKS PROMOTION_PATH PREVIEW_DEFAULT_STACK; do
+```
+
+- [ ] **Step 2: Run the focused recovery test**
+
+Run: `bash test/evaluate-and-continue-test.sh`
+Expected: PASS
+
+### Task 4: Run regression suite and commit
+
+**Files:**
+- Modify: none
+
+- [ ] **Step 1: Run the regression commands**
+
+Run:
+
+```bash
+bash test/bootstrap-deployment-repo-test.sh
+bash test/evaluate-and-continue-test.sh
+bash test/rollout-workflows-test.sh
+```
+
+Expected: all PASS
+
+- [ ] **Step 2: Commit the fix**
+
+```bash
+git add scripts/bootstrap-deployment-repo.sh scripts/evaluate-and-continue.sh test/bootstrap-deployment-repo-test.sh test/evaluate-and-continue-test.sh docs/superpowers/plans/2026-03-31-issue-22-stack-vars.md
+git commit -m "[codex] persist rollout topology repo vars"
+```

--- a/scripts/bootstrap-deployment-repo.sh
+++ b/scripts/bootstrap-deployment-repo.sh
@@ -68,6 +68,9 @@ done < <(bootstrap_env_each_stack)
 gh variable set PULUMI_BACKEND_URL --repo "${DEPLOYMENT_REPO}" --body "${PULUMI_BACKEND_URL}"
 gh variable set LTBASE_RELEASES_REPO --repo "${DEPLOYMENT_REPO}" --body "${LTBASE_RELEASES_REPO}"
 gh variable set LTBASE_RELEASE_ID --repo "${DEPLOYMENT_REPO}" --body "${LTBASE_RELEASE_ID}"
+gh variable set STACKS --repo "${DEPLOYMENT_REPO}" --body "${STACKS}"
+gh variable set PROMOTION_PATH --repo "${DEPLOYMENT_REPO}" --body "${PROMOTION_PATH}"
+gh variable set PREVIEW_DEFAULT_STACK --repo "${DEPLOYMENT_REPO}" --body "${PREVIEW_DEFAULT_STACK}"
 
 gh secret set LTBASE_RELEASES_TOKEN --repo "${DEPLOYMENT_REPO}" --body "${LTBASE_RELEASES_TOKEN}"
 gh secret set CLOUDFLARE_API_TOKEN --repo "${DEPLOYMENT_REPO}" --body "${CLOUDFLARE_API_TOKEN}"

--- a/scripts/evaluate-and-continue.sh
+++ b/scripts/evaluate-and-continue.sh
@@ -85,7 +85,7 @@ run_logged() {
 json_name_list_contains() {
   local json_input="$1"
   local needle="$2"
-  python3 - "${needle}" <<'PY' <<<"${json_input}"
+  printf '%s' "${json_input}" | python3 -c '
 import json
 import sys
 
@@ -96,7 +96,7 @@ if not raw:
 
 names = {item.get("name", "") for item in json.loads(raw)}
 sys.exit(0 if needle in names else 1)
-PY
+' "${needle}"
 }
 
 foundation_present_for_stack() {
@@ -152,7 +152,7 @@ repo_config_present() {
   variable_json="$(gh variable list --repo "${DEPLOYMENT_REPO}" --json name)"
   secret_json="$(gh secret list --repo "${DEPLOYMENT_REPO}" --json name)"
 
-  for required_var in PULUMI_BACKEND_URL LTBASE_RELEASES_REPO LTBASE_RELEASE_ID; do
+  for required_var in PULUMI_BACKEND_URL LTBASE_RELEASES_REPO LTBASE_RELEASE_ID STACKS PROMOTION_PATH PREVIEW_DEFAULT_STACK; do
     if ! json_name_list_contains "${variable_json}" "${required_var}"; then
       return 1
     fi

--- a/test/bootstrap-deployment-repo-test.sh
+++ b/test/bootstrap-deployment-repo-test.sh
@@ -33,14 +33,18 @@ mkdir -p "${fake_bin}" "${temp_dir}/infra"
 touch "${log_file}"
 
 cat >"${temp_dir}/.env" <<'EOF'
-STACKS=devo,prod
+STACKS=devo,staging,prod
+PROMOTION_PATH=devo,staging,prod
 GITHUB_OWNER=Lychee-Technology
 DEPLOYMENT_REPO_NAME=ltbase-private-deployment
 AWS_REGION_DEVO=ap-northeast-1
+AWS_REGION_STAGING=us-east-1
 AWS_REGION_PROD=us-west-2
 AWS_ACCOUNT_ID_DEVO=123456789012
+AWS_ACCOUNT_ID_STAGING=123456789012
 AWS_ACCOUNT_ID_PROD=123456789012
 AWS_ROLE_NAME_DEVO=test-deploy-role
+AWS_ROLE_NAME_STAGING=test-staging-role
 AWS_ROLE_NAME_PROD=test-prod-role
 PULUMI_STATE_BUCKET=test-pulumi-state
 PULUMI_KMS_ALIAS=alias/test-pulumi-secrets
@@ -50,15 +54,20 @@ LTBASE_RELEASES_TOKEN=test-release-token
 CLOUDFLARE_API_TOKEN=test-cloudflare-token
 GEMINI_API_KEY=test-gemini-key
 API_DOMAIN_DEVO=api.devo.example.com
+API_DOMAIN_STAGING=api.staging.example.com
 API_DOMAIN_PROD=api.example.com
 CONTROL_DOMAIN_DEVO=control.devo.example.com
+CONTROL_DOMAIN_STAGING=control.staging.example.com
 CONTROL_DOMAIN_PROD=control.example.com
 AUTH_DOMAIN_DEVO=auth.devo.example.com
+AUTH_DOMAIN_STAGING=auth.staging.example.com
 AUTH_DOMAIN_PROD=auth.example.com
 CLOUDFLARE_ZONE_ID=zone-123
 OIDC_ISSUER_URL_DEVO=https://issuer.example.com/devo
+OIDC_ISSUER_URL_STAGING=https://issuer.example.com/staging
 OIDC_ISSUER_URL_PROD=https://issuer.example.com/prod
 JWKS_URL_DEVO=https://issuer.example.com/devo/jwks.json
+JWKS_URL_STAGING=https://issuer.example.com/staging/jwks.json
 JWKS_URL_PROD=https://issuer.example.com/prod/jwks.json
 GEMINI_MODEL=gemini-3-flash-preview
 DSQL_PORT=5432
@@ -92,8 +101,13 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
   fi
 
   assert_log_contains "${log_file}" "gh variable set AWS_REGION_DEVO --repo Lychee-Technology/ltbase-private-deployment --body ap-northeast-1"
+  assert_log_contains "${log_file}" "gh variable set AWS_REGION_STAGING --repo Lychee-Technology/ltbase-private-deployment --body us-east-1"
   assert_log_contains "${log_file}" "gh variable set AWS_REGION_PROD --repo Lychee-Technology/ltbase-private-deployment --body us-west-2"
+  assert_log_contains "${log_file}" "gh variable set STACKS --repo Lychee-Technology/ltbase-private-deployment --body devo,staging,prod"
+  assert_log_contains "${log_file}" "gh variable set PROMOTION_PATH --repo Lychee-Technology/ltbase-private-deployment --body devo,staging,prod"
+  assert_log_contains "${log_file}" "gh variable set PREVIEW_DEFAULT_STACK --repo Lychee-Technology/ltbase-private-deployment --body devo"
   assert_log_contains "${log_file}" "gh secret set AWS_ROLE_ARN_DEVO --repo Lychee-Technology/ltbase-private-deployment --body arn:aws:iam::123456789012:role/test-deploy-role"
+  assert_log_contains "${log_file}" "gh secret set AWS_ROLE_ARN_STAGING --repo Lychee-Technology/ltbase-private-deployment --body arn:aws:iam::123456789012:role/test-staging-role"
   assert_log_contains "${log_file}" "gh secret set AWS_ROLE_ARN_PROD --repo Lychee-Technology/ltbase-private-deployment --body arn:aws:iam::123456789012:role/test-prod-role"
   assert_log_contains "${log_file}" "pulumi stack init prod --secrets-provider awskms://alias/test-pulumi-secrets?region=us-west-2"
   assert_log_contains "${log_file}" "pulumi config set runtimeBucket ltbase-private-deployment-runtime-prod --stack prod"

--- a/test/evaluate-and-continue-test.sh
+++ b/test/evaluate-and-continue-test.sh
@@ -116,8 +116,10 @@ if [[ "${cmd} ${sub}" == "variable list" ]]; then
   fi
   if [[ "${SCENARIO}" == "repo_config_missing" ]]; then
     printf '[]'
-  else
+  elif [[ "${SCENARIO}" == "repo_topology_missing" ]]; then
     printf '[{"name":"AWS_REGION_DEVO"},{"name":"AWS_REGION_STAGING"},{"name":"AWS_REGION_PROD"},{"name":"PULUMI_BACKEND_URL"},{"name":"PULUMI_SECRETS_PROVIDER_DEVO"},{"name":"PULUMI_SECRETS_PROVIDER_STAGING"},{"name":"PULUMI_SECRETS_PROVIDER_PROD"},{"name":"LTBASE_RELEASES_REPO"},{"name":"LTBASE_RELEASE_ID"}]'
+  else
+    printf '[{"name":"AWS_REGION_DEVO"},{"name":"AWS_REGION_STAGING"},{"name":"AWS_REGION_PROD"},{"name":"PULUMI_BACKEND_URL"},{"name":"PULUMI_SECRETS_PROVIDER_DEVO"},{"name":"PULUMI_SECRETS_PROVIDER_STAGING"},{"name":"PULUMI_SECRETS_PROVIDER_PROD"},{"name":"LTBASE_RELEASES_REPO"},{"name":"LTBASE_RELEASE_ID"},{"name":"STACKS"},{"name":"PROMOTION_PATH"},{"name":"PREVIEW_DEFAULT_STACK"}]'
   fi
   exit 0
 fi
@@ -327,6 +329,14 @@ run_expect_exit_code 2 env \
   "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-repo"
 
 assert_file_contains "${temp_dir}/report-repo/report.json" '"status": "needs_repo_config"'
+
+run_expect_exit_code 2 env \
+  PATH="${temp_dir}/bin:$PATH" \
+  COMMAND_LOG="${temp_dir}/commands.log" \
+  SCENARIO="repo_topology_missing" \
+  "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-topology-missing"
+
+assert_file_contains "${temp_dir}/report-topology-missing/report.json" '"status": "needs_repo_config"'
 
 rm -f "${temp_dir}/infra/Pulumi.devo.yaml" "${temp_dir}/infra/Pulumi.staging.yaml" "${temp_dir}/infra/Pulumi.prod.yaml"
 run_expect_exit_code 2 env \


### PR DESCRIPTION
Closes #22
Refs #16

## Summary
- persist `STACKS`, `PROMOTION_PATH`, and `PREVIEW_DEFAULT_STACK` into the customer deployment repo during bootstrap
- require those rollout topology vars during evaluate-and-continue repo config checks
- fix the repo-var presence helper so missing rollout vars are actually detected, and lock the behavior with regression tests

## Testing
- bash test/bootstrap-deployment-repo-test.sh
- bash test/evaluate-and-continue-test.sh
- bash test/rollout-workflows-test.sh
- bash test/bootstrap-all-test.sh