### PR TITLE
docs: align onboarding docs with current bootstrap scripts and env.template

### DIFF
--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -23,9 +23,12 @@ Your deployment repository should contain:
 - `scripts/create-deployment-repo.sh`
 - `scripts/bootstrap-aws-foundation.sh`
 - `scripts/bootstrap-pulumi-backend.sh`
+- `scripts/bootstrap-oidc-discovery-companion.sh`
 - `scripts/bootstrap-deployment-repo.sh`
 - `scripts/bootstrap-all.sh`
 - `scripts/evaluate-and-continue.sh`
+- `scripts/reconcile-managed-dsql-endpoint.sh`
+- `scripts/lib/bootstrap-env.sh`
 
 ## Quick Checklist / 快速清单
 
@@ -120,6 +123,7 @@ Manual path:
 - `LTBASE_RELEASE_ID`
 - `STACKS`
 - `PROMOTION_PATH`
+- `PREVIEW_DEFAULT_STACK`
 
 ## Notes / 说明
 

--- a/docs/CUSTOMER_ONBOARDING.md
+++ b/docs/CUSTOMER_ONBOARDING.md
@@ -108,13 +108,15 @@ Follow the steps in this order:
 - 阅读：[`docs/onboarding/02-create-repo-and-clone.md`](onboarding/02-create-repo-and-clone.md)
 - 内容包括：从模板创建私有仓库、拉取到本地、确认目录结构
 
-### Step 3 - Create GitHub OIDC and deploy roles / 第三步：创建 GitHub OIDC 和 deploy role
+### Step 3 - Prepare OIDC and deploy roles / 第三步：准备 OIDC 和 deploy role
 
 - Read: [`docs/onboarding/03-create-oidc-and-deploy-roles.md`](onboarding/03-create-oidc-and-deploy-roles.md)
 - Covers: OIDC provider, per-stack deploy roles, trust policy, permissions policy
+- If using one-click bootstrap, review only; the script creates these automatically
 
 - 阅读：[`docs/onboarding/03-create-oidc-and-deploy-roles.md`](onboarding/03-create-oidc-and-deploy-roles.md)
 - 内容包括：OIDC provider、按 stack 划分的 deploy role、信任策略、权限策略
+- 如果使用一键 bootstrap，只需确认即可；脚本会自动创建这些资源
 
 ### Step 4 - Prepare the local `.env` file / 第四步：准备本地 `.env` 文件
 
@@ -175,6 +177,7 @@ Set these repository variables in your deployment repository:
 - `LTBASE_RELEASE_ID`
 - `STACKS`
 - `PROMOTION_PATH`
+- `PREVIEW_DEFAULT_STACK`
 
 The bootstrap scripts write these values for you when `.env` is correct.
 

--- a/docs/onboarding/02-create-repo-and-clone.md
+++ b/docs/onboarding/02-create-repo-and-clone.md
@@ -28,10 +28,14 @@ Use this guide to create your customer-owned deployment repository from the temp
    - `.github/workflows/`
    - `env.template`
    - `scripts/create-deployment-repo.sh`
+   - `scripts/render-bootstrap-policies.sh`
    - `scripts/bootstrap-aws-foundation.sh`
    - `scripts/bootstrap-pulumi-backend.sh`
+   - `scripts/bootstrap-oidc-discovery-companion.sh`
    - `scripts/bootstrap-deployment-repo.sh`
    - `scripts/bootstrap-all.sh`
+   - `scripts/evaluate-and-continue.sh`
+   - `scripts/reconcile-managed-dsql-endpoint.sh`
 5. Confirm that the repository is private.
 6. Confirm that the `prod` environment will be available for later approval gating.
 
@@ -43,10 +47,14 @@ Use this guide to create your customer-owned deployment repository from the temp
    - `.github/workflows/`
    - `env.template`
    - `scripts/create-deployment-repo.sh`
+   - `scripts/render-bootstrap-policies.sh`
    - `scripts/bootstrap-aws-foundation.sh`
    - `scripts/bootstrap-pulumi-backend.sh`
