### PR TITLE
chore: add template upstream sync helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Important files and scripts:
 - `scripts/bootstrap-deployment-repo.sh`
 - `scripts/bootstrap-all.sh`
 - `scripts/evaluate-and-continue.sh`
+- `scripts/sync-template-upstream.sh`
 
 Preferred recovery-aware bootstrap entrypoint:
 
@@ -65,6 +66,10 @@ Preferred recovery-aware bootstrap entrypoint:
 - `./scripts/evaluate-and-continue.sh --env-file .env --scope bootstrap --force --release-id <release>`
 
 The bootstrap flow now also manages the customer-specific `*-oidc-discovery` companion repository, its Cloudflare Pages project and custom domain, and the per-stack read-only discovery roles that the companion publish workflow assumes.
+
+For day-2 maintenance, the generated deployment repository can sync later template changes by running:
+
+- `./scripts/sync-template-upstream.sh`
 
 ## Deployment Principles
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -57,6 +57,7 @@
 - `scripts/bootstrap-deployment-repo.sh`
 - `scripts/bootstrap-all.sh`
 - `scripts/evaluate-and-continue.sh`
+- `scripts/sync-template-upstream.sh`
 
 推荐的可恢复 bootstrap 入口：
 
@@ -65,6 +66,10 @@
 - `./scripts/evaluate-and-continue.sh --env-file .env --scope bootstrap --force --release-id <release>`
 
 当前 bootstrap 流程还会自动管理客户专属的 `*-oidc-discovery` companion repo、对应的 Cloudflare Pages project 与自定义域名，以及 companion publish workflow 需要假设的每个 stack 的只读 discovery role。
+
+对于日常维护，从该模板生成出来的部署仓库可以通过以下命令同步后续模板变更：
+
+- `./scripts/sync-template-upstream.sh`
 
 ## 部署原则
 

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -23,6 +23,7 @@ Your deployment repository should contain:
 - `scripts/bootstrap-deployment-repo.sh`
 - `scripts/bootstrap-all.sh`
 - `scripts/evaluate-and-continue.sh`
+- `scripts/sync-template-upstream.sh`
 - `scripts/reconcile-managed-dsql-endpoint.sh`
 - `scripts/lib/bootstrap-env.sh`
 

--- a/docs/BOOTSTRAP.zh.md
+++ b/docs/BOOTSTRAP.zh.md
@@ -23,6 +23,7 @@
 - `scripts/bootstrap-deployment-repo.sh`
 - `scripts/bootstrap-all.sh`
 - `scripts/evaluate-and-continue.sh`
+- `scripts/sync-template-upstream.sh`
 - `scripts/reconcile-managed-dsql-endpoint.sh`
 - `scripts/lib/bootstrap-env.sh`
 

--- a/docs/onboarding/02-create-repo-and-clone.md
+++ b/docs/onboarding/02-create-repo-and-clone.md
@@ -30,6 +30,7 @@ Use this guide to create your customer-owned deployment repository from the temp
    - `scripts/bootstrap-deployment-repo.sh`
    - `scripts/bootstrap-all.sh`
    - `scripts/evaluate-and-continue.sh`
+   - `scripts/sync-template-upstream.sh`
    - `scripts/reconcile-managed-dsql-endpoint.sh`
 5. Confirm that the repository is private.
 6. Confirm that the `prod` environment will be available for later approval gating.

--- a/docs/onboarding/02-create-repo-and-clone.zh.md
+++ b/docs/onboarding/02-create-repo-and-clone.zh.md
@@ -30,6 +30,7 @@
    - `scripts/bootstrap-deployment-repo.sh`
    - `scripts/bootstrap-all.sh`
    - `scripts/evaluate-and-continue.sh`
+   - `scripts/sync-template-upstream.sh`
    - `scripts/reconcile-managed-dsql-endpoint.sh`
 5. 确认仓库是私有的。
 6. 确认后续用于审批的 `prod` environment 可以创建。

--- a/docs/onboarding/08-day-2-operations.md
+++ b/docs/onboarding/08-day-2-operations.md
@@ -12,12 +12,14 @@ Use this guide for normal follow-up operations after the first successful deploy
 
 ### Upgrade to a new LTBase release
 
