### PR TITLE
docs: align onboarding docs with code and split into EN/ZH

### DIFF
--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -1,20 +1,16 @@
-# Customer Bootstrap Checklist / 客户 Bootstrap 清单
+> **中文版：[BOOTSTRAP.zh.md](BOOTSTRAP.zh.md)**
+
+# Customer Bootstrap Checklist
 
 This is the short checklist version of the customer onboarding flow.
 
-这是客户 onboarding 流程的简版清单。
-
-For the full bilingual runbook, start here:
-
-完整的中英双语说明请从这里开始：
+For the full runbook, start here:
 
 - [`CUSTOMER_ONBOARDING.md`](CUSTOMER_ONBOARDING.md)
 
-## Repository Layout / 仓库结构
+## Repository Layout
 
 Your deployment repository should contain:
-
-你的部署仓库应包含：
 
 - `infra/`
 - `.github/workflows/`
@@ -30,91 +26,60 @@ Your deployment repository should contain:
 - `scripts/reconcile-managed-dsql-endpoint.sh`
 - `scripts/lib/bootstrap-env.sh`
 
-## Quick Checklist / 快速清单
+## Quick Checklist
 
-### 1. Prepare prerequisites / 1. 准备前置条件
+### 1. Prepare prerequisites
 
 - read [`onboarding/01-prerequisites.md`](onboarding/01-prerequisites.md)
 - confirm GitHub, AWS, Cloudflare, `LTBASE_RELEASES_TOKEN`, and `GEMINI_API_KEY`
 
-- 阅读 [`onboarding/01-prerequisites.md`](onboarding/01-prerequisites.md)
-- 确认 GitHub、AWS、Cloudflare、`LTBASE_RELEASES_TOKEN` 与 `GEMINI_API_KEY` 都已准备好
-
-### 2. Create the deployment repository / 2. 创建部署仓库
+### 2. Create the deployment repository
 
 - read [`onboarding/02-create-repo-and-clone.md`](onboarding/02-create-repo-and-clone.md)
 - create the private repo from template and clone it locally
 
-- 阅读 [`onboarding/02-create-repo-and-clone.md`](onboarding/02-create-repo-and-clone.md)
-- 从模板创建私有仓库并 clone 到本地
-
-### 3. Create OIDC and deploy roles / 3. 创建 OIDC 和 deploy role
+### 3. Create OIDC and deploy roles
 
 - read [`onboarding/03-create-oidc-and-deploy-roles.md`](onboarding/03-create-oidc-and-deploy-roles.md)
 - create one deploy role for each stack in `STACKS`
 
-- 阅读 [`onboarding/03-create-oidc-and-deploy-roles.md`](onboarding/03-create-oidc-and-deploy-roles.md)
-- 为 `STACKS` 中的每个环境各创建一个 deploy role
-
-### 4. Prepare `.env` / 4. 准备 `.env`
+### 4. Prepare `.env`
 
 - read [`onboarding/04-prepare-env-file.md`](onboarding/04-prepare-env-file.md)
 - copy `env.template` to `.env`
 - fill real values and never commit `.env`
 
-- 阅读 [`onboarding/04-prepare-env-file.md`](onboarding/04-prepare-env-file.md)
-- 将 `env.template` 复制为 `.env`
-- 填写真实值，并且绝对不要提交 `.env`
-
-### 5. Choose a bootstrap path / 5. 选择 bootstrap 路径
+### 5. Choose a bootstrap path
 
 One-click path:
-
-一键路径：
 
 - read [`onboarding/05-bootstrap-one-click.md`](onboarding/05-bootstrap-one-click.md)
 - run `./scripts/evaluate-and-continue.sh --env-file .env --scope bootstrap --force --infra-dir infra`
 
-- 阅读 [`onboarding/05-bootstrap-one-click.md`](onboarding/05-bootstrap-one-click.md)
-- 运行 `./scripts/evaluate-and-continue.sh --env-file .env --scope bootstrap --force --infra-dir infra`
-
 Manual path:
-
-手动路径：
 
 - read [`onboarding/06-bootstrap-manual.md`](onboarding/06-bootstrap-manual.md)
 - run the bootstrap scripts stage by stage
 
-- 阅读 [`onboarding/06-bootstrap-manual.md`](onboarding/06-bootstrap-manual.md)
-- 按阶段逐个执行 bootstrap 脚本
-
-### 6. Run the first deployment / 6. 执行首次部署
+### 6. Run the first deployment
 
 - read [`onboarding/07-first-deploy-and-managed-dsql.md`](onboarding/07-first-deploy-and-managed-dsql.md)
 - run preview for the first stack in `PROMOTION_PATH`
 - trigger `rollout.yml` once for the chosen release
 - approve each protected target stack as GitHub requests it
 
-- 阅读 [`onboarding/07-first-deploy-and-managed-dsql.md`](onboarding/07-first-deploy-and-managed-dsql.md)
-- 对 `PROMOTION_PATH` 第一个环境执行 preview
-- 针对目标 release 触发一次 `rollout.yml`
-- 在 GitHub 请求时依次审批受保护目标环境
-
-### 7. Day-2 operations / 7. 日常运维
+### 7. Day-2 operations
 
 - read [`onboarding/08-day-2-operations.md`](onboarding/08-day-2-operations.md)
 - use the same preview -> rollout rhythm for upgrades
 
-- 阅读 [`onboarding/08-day-2-operations.md`](onboarding/08-day-2-operations.md)
-- 后续升级继续沿用 preview -> rollout 的节奏
-
-## Required GitHub Secrets / 必需的 GitHub Secrets
+## Required GitHub Secrets
 
 - `AWS_ROLE_ARN_<STACK>` for every stack in `STACKS`
 - `LTBASE_RELEASES_TOKEN`
 - `CLOUDFLARE_API_TOKEN`
 
-## Required GitHub Variables / 必需的 GitHub Variables
+## Required GitHub Variables
 
 - `AWS_REGION_<STACK>` for every stack in `STACKS`
 - `PULUMI_BACKEND_URL`
@@ -125,16 +90,10 @@ Manual path:
 - `PROMOTION_PATH`
 - `PREVIEW_DEFAULT_STACK`
 
-## Notes / 说明
+## Notes
 
 - keep `.env` private and outside version control
 - the deployment repository downloads official LTBase releases; it does not build the app itself
 - preview is manual in the customer repo because live credentials are customer-owned
 - manual preview only supports the first stack in `PROMOTION_PATH`
 - protected target environments are guarded by per-stack GitHub environment approval gates during rollout
-
-- 保持 `.env` 私密，不要纳入版本控制
-- 部署仓库负责下载官方 LTBase release，不负责自行构建应用
-- 客户仓库中的 preview 默认为手动触发，因为真实凭据由客户持有
-- 手动 preview 只支持 `PROMOTION_PATH` 的第一个环境
-- rollout 中的受保护目标环境由各自的 GitHub environment 审批 gate 保护

--- a/docs/BOOTSTRAP.zh.md
+++ b/docs/BOOTSTRAP.zh.md
@@ -1,0 +1,99 @@
+> **English version: [BOOTSTRAP.md](BOOTSTRAP.md)**
+
+# 客户 Bootstrap 清单
+
+这是客户 onboarding 流程的简版清单。
+
+完整的中英双语说明请从这里开始：
+
+- [`CUSTOMER_ONBOARDING.zh.md`](CUSTOMER_ONBOARDING.zh.md)
+
+## 仓库结构
+
+你的部署仓库应包含：
+
+- `infra/`
+- `.github/workflows/`
+- `env.template`
+- `scripts/render-bootstrap-policies.sh`
+- `scripts/create-deployment-repo.sh`
+- `scripts/bootstrap-aws-foundation.sh`
+- `scripts/bootstrap-pulumi-backend.sh`
+- `scripts/bootstrap-oidc-discovery-companion.sh`
+- `scripts/bootstrap-deployment-repo.sh`
+- `scripts/bootstrap-all.sh`
+- `scripts/evaluate-and-continue.sh`
+- `scripts/reconcile-managed-dsql-endpoint.sh`
+- `scripts/lib/bootstrap-env.sh`
+
+## 快速清单
+
+### 1. 准备前置条件
+
+- 阅读 [`onboarding/01-prerequisites.zh.md`](onboarding/01-prerequisites.zh.md)
+- 确认 GitHub、AWS、Cloudflare、`LTBASE_RELEASES_TOKEN` 与 `GEMINI_API_KEY` 都已准备好
+
+### 2. 创建部署仓库
+
+- 阅读 [`onboarding/02-create-repo-and-clone.zh.md`](onboarding/02-create-repo-and-clone.zh.md)
+- 从模板创建私有仓库并 clone 到本地
+
+### 3. 创建 OIDC 和 deploy role
+
+- 阅读 [`onboarding/03-create-oidc-and-deploy-roles.zh.md`](onboarding/03-create-oidc-and-deploy-roles.zh.md)
+- 为 `STACKS` 中的每个环境各创建一个 deploy role
+
+### 4. 准备 `.env`
+
+- 阅读 [`onboarding/04-prepare-env-file.zh.md`](onboarding/04-prepare-env-file.zh.md)
+- 将 `env.template` 复制为 `.env`
+- 填写真实值，并且绝对不要提交 `.env`
+
+### 5. 选择 bootstrap 路径
+
+一键路径：
+
+- 阅读 [`onboarding/05-bootstrap-one-click.zh.md`](onboarding/05-bootstrap-one-click.zh.md)
+- 运行 `./scripts/evaluate-and-continue.sh --env-file .env --scope bootstrap --force --infra-dir infra`
+
+手动路径：
+
+- 阅读 [`onboarding/06-bootstrap-manual.zh.md`](onboarding/06-bootstrap-manual.zh.md)
+- 按阶段逐个执行 bootstrap 脚本
+
+### 6. 执行首次部署
+
+- 阅读 [`onboarding/07-first-deploy-and-managed-dsql.zh.md`](onboarding/07-first-deploy-and-managed-dsql.zh.md)
+- 对 `PROMOTION_PATH` 第一个环境执行 preview
+- 针对目标 release 触发一次 `rollout.yml`
+- 在 GitHub 请求时依次审批受保护目标环境
+
+### 7. 日常运维
+
+- 阅读 [`onboarding/08-day-2-operations.zh.md`](onboarding/08-day-2-operations.zh.md)
+- 后续升级继续沿用 preview -> rollout 的节奏
+
+## 必需的 GitHub Secrets
+
+- `AWS_ROLE_ARN_<STACK>` for every stack in `STACKS`
+- `LTBASE_RELEASES_TOKEN`
+- `CLOUDFLARE_API_TOKEN`
+
+## 必需的 GitHub Variables
+
+- `AWS_REGION_<STACK>` for every stack in `STACKS`
+- `PULUMI_BACKEND_URL`
+- `PULUMI_SECRETS_PROVIDER_<STACK>` for every stack in `STACKS`
+- `LTBASE_RELEASES_REPO`
+- `LTBASE_RELEASE_ID`
+- `STACKS`
+- `PROMOTION_PATH`
+- `PREVIEW_DEFAULT_STACK`
+
+## 说明
+
+- 保持 `.env` 私密，不要纳入版本控制
+- 部署仓库负责下载官方 LTBase release，不负责自行构建应用
+- 客户仓库中的 preview 默认为手动触发，因为真实凭据由客户持有
+- 手动 preview 只支持 `PROMOTION_PATH` 的第一个环境
+- rollout 中的受保护目标环境由各自的 GitHub environment 审批 gate 保护

--- a/docs/CUSTOMER_ONBOARDING.md
+++ b/docs/CUSTOMER_ONBOARDING.md
@@ -1,46 +1,32 @@
-# LTBase Customer Onboarding Runbook / LTBase 客户部署入门指南
+> **中文版：[CUSTOMER_ONBOARDING.zh.md](CUSTOMER_ONBOARDING.zh.md)**
+
+# LTBase Customer Onboarding Runbook
 
 This document is the main entry point for customers deploying LTBase with the private deployment template.
 