+   - `scripts/bootstrap-oidc-discovery-companion.sh`
    - `scripts/bootstrap-deployment-repo.sh`
    - `scripts/bootstrap-all.sh`
+   - `scripts/evaluate-and-continue.sh`
+   - `scripts/reconcile-managed-dsql-endpoint.sh`
 5. 确认仓库是私有的。
 6. 确认后续用于审批的 `prod` environment 可以创建。
 

--- a/docs/onboarding/03-create-oidc-and-deploy-roles.md
+++ b/docs/onboarding/03-create-oidc-and-deploy-roles.md
@@ -10,6 +10,12 @@ Use this guide to prepare the AWS-side trust and deployment roles that GitHub Ac
 
 使用本文档准备 AWS 侧的信任关系与部署角色，让 GitHub Actions 可以执行 LTBase 的 preview 和 deploy。
 
+## Note for one-click bootstrap users / 一键 bootstrap 用户说明
+
+If you plan to use the one-click bootstrap path (`evaluate-and-continue.sh`), the script runs `bootstrap-aws-foundation.sh` which creates OIDC providers and deploy roles automatically. In that case, use this page to **review and verify** what will be created, rather than creating resources manually. If your AWS permissions do not allow the script to create IAM resources, follow the manual steps below.
+
+如果你打算使用一键 bootstrap 路径（`evaluate-and-continue.sh`），该脚本会自动运行 `bootstrap-aws-foundation.sh` 来创建 OIDC provider 和 deploy role。在这种情况下，本页面的作用是让你 **提前了解和确认** 将会创建哪些资源，而不是手动创建它们。如果你的 AWS 权限不允许脚本自动创建 IAM 资源，请按下面的手动步骤操作。
+
 ## Before You Start / 开始前确认
 
 - complete [`02-create-repo-and-clone.md`](02-create-repo-and-clone.md)

--- a/docs/onboarding/04-prepare-env-file.md
+++ b/docs/onboarding/04-prepare-env-file.md
@@ -21,90 +21,82 @@ Use this guide to create the local `.env` file that drives the bootstrap scripts
 ## Steps / 操作步骤
 
 1. Copy `env.template` to `.env`.
-2. Fill in the repository identity values:
+2. Fill in stack topology:
+   - `STACKS` — comma-separated list of environment names, e.g. `devo,prod`
+   - `PROMOTION_PATH` — promotion order, e.g. `devo,prod`
+3. Fill in template and repository identity:
+   - `TEMPLATE_REPO`
    - `GITHUB_OWNER`
    - `DEPLOYMENT_REPO_NAME`
-   - `DEPLOYMENT_REPO`
-3. Fill in AWS environment values:
-   - `AWS_REGION_DEVO`
-   - `AWS_REGION_PROD`
-   - `AWS_ACCOUNT_ID_DEVO`
-   - `AWS_ACCOUNT_ID_PROD`
-   - `AWS_ROLE_NAME_DEVO`
-   - `AWS_ROLE_NAME_PROD`
-   - `AWS_ROLE_ARN_DEVO`
-   - `AWS_ROLE_ARN_PROD`
-4. Fill in Pulumi backend values:
+   - `DEPLOYMENT_REPO_VISIBILITY`
+   - `DEPLOYMENT_REPO_DESCRIPTION`
+4. Fill in OIDC discovery values:
+   - `OIDC_DISCOVERY_DOMAIN`
+   - `CLOUDFLARE_ACCOUNT_ID`
+5. Fill in AWS environment values (one pair per stack):
+   - `AWS_REGION_DEVO`, `AWS_REGION_PROD`
+   - `AWS_ACCOUNT_ID_DEVO`, `AWS_ACCOUNT_ID_PROD`
+   - `AWS_ROLE_NAME_DEVO`, `AWS_ROLE_NAME_PROD`
+6. Fill in Pulumi backend values:
    - `PULUMI_STATE_BUCKET`
    - `PULUMI_KMS_ALIAS`
+   - `PULUMI_PROJECT`
    - leave `PULUMI_BACKEND_URL`, `PULUMI_SECRETS_PROVIDER_DEVO`, and `PULUMI_SECRETS_PROVIDER_PROD` empty if you plan to let bootstrap generate them
