### PR TITLE
fix: resume rollout from detected state and repair promotion environments

### DIFF
--- a/scripts/evaluate-and-continue.sh
+++ b/scripts/evaluate-and-continue.sh
@@ -142,6 +142,20 @@ oidc_companion_repo_exists() {
   gh repo view "${OIDC_DISCOVERY_REPO}" >/dev/null 2>&1
 }
 
+promotion_environments_present() {
+  local promotion_index=0
+  local stack
+  while IFS= read -r stack; do
+    if [[ "${promotion_index}" -gt 0 ]]; then
+      if ! gh api "repos/${DEPLOYMENT_REPO}/environments/${stack}" >/dev/null 2>&1; then
+        return 1
+      fi
+    fi
+    promotion_index=$((promotion_index + 1))
+  done < <(bootstrap_env_each_stack "${PROMOTION_PATH}")
+  return 0
+}
+
 repo_config_present() {
   local variable_json secret_json stack upper_name
 
@@ -176,6 +190,10 @@ repo_config_present() {
       return 1
     fi
   done < <(bootstrap_env_each_stack)
+
+  if ! promotion_environments_present; then
+    return 1
+  fi
 
   return 0
 }
@@ -435,6 +453,9 @@ run_force_actions() {
   local needs_foundation="false"
   local needs_repo="false"
   local needs_oidc_companion="false"
+  local has_dsql_reconcile="false"
+  local has_needs_rollout="false"
+  local first_needs_rollout_stack=""
   local stack status
 
   while IFS=$'\t' read -r stack status; do
@@ -445,6 +466,15 @@ run_force_actions() {
         ;;
       needs_repo_config|needs_stack_bootstrap)
         needs_repo="true"
+        ;;
+      needs_dsql_reconcile)
+        has_dsql_reconcile="true"
+        ;;
+      needs_rollout)
+        has_needs_rollout="true"
+        if [[ -z "${first_needs_rollout_stack}" ]]; then
+          first_needs_rollout_stack="${stack}"
+        fi
         ;;
     esac
   done <"${state_file}"
@@ -475,11 +505,39 @@ run_force_actions() {
     done <"${state_file}"
   fi
 
+  # Bug #21: repair missing promotion environments
+  if repo_exists && ! promotion_environments_present; then
+    local promotion_index=0
+    while IFS= read -r stack; do
+      if [[ "${promotion_index}" -gt 0 ]]; then
+        if ! gh api "repos/${DEPLOYMENT_REPO}/environments/${stack}" >/dev/null 2>&1; then
+          run_logged gh api "repos/${DEPLOYMENT_REPO}/environments/${stack}" --method PUT
+        fi
+      fi
+      promotion_index=$((promotion_index + 1))
+    done < <(bootstrap_env_each_stack "${PROMOTION_PATH}")
+  fi
+
   if [[ "${needs_oidc_companion}" == "true" && "${SCOPE}" != "foundation" ]]; then
     run_logged "${script_dir}/bootstrap-oidc-discovery-companion.sh" --env-file "${ENV_FILE}"
   fi
 
-  if [[ -n "${RELEASE_ID}" && "${SCOPE}" != "foundation" ]]; then
+  # Bug #20: reconcile DSQL endpoints for stacks that have a cluster but no endpoint set
+  if [[ "${has_dsql_reconcile}" == "true" && "${SCOPE}" != "foundation" ]]; then
+    while IFS=$'\t' read -r stack status; do
+      if [[ "${status}" == "needs_dsql_reconcile" ]]; then
+        run_logged "${script_dir}/reconcile-managed-dsql-endpoint.sh" --env-file "${ENV_FILE}" --stack "${stack}" --infra-dir "${INFRA_DIR}"
+      fi
+    done <"${state_file}"
+  fi
+
+  # Bug #20: resume rollout from the first incomplete stack instead of starting over
+  if [[ "${has_needs_rollout}" == "true" && -n "${RELEASE_ID}" && "${SCOPE}" != "foundation" ]]; then
+    run_logged gh workflow run rollout-hop.yml --repo "${DEPLOYMENT_REPO}" \
+      -f release_id="${RELEASE_ID}" \
+      -f target_stack="${first_needs_rollout_stack}" \
+      -f continue_chain=true
+  elif [[ -n "${RELEASE_ID}" && "${SCOPE}" != "foundation" ]]; then
     run_logged gh workflow run rollout.yml --repo "${DEPLOYMENT_REPO}" -f release_id="${RELEASE_ID}"
   fi
 }

--- a/test/evaluate-and-continue-test.sh
+++ b/test/evaluate-and-continue-test.sh
@@ -53,6 +53,7 @@ AWS_ROLE_NAME_STAGING=ltbase-deploy-staging
 AWS_ROLE_NAME_PROD=ltbase-deploy-prod
 PULUMI_STATE_BUCKET=test-pulumi-state
 PULUMI_KMS_ALIAS=alias/test-pulumi-secrets