-本文档是客户使用私有部署模板部署 LTBase 时的主入口文档。
-
-## What This Document Is For / 本文档的用途
+## What This Document Is For
 
 - explain the overall deployment model
 - show the full onboarding order from preparation to first promotion-path rollout
 - link to detailed step-by-step guides for every longer operation
 
-- 解释整体部署模型
-- 给出从准备到第一次按 promotion path 推进 rollout 的完整顺序
-- 为每个较长操作链接到详细步骤文档
-
-## Deployment Model / 部署模型
+## Deployment Model
 
 Your LTBase deployment uses three repositories:
 
-你的 LTBase 部署会涉及三个仓库：
-
 - `ltbase-deploy-workflows`
   - reusable public GitHub Actions workflows maintained by LTBase
-  - LTBase 维护的公共可复用 GitHub Actions 工作流
 - `ltbase-releases`
   - private release repository containing official LTBase application artifacts
-  - 私有发布仓库，存放官方 LTBase 应用发布产物
 - your deployment repository
   - a private repository created from `ltbase-private-deployment`
   - your customer-owned repo that stores workflows, bootstrap scripts, and Pulumi stack configuration
-  - 由 `ltbase-private-deployment` 模板创建出来的私有仓库
-  - 这是你自己的部署仓库，用来保存工作流、bootstrap 脚本和 Pulumi stack 配置
 
 Your deployment repository does not build LTBase application source code. It downloads an official LTBase release and deploys it into your AWS account.
 
-你的部署仓库不会自行构建 LTBase 应用源码。它会下载官方 LTBase release，并将其部署到你的 AWS 账户中。
-
-## End State / 最终完成状态
+## End State
 
 When onboarding is complete, you should have:
-
-完成 onboarding 后，你应该具备以下结果：
 
 - one private deployment repository based on this template
 - one GitHub OIDC trust relationship in each AWS account used for deployment
@@ -51,20 +37,9 @@ When onboarding is complete, you should have:
 - a first promotion stack ready for preview and deployment
 - each later stack in `PROMOTION_PATH` ready for protected promotion after the previous hop is validated
 
-- 一个基于本模板创建的私有部署仓库
-- 每个用于部署的 AWS 账户中各自存在 GitHub OIDC 信任关系
-- `STACKS` 中每个环境各自对应一个 deploy role
-- 一个 Pulumi state bucket
-- 一个用于 Pulumi secrets 加密的 KMS alias
-- 已配置好的 GitHub 仓库 secrets 和 variables
-- 一个可用于 preview 与部署的起点 stack
-- `PROMOTION_PATH` 中每个后续环境在前一跳验证后都可用于受保护 promotion
-
-## Before You Start / 开始之前
+## Before You Start
 
 You will need:
-
-你需要提前准备：
 
 - a GitHub organization or account that can host a private repository
 - one or more AWS accounts that will host the stacks listed in `STACKS`
@@ -73,102 +48,64 @@ You will need:
 - a customer-specific `LTBASE_RELEASES_TOKEN`
 - a Gemini API key
 
-- 一个可以创建私有仓库的 GitHub 组织或账号
-- 一个或多个将承载 `STACKS` 中各环境的 AWS 账户
-- 一个用于业务域名的 Cloudflare zone
-- 创建或更新 IAM role、IAM OIDC provider、S3 bucket、KMS key 的权限
-- 一个客户专用的 `LTBASE_RELEASES_TOKEN`
-- 一个 Gemini API key
-
 For the detailed preparation checklist, use:
-
-更详细的准备清单请看：
 
 - [`docs/onboarding/01-prerequisites.md`](onboarding/01-prerequisites.md)
 
-## Full Onboarding Order / 完整操作顺序
+## Full Onboarding Order
 
 Follow the steps in this order:
 
-请按下面顺序操作：
-
-### Step 1 - Prepare prerequisites / 第一步：准备前置条件
+### Step 1 - Prepare prerequisites
 
 - Read: [`docs/onboarding/01-prerequisites.md`](onboarding/01-prerequisites.md)
 - Covers: accounts, permissions, tokens, domains, local tools
 
-- 阅读：[`docs/onboarding/01-prerequisites.md`](onboarding/01-prerequisites.md)
-- 内容包括：账户、权限、token、域名、本地工具
-
-### Step 2 - Create the deployment repository and clone it / 第二步：创建部署仓库并克隆到本地
+### Step 2 - Create the deployment repository and clone it
 
 - Read: [`docs/onboarding/02-create-repo-and-clone.md`](onboarding/02-create-repo-and-clone.md)
 - Covers: creating the private repo from template, cloning locally, verifying repository layout
 
-- 阅读：[`docs/onboarding/02-create-repo-and-clone.md`](onboarding/02-create-repo-and-clone.md)
-- 内容包括：从模板创建私有仓库、拉取到本地、确认目录结构
-
-### Step 3 - Prepare OIDC and deploy roles / 第三步：准备 OIDC 和 deploy role
+### Step 3 - Prepare OIDC and deploy roles
 
 - Read: [`docs/onboarding/03-create-oidc-and-deploy-roles.md`](onboarding/03-create-oidc-and-deploy-roles.md)
 - Covers: OIDC provider, per-stack deploy roles, trust policy, permissions policy
 - If using one-click bootstrap, review only; the script creates these automatically
 
-- 阅读：[`docs/onboarding/03-create-oidc-and-deploy-roles.md`](onboarding/03-create-oidc-and-deploy-roles.md)
-- 内容包括：OIDC provider、按 stack 划分的 deploy role、信任策略、权限策略
-- 如果使用一键 bootstrap，只需确认即可；脚本会自动创建这些资源
-
-### Step 4 - Prepare the local `.env` file / 第四步：准备本地 `.env` 文件
+### Step 4 - Prepare the local `.env` file
 
 - Read: [`docs/onboarding/04-prepare-env-file.md`](onboarding/04-prepare-env-file.md)
 - Covers: every required `.env` field, where each value comes from, what must not be edited manually
 
-- 阅读：[`docs/onboarding/04-prepare-env-file.md`](onboarding/04-prepare-env-file.md)
-- 内容包括：`.env` 每个必填字段、每个值从哪里来、哪些值不能手填
-
-### Step 5 - Choose a bootstrap path / 第五步：选择 bootstrap 路径
+### Step 5 - Choose a bootstrap path
 
 If you have enough GitHub and AWS permissions, use the one-click path:
-
-如果你拥有足够的 GitHub 和 AWS 权限，优先使用一键路径：
 
 - [`docs/onboarding/05-bootstrap-one-click.md`](onboarding/05-bootstrap-one-click.md)
 
 If you want to control each stage manually, use the manual path:
 
-如果你希望逐步控制每一个阶段，请使用手动路径：
-
 - [`docs/onboarding/06-bootstrap-manual.md`](onboarding/06-bootstrap-manual.md)
 
-### Step 6 - Run the first preview and deployment / 第六步：执行第一次 preview 和部署
+### Step 6 - Run the first preview and deployment
 
 - Read: [`docs/onboarding/07-first-deploy-and-managed-dsql.md`](onboarding/07-first-deploy-and-managed-dsql.md)
 - Covers: preview, promotion-path rollout, protected-environment approvals, managed DSQL post-bootstrap handling
 
-- 阅读：[`docs/onboarding/07-first-deploy-and-managed-dsql.md`](onboarding/07-first-deploy-and-managed-dsql.md)
-- 内容包括：preview、按 promotion path 推进的 rollout、受保护环境审批、managed DSQL 的 bootstrap 后处理
-
-### Step 7 - Day-2 operations / 第七步：日常运维与升级
+### Step 7 - Day-2 operations
 
 - Read: [`docs/onboarding/08-day-2-operations.md`](onboarding/08-day-2-operations.md)
 - Covers: release upgrades, repeated previews, deployment rhythm, operational reminders
 
-- 阅读：[`docs/onboarding/08-day-2-operations.md`](onboarding/08-day-2-operations.md)
-- 内容包括：release 升级、重复 preview、部署节奏、运维提醒
-
-## Required GitHub Secrets and Variables / 必需的 GitHub Secrets 与 Variables
+## Required GitHub Secrets and Variables
 
 Set these repository secrets in your deployment repository:
-
-在你的部署仓库中设置以下 secrets：
 
 - `AWS_ROLE_ARN_<STACK>` for every stack in `STACKS`
 - `LTBASE_RELEASES_TOKEN`
 - `CLOUDFLARE_API_TOKEN`
 
 Set these repository variables in your deployment repository:
-
-在你的部署仓库中设置以下 variables：
 
 - `AWS_REGION_<STACK>` for every stack in `STACKS`
 - `PULUMI_BACKEND_URL`
@@ -181,25 +118,15 @@ Set these repository variables in your deployment repository:
 
 The bootstrap scripts write these values for you when `.env` is correct.
 
-当 `.env` 正确时，bootstrap 脚本会帮你写入这些值。
-
-## Important Managed DSQL Note / Managed DSQL 重要说明
+## Important Managed DSQL Note
 
 For managed deployments, do not manually provide an external `dsqlHost`, `dsqlEndpoint`, or `dsqlPassword`.
 
-对于 managed 部署，不要手动提供外部 `dsqlHost`、`dsqlEndpoint` 或 `dsqlPassword`。
-
 At the time of writing, this repository's bootstrap scripts use a bootstrap-safe split: bootstrap prepares GitHub and Pulumi state first, and `scripts/reconcile-managed-dsql-endpoint.sh` publishes the managed DSQL endpoint after infrastructure exists.
-
-在当前仓库版本中，bootstrap 脚本采用 bootstrap-safe 的拆分流程：bootstrap 先准备 GitHub 与 Pulumi 状态，`scripts/reconcile-managed-dsql-endpoint.sh` 会在基础设施实际存在之后发布 managed DSQL endpoint。
 
 Aurora DSQL itself is created by the Pulumi blueprint. You do not supply an external `dsqlHost`, `dsqlEndpoint`, or `dsqlPassword` for managed deployments.
 
-Aurora DSQL 由 Pulumi blueprint 自动创建。对于 managed 部署，你不需要提供外部 `dsqlHost`、`dsqlEndpoint` 或 `dsqlPassword`。
-
 The current repository version uses a bootstrap-safe flow:
-
-当前仓库版本采用 bootstrap-safe 流程：
 
 - `bootstrap-all.sh` and `bootstrap-deployment-repo.sh` prepare configuration only
 - the first real infrastructure apply creates the managed DSQL cluster
@@ -207,13 +134,7 @@ The current repository version uses a bootstrap-safe flow:
 - the reconcile step publishes the resolved endpoint into stack config as `dsqlEndpoint`
 - after reconciliation, run the next preview/deploy cycle so Lambda environment configuration picks up the managed endpoint
 
-- `bootstrap-all.sh` 和 `bootstrap-deployment-repo.sh` 只负责准备配置
-- 第一次真实基础设施 apply 会创建 managed DSQL cluster
-- `scripts/reconcile-managed-dsql-endpoint.sh` 会通过 Pulumi 导出的 `dsqlClusterIdentifier` 从 AWS 获取权威 endpoint
-- reconcile 步骤会把解析出的 endpoint 写入 stack config 的 `dsqlEndpoint`
-- reconcile 完成后，需要再执行下一轮 preview/deploy，才能让 Lambda 环境变量拿到这个 managed endpoint
-
-## Operational Constraints / 运维约束
+## Operational Constraints
 
 - `LTBASE_RELEASES_TOKEN` is only for downloading official LTBase releases
 - local `.env` files contain secrets and must never be committed
@@ -221,13 +142,7 @@ The current repository version uses a bootstrap-safe flow:
 - manual preview only supports the first stack in `PROMOTION_PATH`
 - protected promotions happen in your own repository through per-stack GitHub environment gates
 