-5. Fill in release values:
+7. Fill in release values:
    - `LTBASE_RELEASES_REPO`
    - `LTBASE_RELEASE_ID`
-6. Fill in runtime and domain values:
-   - `API_DOMAIN`
-   - `CONTROL_DOMAIN`
-   - `AUTH_DOMAIN`
+8. Fill in per-stack domain values:
+   - `API_DOMAIN_DEVO`, `API_DOMAIN_PROD`
+   - `CONTROL_DOMAIN_DEVO`, `CONTROL_DOMAIN_PROD`
+   - `AUTH_DOMAIN_DEVO`, `AUTH_DOMAIN_PROD`
    - `CLOUDFLARE_ZONE_ID`
-   - `OIDC_ISSUER_URL`
-   - `JWKS_URL`
-   - `RUNTIME_BUCKET`
-   - `TABLE_NAME`
-   - `GITHUB_ORG`
-   - `GITHUB_REPO`
+9. Fill in application defaults:
    - `GEMINI_MODEL`
-   - `DSQL_PORT`
-   - `DSQL_DB`
-   - `DSQL_USER`
-   - `DSQL_PROJECT_SCHEMA`
-7. Fill in secret values:
-   - `GEMINI_API_KEY`
-   - `CLOUDFLARE_API_TOKEN`
-   - `LTBASE_RELEASES_TOKEN`
-8. Save the file locally and confirm it is not committed.
+   - `DSQL_PORT`, `DSQL_DB`, `DSQL_USER`, `DSQL_PROJECT_SCHEMA`
+10. Fill in secret values:
+    - `GEMINI_API_KEY`
+    - `CLOUDFLARE_API_TOKEN`
+    - `LTBASE_RELEASES_TOKEN`
+11. Save the file locally and confirm it is not committed.
 
 1. 将 `env.template` 复制为 `.env`。
-2. 填写仓库标识信息：
+2. 填写 stack 拓扑：
+   - `STACKS` — 逗号分隔的环境名列表，例如 `devo,prod`
+   - `PROMOTION_PATH` — promotion 顺序，例如 `devo,prod`
+3. 填写模板与仓库标识：
+   - `TEMPLATE_REPO`
    - `GITHUB_OWNER`
    - `DEPLOYMENT_REPO_NAME`
-   - `DEPLOYMENT_REPO`
-3. 填写 AWS 环境信息：
-   - `AWS_REGION_DEVO`
-   - `AWS_REGION_PROD`
-   - `AWS_ACCOUNT_ID_DEVO`
-   - `AWS_ACCOUNT_ID_PROD`
-   - `AWS_ROLE_NAME_DEVO`
-   - `AWS_ROLE_NAME_PROD`
-   - `AWS_ROLE_ARN_DEVO`
-   - `AWS_ROLE_ARN_PROD`
-4. 填写 Pulumi backend 信息：
+   - `DEPLOYMENT_REPO_VISIBILITY`
+   - `DEPLOYMENT_REPO_DESCRIPTION`
+4. 填写 OIDC discovery 信息：
+   - `OIDC_DISCOVERY_DOMAIN`
+   - `CLOUDFLARE_ACCOUNT_ID`
+5. 填写 AWS 环境信息（每个 stack 一组）：
+   - `AWS_REGION_DEVO`、`AWS_REGION_PROD`
+   - `AWS_ACCOUNT_ID_DEVO`、`AWS_ACCOUNT_ID_PROD`
+   - `AWS_ROLE_NAME_DEVO`、`AWS_ROLE_NAME_PROD`
+6. 填写 Pulumi backend 信息：
    - `PULUMI_STATE_BUCKET`
    - `PULUMI_KMS_ALIAS`
+   - `PULUMI_PROJECT`
    - 如果你希望由 bootstrap 自动生成 `PULUMI_BACKEND_URL`、`PULUMI_SECRETS_PROVIDER_DEVO`、`PULUMI_SECRETS_PROVIDER_PROD`，可先留空
