### PR TITLE
docs: document managed DSQL default connection values

### DIFF
--- a/docs/CUSTOMER_ONBOARDING.md
+++ b/docs/CUSTOMER_ONBOARDING.md
@@ -126,6 +126,13 @@ At the time of writing, this repository's bootstrap scripts use a bootstrap-safe
 
 Aurora DSQL itself is created by the Pulumi blueprint. You do not supply an external `dsqlHost`, `dsqlEndpoint`, or `dsqlPassword` for managed deployments.
 
+The managed DSQL cluster uses the following default connection values set by the Lambda environment:
+
+- `DSQL_DB=postgres`
+- `DSQL_USER=admin`
+
+These are the authoritative defaults for managed deployments.
+
 The current repository version uses a bootstrap-safe flow:
 
 - `bootstrap-all.sh` and `bootstrap-deployment-repo.sh` prepare configuration only


### PR DESCRIPTION
## Summary

- Updates `docs/CUSTOMER_ONBOARDING.md` to explicitly document that managed Aurora DSQL deployments use `DSQL_DB=postgres` and `DSQL_USER=admin` as their authoritative defaults.
- These match the Pulumi blueprint defaults and the reconcile flow; customers should not override them for managed deployments.