-- `LTBASE_RELEASES_TOKEN` 仅用于下载官方 LTBase release
-- 本地 `.env` 文件包含敏感信息，绝对不能提交到仓库
-- 模板仓库不会在 pull request 上自动执行 preview，因为模板仓库不包含真实客户凭据
-- 手动 preview 只支持 `PROMOTION_PATH` 中的第一个环境
-- 受保护环境的 promotion 会在你自己的仓库中通过各自的 GitHub environment gate 完成
-
-## Related Documents / 相关文档
+## Related Documents
 
 - quick checklist: [`docs/BOOTSTRAP.md`](BOOTSTRAP.md)
 - prerequisites: [`docs/onboarding/01-prerequisites.md`](onboarding/01-prerequisites.md)

--- a/docs/CUSTOMER_ONBOARDING.zh.md
+++ b/docs/CUSTOMER_ONBOARDING.zh.md
@@ -1,0 +1,155 @@
+> **English version: [CUSTOMER_ONBOARDING.md](CUSTOMER_ONBOARDING.md)**
+
+# LTBase 客户部署入门指南
+
+本文档是客户使用私有部署模板部署 LTBase 时的主入口文档。
+
+## 本文档的用途
+
+- 解释整体部署模型
+- 给出从准备到第一次按 promotion path 推进 rollout 的完整顺序
+- 为每个较长操作链接到详细步骤文档
+
+## 部署模型
+
+你的 LTBase 部署会涉及三个仓库：
+
+- `ltbase-deploy-workflows`
+  - LTBase 维护的公共可复用 GitHub Actions 工作流
+- `ltbase-releases`
+  - 私有发布仓库，存放官方 LTBase 应用发布产物
+- 你的部署仓库
+  - 由 `ltbase-private-deployment` 模板创建出来的私有仓库
+  - 这是你自己的部署仓库，用来保存工作流、bootstrap 脚本和 Pulumi stack 配置
+
+你的部署仓库不会自行构建 LTBase 应用源码。它会下载官方 LTBase release，并将其部署到你的 AWS 账户中。
+
+## 最终完成状态
+
+完成 onboarding 后，你应该具备以下结果：
+
+- 一个基于本模板创建的私有部署仓库
+- 每个用于部署的 AWS 账户中各自存在 GitHub OIDC 信任关系
+- `STACKS` 中每个环境各自对应一个 deploy role
+- 一个 Pulumi state bucket
+- 一个用于 Pulumi secrets 加密的 KMS alias
+- 已配置好的 GitHub 仓库 secrets 和 variables
+- 一个可用于 preview 与部署的起点 stack
+- `PROMOTION_PATH` 中每个后续环境在前一跳验证后都可用于受保护 promotion
+
+## 开始之前
+
+你需要提前准备：
+
+- 一个可以创建私有仓库的 GitHub 组织或账号
+- 一个或多个将承载 `STACKS` 中各环境的 AWS 账户
+- 一个用于业务域名的 Cloudflare zone
+- 创建或更新 IAM role、IAM OIDC provider、S3 bucket、KMS key 的权限
+- 一个客户专用的 `LTBASE_RELEASES_TOKEN`
+- 一个 Gemini API key
+
+更详细的准备清单请看：
+
+- [`docs/onboarding/01-prerequisites.zh.md`](onboarding/01-prerequisites.zh.md)
+
+## 完整操作顺序
+
+请按下面顺序操作：
+
+### 第一步：准备前置条件
+
+- 阅读：[`docs/onboarding/01-prerequisites.zh.md`](onboarding/01-prerequisites.zh.md)
+- 内容包括：账户、权限、token、域名、本地工具
+
+### 第二步：创建部署仓库并克隆到本地
+
+- 阅读：[`docs/onboarding/02-create-repo-and-clone.zh.md`](onboarding/02-create-repo-and-clone.zh.md)
+- 内容包括：从模板创建私有仓库、拉取到本地、确认目录结构
+
+### 第三步：准备 OIDC 和 deploy role
+
+- 阅读：[`docs/onboarding/03-create-oidc-and-deploy-roles.zh.md`](onboarding/03-create-oidc-and-deploy-roles.zh.md)
+- 内容包括：OIDC provider、按 stack 划分的 deploy role、信任策略、权限策略
+- 如果使用一键 bootstrap，只需确认即可；脚本会自动创建这些资源
+
+### 第四步：准备本地 `.env` 文件
+
+- 阅读：[`docs/onboarding/04-prepare-env-file.zh.md`](onboarding/04-prepare-env-file.zh.md)
+- 内容包括：`.env` 每个必填字段、每个值从哪里来、哪些值不能手填
+
+### 第五步：选择 bootstrap 路径
+
+如果你拥有足够的 GitHub 和 AWS 权限，优先使用一键路径：
+
+- [`docs/onboarding/05-bootstrap-one-click.zh.md`](onboarding/05-bootstrap-one-click.zh.md)
+
+如果你希望逐步控制每一个阶段，请使用手动路径：
+
+- [`docs/onboarding/06-bootstrap-manual.zh.md`](onboarding/06-bootstrap-manual.zh.md)
+
+### 第六步：执行第一次 preview 和部署
+
+- 阅读：[`docs/onboarding/07-first-deploy-and-managed-dsql.zh.md`](onboarding/07-first-deploy-and-managed-dsql.zh.md)
+- 内容包括：preview、按 promotion path 推进的 rollout、受保护环境审批、managed DSQL 的 bootstrap 后处理
+
+### 第七步：日常运维与升级
+
+- 阅读：[`docs/onboarding/08-day-2-operations.zh.md`](onboarding/08-day-2-operations.zh.md)
+- 内容包括：release 升级、重复 preview、部署节奏、运维提醒
+
+## 必需的 GitHub Secrets 与 Variables
+
+在你的部署仓库中设置以下 secrets：
+
+- `AWS_ROLE_ARN_<STACK>`（`STACKS` 中每个环境各一个）
+- `LTBASE_RELEASES_TOKEN`
+- `CLOUDFLARE_API_TOKEN`
+
+在你的部署仓库中设置以下 variables：
+
+- `AWS_REGION_<STACK>`（`STACKS` 中每个环境各一个）
+- `PULUMI_BACKEND_URL`
+- `PULUMI_SECRETS_PROVIDER_<STACK>`（`STACKS` 中每个环境各一个）
+- `LTBASE_RELEASES_REPO`
+- `LTBASE_RELEASE_ID`
+- `STACKS`
+- `PROMOTION_PATH`
+- `PREVIEW_DEFAULT_STACK`
+
+当 `.env` 正确时，bootstrap 脚本会帮你写入这些值。
+
+## Managed DSQL 重要说明
+
+对于 managed 部署，不要手动提供外部 `dsqlHost`、`dsqlEndpoint` 或 `dsqlPassword`。
+
+在当前仓库版本中，bootstrap 脚本采用 bootstrap-safe 的拆分流程：bootstrap 先准备 GitHub 与 Pulumi 状态，`scripts/reconcile-managed-dsql-endpoint.sh` 会在基础设施实际存在之后发布 managed DSQL endpoint。
+
+Aurora DSQL 由 Pulumi blueprint 自动创建。对于 managed 部署，你不需要提供外部 `dsqlHost`、`dsqlEndpoint` 或 `dsqlPassword`。
+
+当前仓库版本采用 bootstrap-safe 流程：
+
+- `bootstrap-all.sh` 和 `bootstrap-deployment-repo.sh` 只负责准备配置
+- 第一次真实基础设施 apply 会创建 managed DSQL cluster
+- `scripts/reconcile-managed-dsql-endpoint.sh` 会通过 Pulumi 导出的 `dsqlClusterIdentifier` 从 AWS 获取权威 endpoint
+- reconcile 步骤会把解析出的 endpoint 写入 stack config 的 `dsqlEndpoint`
+- reconcile 完成后，需要再执行下一轮 preview/deploy，才能让 Lambda 环境变量拿到这个 managed endpoint
+
+## 运维约束
+
+- `LTBASE_RELEASES_TOKEN` 仅用于下载官方 LTBase release
+- 本地 `.env` 文件包含敏感信息，绝对不能提交到仓库
+- 模板仓库不会在 pull request 上自动执行 preview，因为模板仓库不包含真实客户凭据
+- 手动 preview 只支持 `PROMOTION_PATH` 中的第一个环境
+- 受保护环境的 promotion 会在你自己的仓库中通过各自的 GitHub environment gate 完成
+
+## 相关文档
+
+- 快速清单：[`docs/BOOTSTRAP.zh.md`](BOOTSTRAP.zh.md)
+- 前置条件：[`docs/onboarding/01-prerequisites.zh.md`](onboarding/01-prerequisites.zh.md)
+- 创建仓库并克隆：[`docs/onboarding/02-create-repo-and-clone.zh.md`](onboarding/02-create-repo-and-clone.zh.md)
+- 创建 OIDC 和 role：[`docs/onboarding/03-create-oidc-and-deploy-roles.zh.md`](onboarding/03-create-oidc-and-deploy-roles.zh.md)
+- 准备 `.env`：[`docs/onboarding/04-prepare-env-file.zh.md`](onboarding/04-prepare-env-file.zh.md)
+- 一键 bootstrap：[`docs/onboarding/05-bootstrap-one-click.zh.md`](onboarding/05-bootstrap-one-click.zh.md)
+- 手动 bootstrap：[`docs/onboarding/06-bootstrap-manual.zh.md`](onboarding/06-bootstrap-manual.zh.md)
+- 首次部署：[`docs/onboarding/07-first-deploy-and-managed-dsql.zh.md`](onboarding/07-first-deploy-and-managed-dsql.zh.md)
+- 日常运维：[`docs/onboarding/08-day-2-operations.zh.md`](onboarding/08-day-2-operations.zh.md)

--- a/docs/onboarding/01-prerequisites.md
+++ b/docs/onboarding/01-prerequisites.md
@@ -1,20 +1,16 @@
-# Prepare Prerequisites / 准备前置条件
+> **中文版：[01-prerequisites.zh.md](01-prerequisites.zh.md)**
+
+# Prepare Prerequisites
 
 Back to the main guide: [`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md)
 
-返回主文档：[`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md)
-
-## Purpose / 目的
+## Purpose
 
 Use this guide to confirm that you have the minimum accounts, permissions, and local tools required before you begin bootstrap.
 
-使用本文档确认你已经具备开始 bootstrap 所需的最小账户、权限和本地工具。
-
-## Before You Start / 开始前确认
+## Before You Start
 
 You should have access to:
-
-你应该已经可以访问：
 
 - a GitHub organization or personal account that can create private repositories
 - one or more AWS accounts that will host the stacks listed in `STACKS`
@@ -22,15 +18,7 @@ You should have access to:
 - a Gemini API key
 - a customer-specific `LTBASE_RELEASES_TOKEN`
 
-- 一个可以创建私有仓库的 GitHub 组织或个人账号
-- 一个或多个将承载 `STACKS` 中各环境的 AWS 账户
-- 用于应用域名的 Cloudflare zone
-- 一个 Gemini API key
-- 一个客户专用的 `LTBASE_RELEASES_TOKEN`
-
 Install or confirm these local tools:
-
-安装或确认以下本地工具：
 
 - `git`
 - `gh` (GitHub CLI)
@@ -38,7 +26,7 @@ Install or confirm these local tools:
 - `pulumi`
 - `python3`
 
-## Steps / 操作步骤
+## Steps
 
 1. Confirm you can log in to GitHub from the CLI.
 2. Confirm you can access the AWS accounts that will host LTBase.
@@ -47,33 +35,17 @@ Install or confirm these local tools:
 5. Confirm you know the Cloudflare zone ID that will host the domains.
 6. Confirm you have both `LTBASE_RELEASES_TOKEN` and `GEMINI_API_KEY` ready.
 
-1. 确认你可以通过命令行登录 GitHub。
-2. 确认你可以访问将承载 LTBase 的 AWS 账户。
-3. 确认你已经知道 `STACKS` 中每个环境分别对应哪个 AWS 账户。
-4. 确认你已经确定将要创建的 GitHub 仓库名。
-5. 确认你已经知道托管域名的 Cloudflare zone ID。
-6. 确认你已经准备好 `LTBASE_RELEASES_TOKEN` 和 `GEMINI_API_KEY`。
-
-## Expected Result / 预期结果
+## Expected Result
 
 You have all required credentials and no longer need to pause the bootstrap process to ask for missing access.
 