-5. 填写 release 信息：
+7. 填写 release 信息：
    - `LTBASE_RELEASES_REPO`
    - `LTBASE_RELEASE_ID`
-6. 填写运行时与域名信息：
-   - `API_DOMAIN`
-   - `CONTROL_DOMAIN`
-   - `AUTH_DOMAIN`
+8. 填写按 stack 划分的域名信息：
+   - `API_DOMAIN_DEVO`、`API_DOMAIN_PROD`
+   - `CONTROL_DOMAIN_DEVO`、`CONTROL_DOMAIN_PROD`
+   - `AUTH_DOMAIN_DEVO`、`AUTH_DOMAIN_PROD`
    - `CLOUDFLARE_ZONE_ID`
-   - `OIDC_ISSUER_URL`
-   - `JWKS_URL`
-   - `RUNTIME_BUCKET`
-   - `TABLE_NAME`
-   - `GITHUB_ORG`
-   - `GITHUB_REPO`
+9. 填写应用默认值：
    - `GEMINI_MODEL`
-   - `DSQL_PORT`
-   - `DSQL_DB`
-   - `DSQL_USER`
-   - `DSQL_PROJECT_SCHEMA`
-7. 填写 secrets：
-   - `GEMINI_API_KEY`
-   - `CLOUDFLARE_API_TOKEN`
-   - `LTBASE_RELEASES_TOKEN`
-8. 将文件保存在本地，并确认不会提交进仓库。
+   - `DSQL_PORT`、`DSQL_DB`、`DSQL_USER`、`DSQL_PROJECT_SCHEMA`
+10. 填写 secrets：
+    - `GEMINI_API_KEY`
+    - `CLOUDFLARE_API_TOKEN`
+    - `LTBASE_RELEASES_TOKEN`
+11. 将文件保存在本地，并确认不会提交进仓库。
 
 ## Important Rules / 重要规则
 
@@ -112,11 +104,13 @@ Use this guide to create the local `.env` file that drives the bootstrap scripts
 - do not put production secrets into tracked files
 - treat `PULUMI_BACKEND_URL` and `PULUMI_SECRETS_PROVIDER_*` as generated values if you rely on bootstrap to create backend resources
 - only fill values you actually control; generated values should come from bootstrap outputs
+- the following variables are auto-derived by `scripts/lib/bootstrap-env.sh` and normally do not need manual filling: `DEPLOYMENT_REPO`, `AWS_PROFILE_*`, `PULUMI_BACKEND_URL`, `PULUMI_SECRETS_PROVIDER_*`, `OIDC_ISSUER_URL_*`, `JWKS_URL_*`, `RUNTIME_BUCKET_*`, `TABLE_NAME_*`, `GITHUB_ORG`, `GITHUB_REPO`, `OIDC_DISCOVERY_TEMPLATE_REPO`, `OIDC_DISCOVERY_REPO_NAME`, `OIDC_DISCOVERY_REPO`, `OIDC_DISCOVERY_PAGES_PROJECT`, `OIDC_DISCOVERY_AWS_ROLE_NAME_*`
 
 - 不要提交 `.env`
 - 不要把生产 secrets 写进被版本控制的文件
 - 如果你依赖 bootstrap 创建 backend 资源，请把 `PULUMI_BACKEND_URL` 和 `PULUMI_SECRETS_PROVIDER_*` 当作生成值
 - 只填写你真正控制的输入项，生成值应来自 bootstrap 输出
+- 以下变量由 `scripts/lib/bootstrap-env.sh` 自动派生，通常不需要手动填写：`DEPLOYMENT_REPO`、`AWS_PROFILE_*`、`PULUMI_BACKEND_URL`、`PULUMI_SECRETS_PROVIDER_*`、`OIDC_ISSUER_URL_*`、`JWKS_URL_*`、`RUNTIME_BUCKET_*`、`TABLE_NAME_*`、`GITHUB_ORG`、`GITHUB_REPO`、`OIDC_DISCOVERY_TEMPLATE_REPO`、`OIDC_DISCOVERY_REPO_NAME`、`OIDC_DISCOVERY_REPO`、`OIDC_DISCOVERY_PAGES_PROJECT`、`OIDC_DISCOVERY_AWS_ROLE_NAME_*`
 
 ## Expected Result / 预期结果
 