-1. Update `LTBASE_RELEASE_ID` in GitHub variables, or pass a new `release_id` directly to the workflow.
-2. Run the preview workflow.
-3. Review the Pulumi preview output.
-4. Trigger `rollout.yml` once for the new release.
-5. Validate each deployed stack before approving the next protected target environment.
-6. Approve each protected hop in order until the promotion path completes.
+1. If you want to bring in newer template workflows or scripts first, run `./scripts/sync-template-upstream.sh` from your deployment repository on a clean local `main` branch.
+2. Resolve any merge conflicts and review the incoming template changes.
+3. Update `LTBASE_RELEASE_ID` in GitHub variables, or pass a new `release_id` directly to the workflow.
+4. Run the preview workflow.
+5. Review the Pulumi preview output.
+6. Trigger `rollout.yml` once for the new release.
+7. Validate each deployed stack before approving the next protected target environment.
+8. Approve each protected hop in order until the promotion path completes.
 
 ### Re-run preview before changes
 
@@ -33,6 +35,7 @@ Keep `.env` private, current, and outside version control.
 - do not commit `.env`
 - do not bypass the production approval gate
 - keep `LTBASE_RELEASES_TOKEN` scoped to release download access only
+- run `scripts/sync-template-upstream.sh` only from a clean local `main` branch
 
 ## Expected Result
 

--- a/docs/onboarding/08-day-2-operations.zh.md
+++ b/docs/onboarding/08-day-2-operations.zh.md
@@ -12,12 +12,14 @@
 
 ### 升级到新的 LTBase release
 
-1. 更新 GitHub variables 中的 `LTBASE_RELEASE_ID`，或在工作流中直接传入新的 `release_id`。
-2. 运行 preview 工作流。
-3. 审查 Pulumi preview 输出。
-4. 针对新 release 触发一次 `rollout.yml`。
-5. 在审批下一个受保护目标环境前，验证当前已部署 stack。
-6. 按顺序审批每一跳，直到 promotion path 完成。
+1. 如果你想先同步较新的模板工作流或脚本，请在部署仓库干净的本地 `main` 分支上运行 `./scripts/sync-template-upstream.sh`。
+2. 处理可能出现的 merge conflict，并审查同步进来的模板变更。
+3. 更新 GitHub variables 中的 `LTBASE_RELEASE_ID`，或在工作流中直接传入新的 `release_id`。
+4. 运行 preview 工作流。
+5. 审查 Pulumi preview 输出。
+6. 针对新 release 触发一次 `rollout.yml`。
+7. 在审批下一个受保护目标环境前，验证当前已部署 stack。
+8. 按顺序审批每一跳，直到 promotion path 完成。
 
 ### 在变更前重新执行 preview
 
@@ -33,6 +35,7 @@
 - 不要提交 `.env`
 - 不要绕过生产审批 gate
 - 保持 `LTBASE_RELEASES_TOKEN` 仅具备下载 release 的最小权限
+- 只在干净的本地 `main` 分支上运行 `scripts/sync-template-upstream.sh`
 
 ## 预期结果
 

--- a/scripts/sync-template-upstream.sh
+++ b/scripts/sync-template-upstream.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+UPSTREAM_NAME="upstream"
+UPSTREAM_URL="https://github.com/Lychee-Technology/ltbase-private-deployment.git"
+BRANCH="main"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --upstream-name)
+      UPSTREAM_NAME="$2"
+      shift 2
+      ;;
+    --upstream-url)
+      UPSTREAM_URL="$2"
+      shift 2
+      ;;
+    --branch)
+      BRANCH="$2"
+      shift 2
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "current directory is not a git repository" >&2
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "working tree is not clean; commit or stash your changes before syncing" >&2
+  exit 1
+fi
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "${current_branch}" != "${BRANCH}" ]]; then
+  echo "current branch must be ${BRANCH}; found ${current_branch}" >&2
+  exit 1
+fi
+
+if existing_url="$(git remote get-url "${UPSTREAM_NAME}" 2>/dev/null)"; then
+  if [[ "${existing_url}" != "${UPSTREAM_URL}" ]]; then
+    echo "remote ${UPSTREAM_NAME} already exists with unexpected URL: ${existing_url}" >&2
+    exit 1
+  fi
+else
+  git remote add "${UPSTREAM_NAME}" "${UPSTREAM_URL}"
+fi
+
+git fetch "${UPSTREAM_NAME}"
+git merge --no-edit "${UPSTREAM_NAME}/${BRANCH}"
+
+printf 'synced %s/%s into %s\n' "${UPSTREAM_NAME}" "${BRANCH}" "${BRANCH}"