-你已经拥有所有必需凭据，不会在 bootstrap 过程中因为缺少访问权限而中断。
-
-## Common Mistakes / 常见问题
+## Common Mistakes
 
 - using a GitHub account that cannot create private repositories
 - starting without the Cloudflare zone ID
 - starting without the customer-specific releases token
 - assuming one AWS profile can manage two different AWS accounts without switching credentials
 
-- 使用了无法创建私有仓库的 GitHub 账号
-- 在没有 Cloudflare zone ID 的情况下开始
-- 在没有客户专用 releases token 的情况下开始
-- 错误地认为一个 AWS profile 可以直接管理两个不同 AWS 账户而无需切换凭据
-
-## Next Step / 下一步
+## Next Step
 
 Continue with [`02-create-repo-and-clone.md`](02-create-repo-and-clone.md).
-
-继续阅读 [`02-create-repo-and-clone.md`](02-create-repo-and-clone.md)。

--- a/docs/onboarding/01-prerequisites.zh.md
+++ b/docs/onboarding/01-prerequisites.zh.md
@@ -1,0 +1,51 @@
+> **English version: [01-prerequisites.md](01-prerequisites.md)**
+
+# 准备前置条件
+
+返回主文档：[`../CUSTOMER_ONBOARDING.zh.md`](../CUSTOMER_ONBOARDING.zh.md)
+
+## 目的
+
+使用本文档确认你已经具备开始 bootstrap 所需的最小账户、权限和本地工具。
+
+## 开始前确认
+
+你应该已经可以访问：
+
+- 一个可以创建私有仓库的 GitHub 组织或个人账号
+- 一个或多个将承载 `STACKS` 中各环境的 AWS 账户
+- 用于应用域名的 Cloudflare zone
+- 一个 Gemini API key
+- 一个客户专用的 `LTBASE_RELEASES_TOKEN`
+
+安装或确认以下本地工具：
+
+- `git`
+- `gh` (GitHub CLI)
+- `aws` (AWS CLI)
+- `pulumi`
+- `python3`
+
+## 操作步骤
+
+1. 确认你可以通过命令行登录 GitHub。
+2. 确认你可以访问将承载 LTBase 的 AWS 账户。
+3. 确认你已经知道 `STACKS` 中每个环境分别对应哪个 AWS 账户。
+4. 确认你已经确定将要创建的 GitHub 仓库名。
+5. 确认你已经知道托管域名的 Cloudflare zone ID。
+6. 确认你已经准备好 `LTBASE_RELEASES_TOKEN` 和 `GEMINI_API_KEY`。
+
+## 预期结果
+
+你已经拥有所有必需凭据，不会在 bootstrap 过程中因为缺少访问权限而中断。
+
+## 常见问题
+
+- 使用了无法创建私有仓库的 GitHub 账号
+- 在没有 Cloudflare zone ID 的情况下开始
+- 在没有客户专用 releases token 的情况下开始
+- 错误地认为一个 AWS profile 可以直接管理两个不同 AWS 账户而无需切换凭据
+
+## 下一步
+
+继续阅读 [`02-create-repo-and-clone.zh.md`](02-create-repo-and-clone.zh.md)。

--- a/docs/onboarding/02-create-repo-and-clone.md
+++ b/docs/onboarding/02-create-repo-and-clone.md
@@ -1,24 +1,19 @@
-# Create the Deployment Repository and Clone It / 创建部署仓库并克隆到本地
+# Create the Deployment Repository and Clone It
+
+> **[中文版](02-create-repo-and-clone.zh.md)**
 
 Back to the main guide: [`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md)
 
-返回主文档：[`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md)
-
-## Purpose / 目的
+## Purpose
 
 Use this guide to create your customer-owned deployment repository from the template and verify that the local checkout contains the expected files.
 
-使用本文档从模板创建你的客户部署仓库，并确认本地仓库包含预期文件。
-
-## Before You Start / 开始前确认
+## Before You Start
 
 - complete [`01-prerequisites.md`](01-prerequisites.md)
 - know the target GitHub owner and repository name
 
-- 已完成 [`01-prerequisites.md`](01-prerequisites.md)
-- 已确定目标 GitHub owner 和仓库名
-
-## Steps / 操作步骤
+## Steps
 
 1. Create a new private repository from the `ltbase-private-deployment` template.
 2. Use a repository name that matches your internal naming convention.
@@ -39,43 +34,16 @@ Use this guide to create your customer-owned deployment repository from the temp
 5. Confirm that the repository is private.
 6. Confirm that the `prod` environment will be available for later approval gating.
 
-1. 从 `ltbase-private-deployment` 模板创建新的私有仓库。
-2. 使用符合你内部规范的仓库命名。
-3. 将新仓库 clone 到本地。
-4. 打开仓库根目录，确认以下内容存在：
-   - `infra/`
-   - `.github/workflows/`
-   - `env.template`
-   - `scripts/create-deployment-repo.sh`
-   - `scripts/render-bootstrap-policies.sh`
-   - `scripts/bootstrap-aws-foundation.sh`
-   - `scripts/bootstrap-pulumi-backend.sh`
-   - `scripts/bootstrap-oidc-discovery-companion.sh`
-   - `scripts/bootstrap-deployment-repo.sh`
-   - `scripts/bootstrap-all.sh`
-   - `scripts/evaluate-and-continue.sh`
-   - `scripts/reconcile-managed-dsql-endpoint.sh`
-5. 确认仓库是私有的。
-6. 确认后续用于审批的 `prod` environment 可以创建。
-
-## Expected Result / 预期结果
+## Expected Result
 
 You have a local working copy of your deployment repository and it matches the expected LTBase private deployment layout.
 
-你已经获得本地部署仓库副本，并且目录结构符合 LTBase 私有部署模板预期。
-
-## Common Mistakes / 常见问题
+## Common Mistakes
 
 - creating the repo manually without using the template
 - cloning the template repo instead of your own private repo
 - forgetting to verify that `.github/workflows/` and `infra/` exist
 
-- 手动创建空仓库而不是从模板生成
-- clone 错了仓库，拉到了模板仓库而不是自己的私有仓库
-- 没有确认 `.github/workflows/` 和 `infra/` 是否存在
-
-## Next Step / 下一步
+## Next Step
 
 Continue with [`03-create-oidc-and-deploy-roles.md`](03-create-oidc-and-deploy-roles.md).
-
-继续阅读 [`03-create-oidc-and-deploy-roles.md`](03-create-oidc-and-deploy-roles.md)。

--- a/docs/onboarding/02-create-repo-and-clone.zh.md
+++ b/docs/onboarding/02-create-repo-and-clone.zh.md
@@ -1,0 +1,49 @@
+# 创建部署仓库并克隆到本地
+
+> **[English](02-create-repo-and-clone.md)**
+
+返回主文档：[`../CUSTOMER_ONBOARDING.zh.md`](../CUSTOMER_ONBOARDING.zh.md)
+
+## 目的
+
+使用本文档从模板创建你的客户部署仓库，并确认本地仓库包含预期文件。
+
+## 开始前确认
+
+- 已完成 [`01-prerequisites.zh.md`](01-prerequisites.zh.md)
+- 已确定目标 GitHub owner 和仓库名
+
+## 操作步骤
+
+1. 从 `ltbase-private-deployment` 模板创建新的私有仓库。
+2. 使用符合你内部规范的仓库命名。
+3. 将新仓库 clone 到本地。
+4. 打开仓库根目录，确认以下内容存在：
+   - `infra/`
+   - `.github/workflows/`
+   - `env.template`
+   - `scripts/create-deployment-repo.sh`
+   - `scripts/render-bootstrap-policies.sh`
+   - `scripts/bootstrap-aws-foundation.sh`
+   - `scripts/bootstrap-pulumi-backend.sh`
+   - `scripts/bootstrap-oidc-discovery-companion.sh`
+   - `scripts/bootstrap-deployment-repo.sh`
+   - `scripts/bootstrap-all.sh`
+   - `scripts/evaluate-and-continue.sh`
+   - `scripts/reconcile-managed-dsql-endpoint.sh`
+5. 确认仓库是私有的。
+6. 确认后续用于审批的 `prod` environment 可以创建。
+
+## 预期结果
+
+你已经获得本地部署仓库副本，并且目录结构符合 LTBase 私有部署模板预期。
+
+## 常见问题
+
+- 手动创建空仓库而不是从模板生成
+- clone 错了仓库，拉到了模板仓库而不是自己的私有仓库
+- 没有确认 `.github/workflows/` 和 `infra/` 是否存在
+
+## 下一步
+
+继续阅读 [`03-create-oidc-and-deploy-roles.zh.md`](03-create-oidc-and-deploy-roles.zh.md)。

--- a/docs/onboarding/03-create-oidc-and-deploy-roles.md
+++ b/docs/onboarding/03-create-oidc-and-deploy-roles.md
@@ -1,32 +1,24 @@
-# Create GitHub OIDC and Deploy Roles / 创建 GitHub OIDC 与 Deploy Roles
+# Create GitHub OIDC and Deploy Roles
+
+> **[中文版](03-create-oidc-and-deploy-roles.zh.md)**
 
 Back to the main guide: [`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md)
 
-返回主文档：[`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md)
-
-## Purpose / 目的
+## Purpose
 
 Use this guide to prepare the AWS-side trust and deployment roles that GitHub Actions needs in order to preview and deploy LTBase.
 
-使用本文档准备 AWS 侧的信任关系与部署角色，让 GitHub Actions 可以执行 LTBase 的 preview 和 deploy。
-
-## Note for one-click bootstrap users / 一键 bootstrap 用户说明
+## Note for one-click bootstrap users
 
 If you plan to use the one-click bootstrap path (`evaluate-and-continue.sh`), the script runs `bootstrap-aws-foundation.sh` which creates OIDC providers and deploy roles automatically. In that case, use this page to **review and verify** what will be created, rather than creating resources manually. If your AWS permissions do not allow the script to create IAM resources, follow the manual steps below.
 
-如果你打算使用一键 bootstrap 路径（`evaluate-and-continue.sh`），该脚本会自动运行 `bootstrap-aws-foundation.sh` 来创建 OIDC provider 和 deploy role。在这种情况下，本页面的作用是让你 **提前了解和确认** 将会创建哪些资源，而不是手动创建它们。如果你的 AWS 权限不允许脚本自动创建 IAM 资源，请按下面的手动步骤操作。
-
-## Before You Start / 开始前确认
+## Before You Start
 
 - complete [`02-create-repo-and-clone.md`](02-create-repo-and-clone.md)
 - know the AWS account ID for every stack in `STACKS`
 - know your deployment repository full name, for example `customer-org/customer-ltbase`
 
-- 已完成 [`02-create-repo-and-clone.md`](02-create-repo-and-clone.md)
-- 已知道 `STACKS` 中每个环境对应的 AWS account ID
-- 已知道你的部署仓库全名，例如 `customer-org/customer-ltbase`
-
-## Steps / 操作步骤
+## Steps
 
 1. In each AWS account used for deployment, confirm whether the GitHub OIDC provider already exists.
 2. If it does not exist, create the provider for `https://token.actions.githubusercontent.com` with audience `sts.amazonaws.com`.
@@ -36,38 +28,20 @@ If you plan to use the one-click bootstrap path (`evaluate-and-continue.sh`), th
 6. Make a note of every resulting role ARN.
 7. If your stacks span multiple AWS accounts, confirm you can operate each account from your workstation, usually through separate AWS profiles.
 