+PULUMI_BACKEND_URL=s3://test-pulumi-state
 LTBASE_RELEASES_REPO=Lychee-Technology/ltbase-releases
 LTBASE_RELEASE_ID=v1.0.0
 API_DOMAIN_DEVO=api.devo.example.com
@@ -105,6 +106,37 @@ if [[ "${cmd} ${sub}" == "repo view" ]]; then
   fi
   exit 0
 fi
+if [[ "${cmd}" == "api" ]]; then
+  url="${2:-}"
+  method="GET"
+  for arg in "$@"; do
+    if [[ "${arg}" == "--method" ]]; then
+      shift_next="true"
+    elif [[ "${shift_next:-}" == "true" ]]; then
+      method="${arg}"
+      shift_next=""
+    fi
+  done
+  # Check for method in positional args
+  local_args=("$@")
+  for i in "${!local_args[@]}"; do
+    if [[ "${local_args[$i]}" == "--method" && -n "${local_args[$((i + 1))]:-}" ]]; then
+      method="${local_args[$((i + 1))]}"
+    fi
+  done
+  # Environment check/create
+  if [[ "${url}" == *"/environments/"* ]]; then
+    if [[ "${SCENARIO}" == "envs_missing" && "${method}" == "GET" ]]; then
+      exit 1
+    fi
+    if [[ "${method}" == "PUT" ]]; then
+      printf '{"name":"env-created"}\n'
+      exit 0
+    fi
+    exit 0
+  fi
+  exit 0
+fi
 if [[ "${cmd} ${sub}" == "variable list" ]]; then
   if [[ "${4:-}" == "customer-org/customer-ltbase-oidc-discovery" ]]; then
     if [[ "${SCENARIO}" == "oidc_companion_missing" ]]; then
@@ -133,6 +165,9 @@ if [[ "${cmd} ${sub}" == "secret list" ]]; then
   else
     printf '[{"name":"AWS_ROLE_ARN_DEVO"},{"name":"AWS_ROLE_ARN_STAGING"},{"name":"AWS_ROLE_ARN_PROD"},{"name":"LTBASE_RELEASES_TOKEN"},{"name":"CLOUDFLARE_API_TOKEN"}]'
   fi
+  exit 0
+fi
+if [[ "${cmd} ${sub}" == "workflow run" ]]; then
   exit 0
 fi
 exit 0
@@ -181,6 +216,10 @@ case "${SCENARIO}:${command_key}" in
     ;;
   *:kms\ list-aliases)
     printf '{"Aliases":[{"AliasName":"alias/test-pulumi-secrets","TargetKeyId":"key-123"}]}'
+    exit 0
+    ;;
+  *:dsql\ get-cluster)
+    printf 'managed.%s.endpoint.example.com\n' "${STACK_HINT:-devo}"
     exit 0
     ;;
 esac
@@ -275,6 +314,9 @@ if [[ "${1:-} ${2:-} ${3:-} ${4:-}" == "config get dsqlEndpoint --stack" ]]; the
       ;;
   esac
   exit 1
+fi
+if [[ "${1:-} ${2:-}" == "config set" || "${1:-} ${2:-}" == "config rm" ]]; then
+  exit 0
 fi
 exit 0
 EOF
@@ -393,5 +435,51 @@ assert_log_contains "${temp_dir}/commands.log" "pulumi stack init devo --secrets
 assert_log_contains "${temp_dir}/commands.log" "pulumi stack init staging --secrets-provider awskms://alias/test-pulumi-secrets?region=us-east-1"
 assert_log_contains "${temp_dir}/commands.log" "pulumi stack init prod --secrets-provider awskms://alias/test-pulumi-secrets?region=us-west-2"
 assert_log_contains "${temp_dir}/commands.log" "gh workflow run rollout.yml --repo customer-org/customer-ltbase -f release_id=v9.9.9"