--- a/test/sync-template-upstream-test.sh
+++ b/test/sync-template-upstream-test.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/scripts/sync-template-upstream.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_log_contains() {
+  local path="$1"
+  local needle="$2"
+  if ! grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+log_file="${temp_dir}/commands.log"
+touch "${log_file}"
+
+setup_fake_git() {
+  local fake_bin="$1"
+
+  mkdir -p "${fake_bin}"
+
+  cat >"${fake_bin}/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'git %s\n' "$*" >>"${COMMAND_LOG}"
+
+case "$*" in
+  "rev-parse --is-inside-work-tree")
+    printf 'true\n'
+    exit 0
+    ;;
+  "status --porcelain")
+    if [[ "${SCENARIO:-success}" == "dirty" ]]; then
+      printf ' M README.md\n'
+    fi
+    exit 0
+    ;;
+  "rev-parse --abbrev-ref HEAD")
+    printf 'main\n'
+    exit 0
+    ;;
+  "remote get-url upstream")
+    if [[ "${SCENARIO:-success}" == "url_mismatch" ]]; then
+      printf 'https://github.com/example/wrong-template.git\n'
+      exit 0
+    fi
+    exit 2
+    ;;
+  "remote add upstream https://github.com/Lychee-Technology/ltbase-private-deployment.git")
+    exit 0
+    ;;
+  "fetch upstream")
+    exit 0
+    ;;
+  "merge --no-edit upstream/main")
+    exit 0
+    ;;
+esac
+
+exit 0
+EOF
+  chmod +x "${fake_bin}/git"
+}
+
+run_success_case() {
+  local fake_bin="$1"
+  local log_file="$2"
+  setup_fake_git "${fake_bin}"
+
+  if ! output="$(PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" "${SCRIPT_PATH}" 2>&1)"; then
+    fail "expected script to succeed, got: ${output}"
+  fi
+
+  assert_log_contains "${log_file}" "git rev-parse --is-inside-work-tree"
+  assert_log_contains "${log_file}" "git status --porcelain"
+  assert_log_contains "${log_file}" "git rev-parse --abbrev-ref HEAD"
+  assert_log_contains "${log_file}" "git remote get-url upstream"
+  assert_log_contains "${log_file}" "git remote add upstream https://github.com/Lychee-Technology/ltbase-private-deployment.git"
+  assert_log_contains "${log_file}" "git fetch upstream"
+  assert_log_contains "${log_file}" "git merge --no-edit upstream/main"
+}
+
+run_dirty_tree_case() {
+  local fake_bin="$1"
+  setup_fake_git "${fake_bin}"
+
+  if PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" SCENARIO="dirty" "${SCRIPT_PATH}" >"${temp_dir}/dirty.out" 2>&1; then
+    fail "expected script to fail on dirty working tree"
+  fi
+
+  if ! grep -Fq "working tree is not clean" "${temp_dir}/dirty.out"; then
+    fail "expected dirty tree error output"
+  fi
+}
+
+run_url_mismatch_case() {
+  local fake_bin="$1"
+  setup_fake_git "${fake_bin}"
+
+  if PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" SCENARIO="url_mismatch" "${SCRIPT_PATH}" >"${temp_dir}/url-mismatch.out" 2>&1; then
+    fail "expected script to fail on upstream URL mismatch"
+  fi
+
+  if ! grep -Fq "remote upstream already exists with unexpected URL" "${temp_dir}/url-mismatch.out"; then
+    fail "expected upstream URL mismatch error output"
+  fi
+}
+
+if [[ ! -x "${SCRIPT_PATH}" ]]; then
+  fail "missing executable script: ${SCRIPT_PATH}"
+fi
+
+success_bin="${temp_dir}/success-bin"
+dirty_bin="${temp_dir}/dirty-bin"
+url_mismatch_bin="${temp_dir}/url-mismatch-bin"
+
+run_success_case "${success_bin}" "${log_file}"
+run_dirty_tree_case "${dirty_bin}"
+run_url_mismatch_case "${url_mismatch_bin}"
+
+printf 'PASS: sync-template-upstream tests\n'


### PR DESCRIPTION
## Summary
- add a `scripts/sync-template-upstream.sh` helper for repos created from this template to add `upstream` and merge template updates from `main`
- add a shell test covering the happy path and key safety checks for dirty worktrees and remote URL mismatches
- document the helper in README, bootstrap docs, and day-2 upgrade guidance in both English and Chinese