-1. 在每个用于部署的 AWS 账户中，确认 GitHub OIDC provider 是否已经存在。
-2. 如果不存在，使用 `https://token.actions.githubusercontent.com` 和 audience `sts.amazonaws.com` 创建它。
-3. 为 `STACKS` 中的每个环境各创建一个 deploy role。
-4. 为两个角色分别附加 trust policy，允许你的部署仓库中的 GitHub Actions assume 该角色。
-5. 为角色附加足以完成首次 bootstrap 与首次部署的 permissions policy。
-6. 记录每个角色最终的 ARN。
-7. 如果这些环境跨越多个 AWS 账户，确认你的工作站可以操作每个账户，通常通过不同 AWS profile 完成。
-
-## Practical Tip / 实操建议
+## Practical Tip
 
 If you want the template to generate copy-paste policy files for review, do that after `.env` is ready by using `./scripts/render-bootstrap-policies.sh --env-file .env`.
 
-如果你希望模板先生成可复制的策略文件供审阅，请在 `.env` 准备完成之后运行 `./scripts/render-bootstrap-policies.sh --env-file .env`。
-
-## Expected Result / 预期结果
+## Expected Result
 
 You now have a working OIDC trust chain and one deploy role per stack whose ARN can be placed into `.env`.
 
-你现在已经具备可用的 OIDC 信任链，以及每个 stack 都可写入 `.env` 的 deploy role ARN。
-
-## Common Mistakes / 常见问题
+## Common Mistakes
 
 - creating only one role and trying to reuse it for multiple stacks
 - forgetting to include the deployment repository name in the trust policy
 - using permissions that are too narrow for the first deployment
 
-- 只创建一个角色，然后尝试让多个 stack 共用
-- 在 trust policy 中遗漏部署仓库名称
-- 给首次部署分配了过窄的权限，导致 bootstrap 失败
-
-## Next Step / 下一步
+## Next Step
 
 Continue with [`04-prepare-env-file.md`](04-prepare-env-file.md).
-
-继续阅读 [`04-prepare-env-file.md`](04-prepare-env-file.md)。

--- a/docs/onboarding/03-create-oidc-and-deploy-roles.zh.md
+++ b/docs/onboarding/03-create-oidc-and-deploy-roles.zh.md
@@ -1,0 +1,47 @@
+# 创建 GitHub OIDC 与 Deploy Roles
+
+> **[English](03-create-oidc-and-deploy-roles.md)**
+
+返回主文档：[`../CUSTOMER_ONBOARDING.zh.md`](../CUSTOMER_ONBOARDING.zh.md)
+
+## 目的
+
+使用本文档准备 AWS 侧的信任关系与部署角色，让 GitHub Actions 可以执行 LTBase 的 preview 和 deploy。
+
+## 一键 bootstrap 用户说明
+
+如果你打算使用一键 bootstrap 路径（`evaluate-and-continue.sh`），该脚本会自动运行 `bootstrap-aws-foundation.sh` 来创建 OIDC provider 和 deploy role。在这种情况下，本页面的作用是让你 **提前了解和确认** 将会创建哪些资源，而不是手动创建它们。如果你的 AWS 权限不允许脚本自动创建 IAM 资源，请按下面的手动步骤操作。
+
+## 开始前确认
+
+- 已完成 [`02-create-repo-and-clone.zh.md`](02-create-repo-and-clone.zh.md)
+- 已知道 `STACKS` 中每个环境对应的 AWS account ID
+- 已知道你的部署仓库全名，例如 `customer-org/customer-ltbase`
+
+## 操作步骤
+
+1. 在每个用于部署的 AWS 账户中，确认 GitHub OIDC provider 是否已经存在。
+2. 如果不存在，使用 `https://token.actions.githubusercontent.com` 和 audience `sts.amazonaws.com` 创建它。
+3. 为 `STACKS` 中的每个环境各创建一个 deploy role。
+4. 为两个角色分别附加 trust policy，允许你的部署仓库中的 GitHub Actions assume 该角色。
+5. 为角色附加足以完成首次 bootstrap 与首次部署的 permissions policy。
+6. 记录每个角色最终的 ARN。
+7. 如果这些环境跨越多个 AWS 账户，确认你的工作站可以操作每个账户，通常通过不同 AWS profile 完成。
+
+## 实操建议
+
+如果你希望模板先生成可复制的策略文件供审阅，请在 `.env` 准备完成之后运行 `./scripts/render-bootstrap-policies.sh --env-file .env`。
+
+## 预期结果
+
+你现在已经具备可用的 OIDC 信任链，以及每个 stack 都可写入 `.env` 的 deploy role ARN。
+
+## 常见问题
+
+- 只创建一个角色，然后尝试让多个 stack 共用
+- 在 trust policy 中遗漏部署仓库名称
+- 给首次部署分配了过窄的权限，导致 bootstrap 失败
+
+## 下一步
+
+继续阅读 [`04-prepare-env-file.zh.md`](04-prepare-env-file.zh.md)。

--- a/docs/onboarding/04-prepare-env-file.md
+++ b/docs/onboarding/04-prepare-env-file.md
@@ -1,24 +1,19 @@
-# Prepare the Local .env File / 准备本地 .env 文件
+# Prepare the Local .env File
+
+> **[中文版](04-prepare-env-file.zh.md)**
 
 Back to the main guide: [`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md)
 
-返回主文档：[`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md)
-
-## Purpose / 目的
+## Purpose
 
 Use this guide to create the local `.env` file that drives the bootstrap scripts and repository configuration.
 
-使用本文档创建本地 `.env` 文件，该文件将驱动 bootstrap 脚本和仓库配置。
-
-## Before You Start / 开始前确认
+## Before You Start
 
 - complete [`03-create-oidc-and-deploy-roles.md`](03-create-oidc-and-deploy-roles.md)
 - have the final GitHub repository name, AWS account IDs, role ARNs, and domain values ready
 
-- 已完成 [`03-create-oidc-and-deploy-roles.md`](03-create-oidc-and-deploy-roles.md)
-- 已准备好 GitHub 仓库名、AWS account ID、role ARN、域名等最终值
-
-## Steps / 操作步骤
+## Steps
 
 1. Copy `env.template` to `.env`.
 2. Fill in stack topology:
@@ -59,46 +54,7 @@ Use this guide to create the local `.env` file that drives the bootstrap scripts
     - `LTBASE_RELEASES_TOKEN`
 11. Save the file locally and confirm it is not committed.
 
-1. 将 `env.template` 复制为 `.env`。
-2. 填写 stack 拓扑：
-   - `STACKS` — 逗号分隔的环境名列表，例如 `devo,prod`
-   - `PROMOTION_PATH` — promotion 顺序，例如 `devo,prod`
-3. 填写模板与仓库标识：
-   - `TEMPLATE_REPO`
-   - `GITHUB_OWNER`
-   - `DEPLOYMENT_REPO_NAME`
-   - `DEPLOYMENT_REPO_VISIBILITY`
-   - `DEPLOYMENT_REPO_DESCRIPTION`
-4. 填写 OIDC discovery 信息：
-   - `OIDC_DISCOVERY_DOMAIN`
-   - `CLOUDFLARE_ACCOUNT_ID`
-5. 填写 AWS 环境信息（每个 stack 一组）：
-   - `AWS_REGION_DEVO`、`AWS_REGION_PROD`
-   - `AWS_ACCOUNT_ID_DEVO`、`AWS_ACCOUNT_ID_PROD`
-   - `AWS_ROLE_NAME_DEVO`、`AWS_ROLE_NAME_PROD`
-6. 填写 Pulumi backend 信息：
-   - `PULUMI_STATE_BUCKET`
-   - `PULUMI_KMS_ALIAS`
-   - `PULUMI_PROJECT`
-   - 如果你希望由 bootstrap 自动生成 `PULUMI_BACKEND_URL`、`PULUMI_SECRETS_PROVIDER_DEVO`、`PULUMI_SECRETS_PROVIDER_PROD`，可先留空
-7. 填写 release 信息：
-   - `LTBASE_RELEASES_REPO`
-   - `LTBASE_RELEASE_ID`
-8. 填写按 stack 划分的域名信息：
-   - `API_DOMAIN_DEVO`、`API_DOMAIN_PROD`
-   - `CONTROL_DOMAIN_DEVO`、`CONTROL_DOMAIN_PROD`
-   - `AUTH_DOMAIN_DEVO`、`AUTH_DOMAIN_PROD`
-   - `CLOUDFLARE_ZONE_ID`
-9. 填写应用默认值：
-   - `GEMINI_MODEL`
-   - `DSQL_PORT`、`DSQL_DB`、`DSQL_USER`、`DSQL_PROJECT_SCHEMA`
-10. 填写 secrets：
-    - `GEMINI_API_KEY`
-    - `CLOUDFLARE_API_TOKEN`
-    - `LTBASE_RELEASES_TOKEN`
-11. 将文件保存在本地，并确认不会提交进仓库。
-
-## Important Rules / 重要规则
+## Important Rules
 
 - do not commit `.env`
 - do not put production secrets into tracked files
@@ -106,35 +62,20 @@ Use this guide to create the local `.env` file that drives the bootstrap scripts
 - only fill values you actually control; generated values should come from bootstrap outputs
 - the following variables are auto-derived by `scripts/lib/bootstrap-env.sh` and normally do not need manual filling: `DEPLOYMENT_REPO`, `AWS_PROFILE_*`, `PULUMI_BACKEND_URL`, `PULUMI_SECRETS_PROVIDER_*`, `OIDC_ISSUER_URL_*`, `JWKS_URL_*`, `RUNTIME_BUCKET_*`, `TABLE_NAME_*`, `GITHUB_ORG`, `GITHUB_REPO`, `OIDC_DISCOVERY_TEMPLATE_REPO`, `OIDC_DISCOVERY_REPO_NAME`, `OIDC_DISCOVERY_REPO`, `OIDC_DISCOVERY_PAGES_PROJECT`, `OIDC_DISCOVERY_AWS_ROLE_NAME_*`
 
-- 不要提交 `.env`
-- 不要把生产 secrets 写进被版本控制的文件
-- 如果你依赖 bootstrap 创建 backend 资源，请把 `PULUMI_BACKEND_URL` 和 `PULUMI_SECRETS_PROVIDER_*` 当作生成值
-- 只填写你真正控制的输入项，生成值应来自 bootstrap 输出
-- 以下变量由 `scripts/lib/bootstrap-env.sh` 自动派生，通常不需要手动填写：`DEPLOYMENT_REPO`、`AWS_PROFILE_*`、`PULUMI_BACKEND_URL`、`PULUMI_SECRETS_PROVIDER_*`、`OIDC_ISSUER_URL_*`、`JWKS_URL_*`、`RUNTIME_BUCKET_*`、`TABLE_NAME_*`、`GITHUB_ORG`、`GITHUB_REPO`、`OIDC_DISCOVERY_TEMPLATE_REPO`、`OIDC_DISCOVERY_REPO_NAME`、`OIDC_DISCOVERY_REPO`、`OIDC_DISCOVERY_PAGES_PROJECT`、`OIDC_DISCOVERY_AWS_ROLE_NAME_*`
-
-## Expected Result / 预期结果
+## Expected Result
 
 You now have a complete local `.env` file that can be used by the bootstrap scripts.
 
-你现在已经拥有一个完整的本地 `.env` 文件，可供 bootstrap 脚本使用。
-
-## Common Mistakes / 常见问题
+## Common Mistakes
 
 - mixing placeholder values with real values
 - setting the wrong repository name in `DEPLOYMENT_REPO`
 - forgetting to update the AWS account IDs to match the target roles
 - committing `.env` by accident
 
-- 将占位符和真实值混在一起使用
-- `DEPLOYMENT_REPO` 写成了错误的仓库名
-- 忘记让 AWS account ID 与目标角色匹配
-- 误把 `.env` 提交到仓库
-
-## Next Step / 下一步
+## Next Step
 
 Choose one bootstrap path:
-
-选择一个 bootstrap 路径：
 
 - one-click: [`05-bootstrap-one-click.md`](05-bootstrap-one-click.md)
 - manual: [`06-bootstrap-manual.md`](06-bootstrap-manual.md)