--- a/docs/onboarding/05-bootstrap-one-click.md
+++ b/docs/onboarding/05-bootstrap-one-click.md
@@ -65,6 +65,7 @@ The one-click script runs these stages in order:
 - `create-deployment-repo.sh`
 - `render-bootstrap-policies.sh`
 - `bootstrap-aws-foundation.sh`
+- `bootstrap-oidc-discovery-companion.sh`
 - `bootstrap-deployment-repo.sh --stack <each stack in STACKS>`
 - optional `gh workflow run rollout.yml ...` when `--release-id` is set
 

--- a/docs/onboarding/06-bootstrap-manual.md
+++ b/docs/onboarding/06-bootstrap-manual.md
@@ -89,6 +89,20 @@ Repeat the command once for each stack listed in `STACKS`, in the same order as 
 
 对 `STACKS` 中列出的每个 stack 都执行一次，顺序与 `PROMOTION_PATH` 保持一致。
 
+### 6. Bootstrap OIDC discovery companion / 初始化 OIDC discovery 配套资源
+
+Run:
+
+执行：
+
+```bash
+./scripts/bootstrap-oidc-discovery-companion.sh --env-file .env
+```
+
+This step creates or updates the OIDC discovery companion repository, Cloudflare Pages project, custom domain binding, and per-stack OIDC discovery IAM roles.
+
+该步骤会创建或更新 OIDC discovery 配套仓库、Cloudflare Pages 项目、自定义域名绑定，以及每个 stack 对应的 OIDC discovery IAM role。
+
 ### 7. Confirm repository configuration / 确认仓库配置完成
 
 Check that the repository now contains the required GitHub secrets and variables.


### PR DESCRIPTION
## Summary

Review of BOOTSTRAP.md and CUSTOMER_ONBOARDING.md found 7 alignment gaps with the current codebase. This PR fixes all of them.

## Changes

| # | Fix | Files |
|---|-----|-------|
| 1 | Add `bootstrap-oidc-discovery-companion.sh`, `reconcile-managed-dsql-endpoint.sh`, `lib/bootstrap-env.sh` to repository layout | `BOOTSTRAP.md` |
| 2 | Add `PREVIEW_DEFAULT_STACK` to Required GitHub Variables | `BOOTSTRAP.md`, `CUSTOMER_ONBOARDING.md` |
| 3 | Rewrite env var list: add `STACKS`/`PROMOTION_PATH`, OIDC discovery vars, `PULUMI_PROJECT`, use per-stack domain names; remove auto-derived vars; document auto-derived variable list | `04-prepare-env-file.md` |
| 4 | Add `bootstrap-oidc-discovery-companion.sh` to one-click stages list | `05-bootstrap-one-click.md` |
| 5 | Add OIDC discovery companion step, fix step 5→7 numbering gap | `06-bootstrap-manual.md` |
| 6 | Update file checklist with all current scripts | `02-create-repo-and-clone.md` |
| 7 | Clarify step 3 is review-only for one-click bootstrap users | `03-create-oidc-and-deploy-roles.md`, `CUSTOMER_ONBOARDING.md` |

## Why

- OIDC discovery companion (`bootstrap-oidc-discovery-companion.sh`) was completely undocumented despite being called by both `bootstrap-all.sh` and `evaluate-and-continue.sh`
- `STACKS` and `PROMOTION_PATH` — the two most critical config variables — were missing from the env file preparation guide
- Domain variable names in docs didn't match `env.template` (e.g. `API_DOMAIN` vs `API_DOMAIN_DEVO`/`API_DOMAIN_PROD`)
- Step 3 (manual OIDC/role creation) is redundant for one-click users since `bootstrap-aws-foundation.sh` handles it automatically
- `PREVIEW_DEFAULT_STACK` is set by `bootstrap-deployment-repo.sh` and checked by `evaluate-and-continue.sh` but was undocumented

Documentation only — no code changes.