+
+# Bug #20: force mode with rollout_mix should reconcile DSQL and resume rollout via rollout-hop
+for stack in devo staging prod; do
+  cat >"${temp_dir}/infra/Pulumi.${stack}.yaml" <<EOF
+config:
+  ltbase-infra:awsRegion: test
+EOF
+done
+
+: >"${temp_dir}/commands.log"
+run_expect_exit_code 0 env \
+  PATH="${temp_dir}/bin:$PATH" \
+  COMMAND_LOG="${temp_dir}/commands.log" \
+  SCENARIO="rollout_mix" \
+  "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-force-rollout" --force --release-id v2.0.0
+
+# Should call reconcile for staging (needs_dsql_reconcile)
+assert_log_contains "${temp_dir}/report-force-rollout/actions.log" "reconcile-managed-dsql-endpoint.sh --env-file ${temp_dir}/.env --stack staging --infra-dir ${temp_dir}/infra"
+# Should dispatch rollout-hop.yml for devo (first needs_rollout stack), NOT rollout.yml
+assert_log_contains "${temp_dir}/report-force-rollout/actions.log" "gh workflow run rollout-hop.yml --repo customer-org/customer-ltbase -f release_id=v2.0.0 -f target_stack=devo -f continue_chain=true"
+# Should NOT dispatch rollout.yml
+if grep -Fq "gh workflow run rollout.yml" "${temp_dir}/report-force-rollout/actions.log"; then
+  fail "force mode with needs_rollout should dispatch rollout-hop.yml, not rollout.yml"
+fi
+
+# Bug #21: force mode should repair missing promotion environments
+: >"${temp_dir}/commands.log"
+run_expect_exit_code 0 env \
+  PATH="${temp_dir}/bin:$PATH" \
+  COMMAND_LOG="${temp_dir}/commands.log" \
+  SCENARIO="envs_missing" \
+  "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-force-envs" --force --release-id v3.0.0
+
+# Should create missing promotion environments (staging and prod, not devo which is first)
+assert_log_contains "${temp_dir}/report-force-envs/actions.log" "gh api repos/customer-org/customer-ltbase/environments/staging --method PUT"
+assert_log_contains "${temp_dir}/report-force-envs/actions.log" "gh api repos/customer-org/customer-ltbase/environments/prod --method PUT"
+
+# Bug #21: envs_missing should be detected as non-complete by repo_config_present
+: >"${temp_dir}/commands.log"
+run_expect_exit_code 2 env \
+  PATH="${temp_dir}/bin:$PATH" \
+  COMMAND_LOG="${temp_dir}/commands.log" \
+  SCENARIO="envs_missing" \
+  "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-envs-detect"
+
+assert_file_contains "${temp_dir}/report-envs-detect/report.json" '"status": "needs_repo_config"'
 
 printf 'PASS: evaluate-and-continue tests\n'


### PR DESCRIPTION
## Summary

- **Fixes #20**: `run_force_actions()` now handles `needs_rollout` status by dispatching `rollout-hop.yml` to the first incomplete stack with `continue_chain=true` (instead of unconditionally dispatching `rollout.yml` which always starts from the first promotion hop). Also handles `needs_dsql_reconcile` by calling `reconcile-managed-dsql-endpoint.sh` for each affected stack.
- **Fixes #21**: `repo_config_present()` now verifies that GitHub promotion environments exist via `gh api`. `run_force_actions()` repairs any missing promotion environments (creating them with `PUT`) before dispatching workflows.

## Changes

### `scripts/evaluate-and-continue.sh`
- Add `promotion_environments_present()` function that checks each non-first promotion path stack has a GitHub environment
- Call `promotion_environments_present()` from `repo_config_present()` so missing envs are detected as `needs_repo_config`
- Add `needs_dsql_reconcile` and `needs_rollout` tracking in `run_force_actions()`
- Add environment repair logic: create missing promotion environments before workflow dispatch
- Add DSQL reconcile: call `reconcile-managed-dsql-endpoint.sh` for each `needs_dsql_reconcile` stack
- Add rollout resume: dispatch `rollout-hop.yml` with `target_stack` set to first `needs_rollout` stack and `continue_chain=true`
- Fall back to `rollout.yml` only when no stacks are in `needs_rollout` state

### `test/evaluate-and-continue-test.sh`
- Add `gh api` handling to fake `gh` for environment GET/PUT operations
- Add `workflow run` handling to fake `gh`
- Add `dsql get-cluster` handling to fake `aws`
- Add `config set`/`config rm` handling to fake `pulumi`
- Add `PULUMI_BACKEND_URL` to test env (needed by `reconcile-managed-dsql-endpoint.sh`)
- Add test: force mode with `rollout_mix` scenario verifies DSQL reconcile for `staging` and `rollout-hop.yml` dispatch for `devo`
- Add test: force mode with `envs_missing` scenario verifies environment repair via `gh api PUT`
- Add test: non-force mode with `envs_missing` scenario verifies detection as `needs_repo_config`

## Stack position

```
main <- PR #17 (evaluate-and-continue engine)
     <- PR #18 (OIDC companion)
       <- PR #19 (promotion orchestration)
         <- PR #23 (persist STACKS/PROMOTION_PATH)
           <- This PR (fix #20 + #21)
```

## Note

`managed-dsql-consistency-test.sh` fails on this branch and on the parent — this is a pre-existing documentation gap, not introduced by these changes.