--- a/docs/onboarding/04-prepare-env-file.zh.md
+++ b/docs/onboarding/04-prepare-env-file.zh.md
@@ -1,0 +1,81 @@
+# 准备本地 .env 文件
+
+> **[English](04-prepare-env-file.md)**
+
+返回主文档：[`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.zh.md)
+
+## 目的
+
+使用本文档创建本地 `.env` 文件，该文件将驱动 bootstrap 脚本和仓库配置。
+
+## 开始前确认
+
+- 已完成 [`03-create-oidc-and-deploy-roles.zh.md`](03-create-oidc-and-deploy-roles.zh.md)
+- 已准备好 GitHub 仓库名、AWS account ID、role ARN、域名等最终值
+
+## 操作步骤
+
+1. 将 `env.template` 复制为 `.env`。
+2. 填写 stack 拓扑：
+   - `STACKS` — 逗号分隔的环境名列表，例如 `devo,prod`
+   - `PROMOTION_PATH` — promotion 顺序，例如 `devo,prod`
+3. 填写模板与仓库标识：
+   - `TEMPLATE_REPO`
+   - `GITHUB_OWNER`
+   - `DEPLOYMENT_REPO_NAME`
+   - `DEPLOYMENT_REPO_VISIBILITY`
+   - `DEPLOYMENT_REPO_DESCRIPTION`
+4. 填写 OIDC discovery 信息：
+   - `OIDC_DISCOVERY_DOMAIN`
+   - `CLOUDFLARE_ACCOUNT_ID`
+5. 填写 AWS 环境信息（每个 stack 一组）：
+   - `AWS_REGION_DEVO`、`AWS_REGION_PROD`
+   - `AWS_ACCOUNT_ID_DEVO`、`AWS_ACCOUNT_ID_PROD`
+   - `AWS_ROLE_NAME_DEVO`、`AWS_ROLE_NAME_PROD`
+6. 填写 Pulumi backend 信息：
+   - `PULUMI_STATE_BUCKET`
+   - `PULUMI_KMS_ALIAS`
+   - `PULUMI_PROJECT`
+   - 如果你希望由 bootstrap 自动生成 `PULUMI_BACKEND_URL`、`PULUMI_SECRETS_PROVIDER_DEVO`、`PULUMI_SECRETS_PROVIDER_PROD`，可先留空
+7. 填写 release 信息：
+   - `LTBASE_RELEASES_REPO`
+   - `LTBASE_RELEASE_ID`
+8. 填写按 stack 划分的域名信息：
+   - `API_DOMAIN_DEVO`、`API_DOMAIN_PROD`
+   - `CONTROL_DOMAIN_DEVO`、`CONTROL_DOMAIN_PROD`
+   - `AUTH_DOMAIN_DEVO`、`AUTH_DOMAIN_PROD`
+   - `CLOUDFLARE_ZONE_ID`
+9. 填写应用默认值：
+   - `GEMINI_MODEL`
+   - `DSQL_PORT`、`DSQL_DB`、`DSQL_USER`、`DSQL_PROJECT_SCHEMA`
+10. 填写 secrets：
+    - `GEMINI_API_KEY`
+    - `CLOUDFLARE_API_TOKEN`
+    - `LTBASE_RELEASES_TOKEN`
+11. 将文件保存在本地，并确认不会提交进仓库。
+
+## 重要规则
+
+- 不要提交 `.env`
+- 不要把生产 secrets 写进被版本控制的文件
+- 如果你依赖 bootstrap 创建 backend 资源，请把 `PULUMI_BACKEND_URL` 和 `PULUMI_SECRETS_PROVIDER_*` 当作生成值
+- 只填写你真正控制的输入项，生成值应来自 bootstrap 输出
+- 以下变量由 `scripts/lib/bootstrap-env.sh` 自动派生，通常不需要手动填写：`DEPLOYMENT_REPO`、`AWS_PROFILE_*`、`PULUMI_BACKEND_URL`、`PULUMI_SECRETS_PROVIDER_*`、`OIDC_ISSUER_URL_*`、`JWKS_URL_*`、`RUNTIME_BUCKET_*`、`TABLE_NAME_*`、`GITHUB_ORG`、`GITHUB_REPO`、`OIDC_DISCOVERY_TEMPLATE_REPO`、`OIDC_DISCOVERY_REPO_NAME`、`OIDC_DISCOVERY_REPO`、`OIDC_DISCOVERY_PAGES_PROJECT`、`OIDC_DISCOVERY_AWS_ROLE_NAME_*`
+
+## 预期结果
+
+你现在已经拥有一个完整的本地 `.env` 文件，可供 bootstrap 脚本使用。
+
+## 常见问题
+
+- 将占位符和真实值混在一起使用
+- `DEPLOYMENT_REPO` 写成了错误的仓库名
+- 忘记让 AWS account ID 与目标角色匹配
+- 误把 `.env` 提交到仓库
+
+## 下一步
+
+选择一个 bootstrap 路径：
+
+- 一键部署：[`05-bootstrap-one-click.zh.md`](05-bootstrap-one-click.zh.md)
+- 手动部署：[`06-bootstrap-manual.zh.md`](06-bootstrap-manual.zh.md)

--- a/docs/onboarding/05-bootstrap-one-click.md
+++ b/docs/onboarding/05-bootstrap-one-click.md
@@ -1,24 +1,19 @@
-# One-Click Bootstrap / 一键 Bootstrap
+> **[中文版](05-bootstrap-one-click.zh.md)**
+
+# One-Click Bootstrap
 
 Back to the main guide: [`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md)
 
-返回主文档：[`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md)
-
-## Purpose / 目的
+## Purpose
 
 Use this guide when you want the repository creation, policy rendering, AWS foundation setup, stack bootstrap, and optional rollout trigger to run from one recovery-aware command.
 
-如果你希望通过一个可恢复命令完成仓库创建、策略生成、AWS 基础设施初始化、stack bootstrap，以及可选的 rollout 触发，请使用本文档。
-
-## Before You Start / 开始前确认
+## Before You Start
 
 - complete [`04-prepare-env-file.md`](04-prepare-env-file.md)
 - have enough GitHub and AWS permissions to create and update all required resources
 
-- 已完成 [`04-prepare-env-file.md`](04-prepare-env-file.md)
-- 拥有足够的 GitHub 和 AWS 权限来创建和更新所需资源
-
-## Steps / 操作步骤
+## Steps
 
 1. Open a terminal in the root of your deployment repository.
 2. Confirm `.env` exists and contains the values you prepared.
@@ -31,8 +26,6 @@ Use this guide when you want the repository creation, policy rendering, AWS foun
 
 If you also want bootstrap to trigger the first rollout automatically, include the release tag:
 
-如果你还希望在 bootstrap 完成后自动触发第一次 rollout，请同时提供 release tag：
-
 ```bash
 ./scripts/evaluate-and-continue.sh --env-file .env --scope bootstrap --force --infra-dir infra --release-id v1.0.0
 ```
@@ -42,25 +35,9 @@ If you also want bootstrap to trigger the first rollout automatically, include t
 7. Confirm GitHub variables and secrets were created in the deployment repository.
 8. Confirm every stack in `STACKS` was initialized.
 
-1. 在部署仓库根目录打开终端。
-2. 确认 `.env` 已存在且已填好需要的值。
-3. 如果你使用分离的 AWS 账户，请在执行 bootstrap 前导出正确的 AWS 凭据或 profile。
-4. 执行：
-
-```bash
-./scripts/evaluate-and-continue.sh --env-file .env --scope bootstrap --force --infra-dir infra
-```
-
-5. 等待脚本执行完成。
-6. 检查 `dist/` 中生成的文件。
-7. 确认部署仓库中的 GitHub variables 和 secrets 已创建。
-8. 确认 `STACKS` 中的每个 Pulumi stack 都已初始化。
-
-## What This Command Does / 这个命令会做什么
+## What This Command Does
 
 The one-click script runs these stages in order:
-
-一键脚本会按顺序执行这些阶段：
 
 - `create-deployment-repo.sh`
 - `render-bootstrap-policies.sh`
@@ -69,24 +46,16 @@ The one-click script runs these stages in order:
 - `bootstrap-deployment-repo.sh --stack <each stack in STACKS>`
 - optional `gh workflow run rollout.yml ...` when `--release-id` is set
 
-## Expected Result / 预期结果
+## Expected Result
 
 You finish with repository configuration written to GitHub, Pulumi stacks initialized for every configured environment, and optionally the first rollout already queued.
 
-执行完成后，你应该获得已经写入 GitHub 的仓库配置、为所有已配置环境初始化好的 Pulumi stack，以及在需要时已经排队的第一次 rollout。
-
-## Common Mistakes / 常见问题
+## Common Mistakes
 
 - trying one-click bootstrap without enough GitHub permissions
 - trying one-click bootstrap without enough AWS permissions
 - forgetting to prepare split-account credentials before running the script
 
-- 在 GitHub 权限不足时尝试一键 bootstrap
-- 在 AWS 权限不足时尝试一键 bootstrap
-- 在多账户场景下忘记先准备好对应凭据再执行脚本
-
-## Next Step / 下一步
+## Next Step
 
 Continue with [`07-first-deploy-and-managed-dsql.md`](07-first-deploy-and-managed-dsql.md).
-
-继续阅读 [`07-first-deploy-and-managed-dsql.md`](07-first-deploy-and-managed-dsql.md)。

--- a/docs/onboarding/05-bootstrap-one-click.zh.md
+++ b/docs/onboarding/05-bootstrap-one-click.zh.md
@@ -1,0 +1,61 @@
+> **[English](05-bootstrap-one-click.md)**
+
+# 一键 Bootstrap
+
+返回主文档：[`../CUSTOMER_ONBOARDING.zh.md`](../CUSTOMER_ONBOARDING.zh.md)
+
+## 目的
+
+如果你希望通过一个可恢复命令完成仓库创建、策略生成、AWS 基础设施初始化、stack bootstrap，以及可选的 rollout 触发，请使用本文档。
+
+## 开始前确认
+
+- 已完成 [`04-prepare-env-file.zh.md`](04-prepare-env-file.zh.md)
+- 拥有足够的 GitHub 和 AWS 权限来创建和更新所需资源
+
+## 操作步骤
+
+1. 在部署仓库根目录打开终端。
+2. 确认 `.env` 已存在且已填好需要的值。
+3. 如果你使用分离的 AWS 账户，请在执行 bootstrap 前导出正确的 AWS 凭据或 profile。
+4. 执行：
+
+```bash
+./scripts/evaluate-and-continue.sh --env-file .env --scope bootstrap --force --infra-dir infra
+```
+
+如果你还希望在 bootstrap 完成后自动触发第一次 rollout，请同时提供 release tag：
+
+```bash
+./scripts/evaluate-and-continue.sh --env-file .env --scope bootstrap --force --infra-dir infra --release-id v1.0.0
+```
+
+5. 等待脚本执行完成。
+6. 检查 `dist/` 中生成的文件。
+7. 确认部署仓库中的 GitHub variables 和 secrets 已创建。
+8. 确认 `STACKS` 中的每个 Pulumi stack 都已初始化。
+
+## 这个命令会做什么
+
+一键脚本会按顺序执行这些阶段：
+
+- `create-deployment-repo.sh`
+- `render-bootstrap-policies.sh`
+- `bootstrap-aws-foundation.sh`
+- `bootstrap-oidc-discovery-companion.sh`
+- `bootstrap-deployment-repo.sh --stack <each stack in STACKS>`
+- optional `gh workflow run rollout.yml ...` when `--release-id` is set
+
+## 预期结果
+
+执行完成后，你应该获得已经写入 GitHub 的仓库配置、为所有已配置环境初始化好的 Pulumi stack，以及在需要时已经排队的第一次 rollout。
+
+## 常见问题
+
+- 在 GitHub 权限不足时尝试一键 bootstrap
+- 在 AWS 权限不足时尝试一键 bootstrap
+- 在多账户场景下忘记先准备好对应凭据再执行脚本
+
+## 下一步
+
+继续阅读 [`07-first-deploy-and-managed-dsql.zh.md`](07-first-deploy-and-managed-dsql.zh.md)。

--- a/docs/onboarding/06-bootstrap-manual.md
+++ b/docs/onboarding/06-bootstrap-manual.md
@@ -1,48 +1,37 @@
-# Manual Bootstrap / 手动 Bootstrap
+# Manual Bootstrap
+
+> **[中文版](06-bootstrap-manual.zh.md)**
 
 Back to the main guide: [`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md)
 
-返回主文档：[`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md)
-
-## Purpose / 目的
+## Purpose
 
 Use this guide when you want to review each bootstrap stage separately instead of running the one-click path.
 
-如果你希望逐步检查每个 bootstrap 阶段，而不是使用一键流程，请使用本文档。
-
-## Before You Start / 开始前确认
+## Before You Start
 
 - complete [`04-prepare-env-file.md`](04-prepare-env-file.md)
 - decide that you want to control each bootstrap stage manually
 
-- 已完成 [`04-prepare-env-file.md`](04-prepare-env-file.md)
-- 已决定手动控制每一个 bootstrap 阶段
+## Steps
 
-## Steps / 操作步骤
-
-### 1. Create the real deployment repo / 创建真实部署仓库
+### 1. Create the real deployment repo
 
 Run:
-
-执行：
 
 ```bash
 ./scripts/create-deployment-repo.sh --env-file .env
 ```
 
-### 2. Bootstrap AWS foundation / 初始化 AWS 基础资源
+### 2. Bootstrap AWS foundation
 
 Run:
-
-执行：
 
 ```bash
 ./scripts/bootstrap-aws-foundation.sh --env-file .env
 ```
 
 This step creates or updates:
-
-该步骤会创建或更新：
 
 - GitHub OIDC provider
 - deploy roles
@@ -53,33 +42,25 @@ This step creates or updates:
 
 It also generates `dist/foundation.env` and review artifacts.
 
-它还会生成 `dist/foundation.env` 和审阅用文件。
-
-### 3. Optionally merge generated foundation values / 可选：合并自动生成的 foundation 值
+### 3. Optionally merge generated foundation values
 
 If bootstrap generated new Pulumi backend values, merge them into your shell or `.env`:
-
-如果 bootstrap 生成了新的 Pulumi backend 值，请将它们合并回 shell 或 `.env`：
 
 ```bash
 source dist/foundation.env
 ```
 
-### 4. Bootstrap Pulumi backend only if needed / 仅在需要时单独初始化 Pulumi backend
+### 4. Bootstrap Pulumi backend only if needed
 
 Run this if you want the backend/KMS path separately:
-
-如果你希望单独执行 backend/KMS 流程，可运行：
 
 ```bash
 ./scripts/bootstrap-pulumi-backend.sh --env-file .env
 ```
 
-### 5. Bootstrap every configured stack / 初始化所有已配置 stack
+### 5. Bootstrap every configured stack
 
 Run:
-
-执行：
 
 ```bash
 ./scripts/bootstrap-deployment-repo.sh --env-file .env --stack <stack> --infra-dir infra
@@ -87,13 +68,9 @@ Run:
 
 Repeat the command once for each stack listed in `STACKS`, in the same order as `PROMOTION_PATH`.
 
-对 `STACKS` 中列出的每个 stack 都执行一次，顺序与 `PROMOTION_PATH` 保持一致。
-
-### 6. Bootstrap OIDC discovery companion / 初始化 OIDC discovery 配套资源
+### 6. Bootstrap OIDC discovery companion
 
 Run:
-
-执行：
 
 ```bash
 ./scripts/bootstrap-oidc-discovery-companion.sh --env-file .env
@@ -101,32 +78,20 @@ Run:
 
 This step creates or updates the OIDC discovery companion repository, Cloudflare Pages project, custom domain binding, and per-stack OIDC discovery IAM roles.
 
-该步骤会创建或更新 OIDC discovery 配套仓库、Cloudflare Pages 项目、自定义域名绑定，以及每个 stack 对应的 OIDC discovery IAM role。
-
-### 7. Confirm repository configuration / 确认仓库配置完成
+### 7. Confirm repository configuration
 
 Check that the repository now contains the required GitHub secrets and variables.
 
-确认仓库中已经出现所需 GitHub secrets 和 variables。
-
-## Expected Result / 预期结果
+## Expected Result
 
 You finish with all bootstrap stages completed manually and the repository is ready for the first preview and deployment.
 
-执行完成后，所有 bootstrap 阶段都已手动完成，仓库已可用于第一次 preview 和 deployment。
-
-## Common Mistakes / 常见问题
+## Common Mistakes
 
 - forgetting to source `dist/foundation.env` after AWS foundation generated new values
 - skipping later stacks in `STACKS` and only preparing the first stack
 - running manual bootstrap commands outside the repository root
 
-- 在 AWS foundation 生成新值后忘记 `source dist/foundation.env`
-- 只初始化了第一个 stack，没有初始化 `STACKS` 中后续环境
-- 在仓库根目录之外执行手动 bootstrap 命令
-
-## Next Step / 下一步
+## Next Step
 
 Continue with [`07-first-deploy-and-managed-dsql.md`](07-first-deploy-and-managed-dsql.md).
-
-继续阅读 [`07-first-deploy-and-managed-dsql.md`](07-first-deploy-and-managed-dsql.md)。

--- a/docs/onboarding/06-bootstrap-manual.zh.md
+++ b/docs/onboarding/06-bootstrap-manual.zh.md
@@ -1,0 +1,97 @@
+# 手动 Bootstrap
+
+> **[English](06-bootstrap-manual.md)**
+
+返回主文档：[`../CUSTOMER_ONBOARDING.zh.md`](../CUSTOMER_ONBOARDING.zh.md)
+
+## 目的
+
+如果你希望逐步检查每个 bootstrap 阶段，而不是使用一键流程，请使用本文档。
+
+## 开始前确认
+
+- 已完成 [`04-prepare-env-file.zh.md`](04-prepare-env-file.zh.md)
+- 已决定手动控制每一个 bootstrap 阶段
+
+## 操作步骤
+
+### 1. 创建真实部署仓库
+
+执行：
+
+```bash
+./scripts/create-deployment-repo.sh --env-file .env
+```
+
+### 2. 初始化 AWS 基础资源
+
+执行：
+
+```bash
+./scripts/bootstrap-aws-foundation.sh --env-file .env
+```
+
+该步骤会创建或更新：
+
+- GitHub OIDC provider
+- deploy roles
+- trust policies
+- inline role policies
+- Pulumi state bucket
+- Pulumi KMS alias
+
+它还会生成 `dist/foundation.env` 和审阅用文件。
+
+### 3. 可选：合并自动生成的 foundation 值
+
+如果 bootstrap 生成了新的 Pulumi backend 值，请将它们合并回 shell 或 `.env`：
+
+```bash
+source dist/foundation.env
+```
+
+### 4. 仅在需要时单独初始化 Pulumi backend
+
+如果你希望单独执行 backend/KMS 流程，可运行：
+
+```bash
+./scripts/bootstrap-pulumi-backend.sh --env-file .env
+```
+
+### 5. 初始化所有已配置 stack
+
+执行：
+
+```bash
+./scripts/bootstrap-deployment-repo.sh --env-file .env --stack <stack> --infra-dir infra
+```
+
+对 `STACKS` 中列出的每个 stack 都执行一次，顺序与 `PROMOTION_PATH` 保持一致。
+
+### 6. 初始化 OIDC discovery 配套资源
+
+执行：
+
+```bash
+./scripts/bootstrap-oidc-discovery-companion.sh --env-file .env
+```
+
+该步骤会创建或更新 OIDC discovery 配套仓库、Cloudflare Pages 项目、自定义域名绑定，以及每个 stack 对应的 OIDC discovery IAM role。
+
+### 7. 确认仓库配置完成
+
+确认仓库中已经出现所需 GitHub secrets 和 variables。
+
+## 预期结果
+
+执行完成后，所有 bootstrap 阶段都已手动完成，仓库已可用于第一次 preview 和 deployment。
+
+## 常见问题
+
+- 在 AWS foundation 生成新值后忘记 `source dist/foundation.env`
+- 只初始化了第一个 stack，没有初始化 `STACKS` 中后续环境
+- 在仓库根目录之外执行手动 bootstrap 命令
+
+## 下一步
+
+继续阅读 [`07-first-deploy-and-managed-dsql.zh.md`](07-first-deploy-and-managed-dsql.zh.md)。

--- a/docs/onboarding/07-first-deploy-and-managed-dsql.md
+++ b/docs/onboarding/07-first-deploy-and-managed-dsql.md
@@ -1,101 +1,66 @@
-# First Deploy and Managed DSQL Handling / 首次部署与 Managed DSQL 处理
+# First Deploy and Managed DSQL Handling
+
+> **[中文版](07-first-deploy-and-managed-dsql.zh.md)**
 
 Back to the main guide: [`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md)
 
-返回主文档：[`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md)
-
-## Purpose / 目的
+## Purpose
 
 Use this guide to run the first preview and rollout workflows after bootstrap, and to understand how managed DSQL should be treated in the current customer repository flow.
 
-使用本文档在 bootstrap 完成后执行第一次 preview 与 rollout 工作流，并理解当前客户仓库流程下 managed DSQL 的处理方式。
-
-## Before You Start / 开始前确认
+## Before You Start
 
 - complete either [`05-bootstrap-one-click.md`](05-bootstrap-one-click.md) or [`06-bootstrap-manual.md`](06-bootstrap-manual.md)
 - confirm the required GitHub secrets and variables are present
 
-- 已完成 [`05-bootstrap-one-click.md`](05-bootstrap-one-click.md) 或 [`06-bootstrap-manual.md`](06-bootstrap-manual.md)
-- 已确认所需的 GitHub secrets 和 variables 已存在
+## Steps
 
-## Steps / 操作步骤
-
-### 1. Run the preview workflow / 执行 preview 工作流
+### 1. Run the preview workflow
 
 Open GitHub Actions in your deployment repository and run the `Preview LTBase Blueprint` workflow for the first stack in `PROMOTION_PATH`.
 
-打开部署仓库中的 GitHub Actions，针对 `PROMOTION_PATH` 中的第一个 stack 手动运行 `Preview LTBase Blueprint` 工作流。
-
 Use the `release_id` input if you want to override `vars.LTBASE_RELEASE_ID`.
 
-如果你想覆盖 `vars.LTBASE_RELEASE_ID`，请填写 `release_id` 输入参数。
-
-### 2. Review the preview output / 审查 preview 输出
+### 2. Review the preview output
 
 Confirm that the Pulumi preview matches your expected infrastructure changes.
 
-确认 Pulumi preview 输出与你预期的基础设施变更一致。
-
-### 3. Start the rollout workflow / 启动 rollout 工作流
+### 3. Start the rollout workflow
 
 Run the `Rollout LTBase Release` workflow and provide the release tag you want to deploy.
 
-运行 `Rollout LTBase Release` 工作流，并填写你希望部署的 release tag。
-
 This workflow deploys the first stack in `PROMOTION_PATH`, then automatically dispatches the next hop after each successful deployment.
 
-该工作流会先部署 `PROMOTION_PATH` 的第一个 stack，并在每次成功部署后自动派发下一跳。
-
-### 4. Verify each deployed environment / 验证每个已部署环境
+### 4. Verify each deployed environment
 
 Confirm the first deployed environment works before approving the next protected target stack.
 
-在审批下一个受保护目标环境之前，先确认当前已部署环境工作正常。
-
-### 5. Approve protected target environments / 审批受保护目标环境
+### 5. Approve protected target environments
 
 When GitHub requests approval for a protected target stack, approve it from the matching GitHub environment gate in your repository.
 
-当 GitHub 请求某个受保护目标 stack 的审批时，请在你的仓库中对应的 GitHub environment gate 完成审批。
-
-### 6. Optional manual single-hop promotion / 可选：手动执行单跳 promotion
+### 6. Optional manual single-hop promotion
 
 If you need to recover or replay only one hop, use `Promote LTBase Between Stacks` and provide `from_stack`, `to_stack`, and the same release tag. Invalid jumps fail fast.
 
-如果你只需要恢复或重放某一跳，可以使用 `Promote LTBase Between Stacks`，并提供 `from_stack`、`to_stack` 与同一个 release tag。非法跳转会立即失败。
-
-## Managed DSQL Guidance / Managed DSQL 指引
+## Managed DSQL Guidance
 
 In this repository version, customers should not manually provide external `dsqlHost`, `dsqlEndpoint`, or `dsqlPassword` values for managed deployments.
 
-在当前仓库版本中，managed 部署不应由客户手动提供外部 `dsqlHost`、`dsqlEndpoint` 或 `dsqlPassword`。
-
 Treat managed DSQL details as deployment-owned state produced by the infrastructure and release workflow of the repository version you are using.
-
-请将 managed DSQL 的具体连接信息视为由你当前仓库版本的基础设施与发布流程生成和维护的部署状态。
 
 In the current repository version, follow the explicit post-deploy reconciliation step when managed DSQL infrastructure exists, and do not invent your own endpoint values.
 
-在当前仓库版本中，当 managed DSQL 基础设施已经存在时，请按显式的部署后 reconcile 步骤执行，不要自行构造 endpoint 值。
-
-## Expected Result / 预期结果
+## Expected Result
 
 You have completed the first full LTBase deployment path: preview, start-stack deploy, validation, and promotion-path rollout.
 
-你已经完成 LTBase 的第一次完整部署流程：preview、起点环境部署、验证，以及按 promotion path 推进的 rollout。
-
-## Common Mistakes / 常见问题
+## Common Mistakes
 
 - approving the next protected environment before validating the previous deployed stack
 - changing release IDs midway through the same promotion path rollout
 - manually inventing managed DSQL endpoint values
 
-- 在验证前一个已部署环境之前就审批下一个受保护环境
-- 在同一次 promotion path rollout 中途切换 release ID
-- 手动伪造 managed DSQL endpoint 值
-
-## Next Step / 下一步
+## Next Step
 
 Continue with [`08-day-2-operations.md`](08-day-2-operations.md).
-
-继续阅读 [`08-day-2-operations.md`](08-day-2-operations.md)。

--- a/docs/onboarding/07-first-deploy-and-managed-dsql.zh.md
+++ b/docs/onboarding/07-first-deploy-and-managed-dsql.zh.md
@@ -1,0 +1,66 @@
+# 首次部署与 Managed DSQL 处理
+
+> **[English](07-first-deploy-and-managed-dsql.md)**
+
+返回主文档：[`../CUSTOMER_ONBOARDING.zh.md`](../CUSTOMER_ONBOARDING.zh.md)
+
+## 目的
+
+使用本文档在 bootstrap 完成后执行第一次 preview 与 rollout 工作流，并理解当前客户仓库流程下 managed DSQL 的处理方式。
+
+## 开始前确认
+
+- 已完成 [`05-bootstrap-one-click.zh.md`](05-bootstrap-one-click.zh.md) 或 [`06-bootstrap-manual.zh.md`](06-bootstrap-manual.zh.md)
+- 已确认所需的 GitHub secrets 和 variables 已存在
+
+## 操作步骤
+
+### 1. 执行 preview 工作流
+
+打开部署仓库中的 GitHub Actions，针对 `PROMOTION_PATH` 中的第一个 stack 手动运行 `Preview LTBase Blueprint` 工作流。
+
+如果你想覆盖 `vars.LTBASE_RELEASE_ID`，请填写 `release_id` 输入参数。
+
+### 2. 审查 preview 输出
+
+确认 Pulumi preview 输出与你预期的基础设施变更一致。
+
+### 3. 启动 rollout 工作流
+
+运行 `Rollout LTBase Release` 工作流，并填写你希望部署的 release tag。
+
+该工作流会先部署 `PROMOTION_PATH` 的第一个 stack，并在每次成功部署后自动派发下一跳。
+
+### 4. 验证每个已部署环境
+
+在审批下一个受保护目标环境之前，先确认当前已部署环境工作正常。
+
+### 5. 审批受保护目标环境
+
+当 GitHub 请求某个受保护目标 stack 的审批时，请在你的仓库中对应的 GitHub environment gate 完成审批。
+
+### 6. 可选：手动执行单跳 promotion
+
+如果你只需要恢复或重放某一跳，可以使用 `Promote LTBase Between Stacks`，并提供 `from_stack`、`to_stack` 与同一个 release tag。非法跳转会立即失败。
+
+## Managed DSQL 指引
+
+在当前仓库版本中，managed 部署不应由客户手动提供外部 `dsqlHost`、`dsqlEndpoint` 或 `dsqlPassword`。
+
+请将 managed DSQL 的具体连接信息视为由你当前仓库版本的基础设施与发布流程生成和维护的部署状态。
+
+在当前仓库版本中，当 managed DSQL 基础设施已经存在时，请按显式的部署后 reconcile 步骤执行，不要自行构造 endpoint 值。
+
+## 预期结果
+
+你已经完成 LTBase 的第一次完整部署流程：preview、起点环境部署、验证，以及按 promotion path 推进的 rollout。
+
+## 常见问题
+
+- 在验证前一个已部署环境之前就审批下一个受保护环境
+- 在同一次 promotion path rollout 中途切换 release ID
+- 手动伪造 managed DSQL endpoint 值
+
+## 下一步
+
+继续阅读 [`08-day-2-operations.zh.md`](08-day-2-operations.zh.md)。

--- a/docs/onboarding/08-day-2-operations.md
+++ b/docs/onboarding/08-day-2-operations.md
@@ -1,18 +1,16 @@
-# Day-2 Operations / 日常运维操作
+# Day-2 Operations
+
+> **[中文版](08-day-2-operations.zh.md)**
 
 Back to the main guide: [`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md)
 
-返回主文档：[`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md)
-
-## Purpose / 目的
+## Purpose
 
 Use this guide for normal follow-up operations after the first successful deployment.
 
-使用本文档处理首次成功部署之后的日常操作。
+## Typical Operations
 
-## Typical Operations / 常见操作
-
-### Upgrade to a new LTBase release / 升级到新的 LTBase release
+### Upgrade to a new LTBase release
 
 1. Update `LTBASE_RELEASE_ID` in GitHub variables, or pass a new `release_id` directly to the workflow.
 2. Run the preview workflow.
@@ -21,55 +19,31 @@ Use this guide for normal follow-up operations after the first successful deploy
 5. Validate each deployed stack before approving the next protected target environment.
 6. Approve each protected hop in order until the promotion path completes.
 
-1. 更新 GitHub variables 中的 `LTBASE_RELEASE_ID`，或在工作流中直接传入新的 `release_id`。
-2. 运行 preview 工作流。
-3. 审查 Pulumi preview 输出。
-4. 针对新 release 触发一次 `rollout.yml`。
-5. 在审批下一个受保护目标环境前，验证当前已部署 stack。
-6. 按顺序审批每一跳，直到 promotion path 完成。
-
-### Re-run preview before changes / 在变更前重新执行 preview
+### Re-run preview before changes
 
 Use preview whenever you change stack configuration, release selection, or deployment-related values.
 
-当你修改 stack 配置、release 选择或部署相关值时，都应先重新执行 preview。
-
-### Maintain local bootstrap inputs / 维护本地 bootstrap 输入
+### Maintain local bootstrap inputs
 
 Keep `.env` private, current, and outside version control.
 
-保持 `.env` 私密、最新，并确保它不受版本控制。
-
-## Operational Reminders / 运维提醒
+## Operational Reminders
 
 - do not rebuild LTBase application binaries in the deployment repository
 - do not commit `.env`
 - do not bypass the production approval gate
 - keep `LTBASE_RELEASES_TOKEN` scoped to release download access only
 
-- 不要在部署仓库中自行重建 LTBase 应用二进制
-- 不要提交 `.env`
-- 不要绕过生产审批 gate
-- 保持 `LTBASE_RELEASES_TOKEN` 仅具备下载 release 的最小权限
-
-## Expected Result / 预期结果
+## Expected Result
 
 You can safely repeat previews and promotion-path rollouts after onboarding is complete.
 
-在 onboarding 完成之后，你可以安全地重复执行 preview 与按 promotion path 推进的 rollout。
-
-## Common Mistakes / 常见问题
+## Common Mistakes
 
 - approving a later stack before validating the previous hop
 - changing deployment inputs without running preview first
 - treating the deployment repository as an application source repository
 
-- 在未验证前一跳之前就审批后续 stack
-- 修改部署输入后没有先执行 preview
-- 把部署仓库当成应用源码仓库来使用
-
-## Back to Onboarding / 返回主文档
+## Back to Onboarding
 
 Return to [`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md).
-
-返回 [`../CUSTOMER_ONBOARDING.md`](../CUSTOMER_ONBOARDING.md)。

--- a/docs/onboarding/08-day-2-operations.zh.md
+++ b/docs/onboarding/08-day-2-operations.zh.md
@@ -1,0 +1,49 @@
+# 日常运维操作
+
+> **[English](08-day-2-operations.md)**
+
+返回主文档：[`../CUSTOMER_ONBOARDING.zh.md`](../CUSTOMER_ONBOARDING.zh.md)
+
+## 目的
+
+使用本文档处理首次成功部署之后的日常操作。
+
+## 常见操作
+
+### 升级到新的 LTBase release
+
+1. 更新 GitHub variables 中的 `LTBASE_RELEASE_ID`，或在工作流中直接传入新的 `release_id`。
+2. 运行 preview 工作流。
+3. 审查 Pulumi preview 输出。
+4. 针对新 release 触发一次 `rollout.yml`。
+5. 在审批下一个受保护目标环境前，验证当前已部署 stack。
+6. 按顺序审批每一跳，直到 promotion path 完成。
+
+### 在变更前重新执行 preview
+
+当你修改 stack 配置、release 选择或部署相关值时，都应先重新执行 preview。
+
+### 维护本地 bootstrap 输入
+
+保持 `.env` 私密、最新，并确保它不受版本控制。
+
+## 运维提醒
+
+- 不要在部署仓库中自行重建 LTBase 应用二进制
+- 不要提交 `.env`
+- 不要绕过生产审批 gate
+- 保持 `LTBASE_RELEASES_TOKEN` 仅具备下载 release 的最小权限
+
+## 预期结果
+
+在 onboarding 完成之后，你可以安全地重复执行 preview 与按 promotion path 推进的 rollout。
+
+## 常见问题
+
+- 在未验证前一跳之前就审批后续 stack
+- 修改部署输入后没有先执行 preview
+- 把部署仓库当成应用源码仓库来使用
+
+## 返回主文档
+
+返回 [`../CUSTOMER_ONBOARDING.zh.md`](../CUSTOMER_ONBOARDING.zh.md)。


### PR DESCRIPTION
## Summary

- **Align docs with current codebase**: fixed 7 discrepancies between onboarding documentation and actual bootstrap scripts / env.template (commit af2e609)
- **Split bilingual docs into separate EN and ZH files**: each of the 10 bilingual docs now has a dedicated `.zh.md` counterpart with language switcher links at the top (commit d1f7495)

## Changes

### Doc alignment fixes (af2e609)
1. Added `bootstrap-oidc-discovery-companion.sh`, `reconcile-managed-dsql-endpoint.sh`, `lib/bootstrap-env.sh` to BOOTSTRAP.md layout
2. Added `PREVIEW_DEFAULT_STACK` to GitHub Variables lists
3. Rewrote `04-prepare-env-file.md` with correct per-stack variable names, added missing vars
4. Added OIDC discovery companion stage to `05-bootstrap-one-click.md`
5. Added OIDC discovery companion step to `06-bootstrap-manual.md`, fixed step numbering
6. Updated `02-create-repo-and-clone.md` file checklist
7. Clarified auto-handled steps in `03` and `CUSTOMER_ONBOARDING.md`

### Bilingual doc split (d1f7495)
- 10 EN files stripped of Chinese content, language switcher added
- 10 new `.zh.md` files with Chinese-only content, language switcher added
- All cross-references updated to point to matching language version