### PR TITLE
fix: add sync template tooling updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Important files and scripts:
 - `scripts/bootstrap-deployment-repo.sh`
 - `scripts/bootstrap-all.sh`
 - `scripts/evaluate-and-continue.sh`
+- `scripts/update-sync-template-tooling.sh`
 - `scripts/sync-template-upstream.sh`
 
 Preferred recovery-aware bootstrap entrypoint:
@@ -85,7 +86,10 @@ The bootstrap flow now also manages the customer-specific `*-oidc-discovery` com
 
 For day-2 maintenance, the generated deployment repository can sync later template changes by running:
 
+- `./scripts/update-sync-template-tooling.sh`
 - `./scripts/sync-template-upstream.sh`
+
+Use `./scripts/update-sync-template-tooling.sh` first when you want the latest sync helper and its regression test from the template. Then run `./scripts/sync-template-upstream.sh` to sync template-managed files. The template sync preserves local `.env` files, `infra/Pulumi.*.yaml`, customer-owned `infra/auth-providers.*.json`, and the sync helper's own script/test files.
 
 ## Deployment Principles
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -73,6 +73,7 @@ onboarding 文档支持通用多 stack 拓扑。文中出现 `devo`、`prod` 等
 - `scripts/bootstrap-deployment-repo.sh`
 - `scripts/bootstrap-all.sh`
 - `scripts/evaluate-and-continue.sh`
+- `scripts/update-sync-template-tooling.sh`
 - `scripts/sync-template-upstream.sh`
 
 推荐的可恢复 bootstrap 入口：
@@ -85,7 +86,10 @@ onboarding 文档支持通用多 stack 拓扑。文中出现 `devo`、`prod` 等
 
 对于日常维护，从该模板生成出来的部署仓库可以通过以下命令同步后续模板变更：
 
+- `./scripts/update-sync-template-tooling.sh`
 - `./scripts/sync-template-upstream.sh`
+
+当你希望先拿到模板中的最新同步工具和对应回归测试时，先运行 `./scripts/update-sync-template-tooling.sh`，再运行 `./scripts/sync-template-upstream.sh` 同步模板管理的文件。模板同步会保留本地 `.env`、`infra/Pulumi.*.yaml`、由 deployment repo 自行维护的 `infra/auth-providers.*.json`，以及同步工具自己的脚本与测试文件。
 
 ## 部署原则
 

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -23,6 +23,7 @@ Your deployment repository should contain:
 - `scripts/bootstrap-deployment-repo.sh`
 - `scripts/bootstrap-all.sh`
 - `scripts/evaluate-and-continue.sh`
+- `scripts/update-sync-template-tooling.sh`
 - `scripts/sync-template-upstream.sh`
 - `scripts/reconcile-managed-dsql-endpoint.sh`
 - `scripts/lib/bootstrap-env.sh`

--- a/docs/BOOTSTRAP.zh.md
+++ b/docs/BOOTSTRAP.zh.md
@@ -23,6 +23,7 @@
 - `scripts/bootstrap-deployment-repo.sh`
 - `scripts/bootstrap-all.sh`
 - `scripts/evaluate-and-continue.sh`
+- `scripts/update-sync-template-tooling.sh`
 - `scripts/sync-template-upstream.sh`
 - `scripts/reconcile-managed-dsql-endpoint.sh`
 - `scripts/lib/bootstrap-env.sh`

--- a/docs/onboarding/08-day-2-operations.md
+++ b/docs/onboarding/08-day-2-operations.md
@@ -12,14 +12,15 @@ Use this guide for normal follow-up operations after the first successful deploy
 
 ### Upgrade to a new LTBase release
 
-1. If you want to bring in newer template-managed files first, run `./scripts/sync-template-upstream.sh` from your deployment repository on a clean local `main` branch.
-2. Review the synced template changes. The sync preserves local `.env` files, `infra/Pulumi.*.yaml`, and the sync helper's own script/test files.
-3. Update `LTBASE_RELEASE_ID` in GitHub variables, or pass a new `release_id` directly to the workflow.
-4. Run the preview workflow.
-5. Review the Pulumi preview output.
-6. Trigger `rollout.yml` once for the new release.
-7. Validate each deployed stack before approving the next protected target environment.
-8. Approve each protected hop in order until the promotion path completes.
+1. If you want the latest template copy of the sync helper itself first, run `./scripts/update-sync-template-tooling.sh` from your deployment repository on a clean local `main` branch.
+2. If you want to bring in newer template-managed files, run `./scripts/sync-template-upstream.sh` from the same clean local `main` branch.
+3. Review the synced template changes. The sync preserves local `.env` files, `infra/Pulumi.*.yaml`, customer-owned `infra/auth-providers.*.json`, and the sync helper's own script/test files.
+4. Update `LTBASE_RELEASE_ID` in GitHub variables, or pass a new `release_id` directly to the workflow.
+5. Run the preview workflow.
+6. Review the Pulumi preview output.
+7. Trigger `rollout.yml` once for the new release.
+8. Validate each deployed stack before approving the next protected target environment.
+9. Approve each protected hop in order until the promotion path completes.
 
 ### Re-run preview before changes
 
@@ -35,6 +36,7 @@ Keep `.env` private, current, and outside version control.
 - do not commit `.env`
 - do not bypass the production approval gate
 - keep `LTBASE_RELEASES_TOKEN` scoped to release download access only
+- run `scripts/update-sync-template-tooling.sh` only from a clean local `main` branch
 - run `scripts/sync-template-upstream.sh` only from a clean local `main` branch
 
 ## Expected Result

--- a/docs/onboarding/08-day-2-operations.zh.md
+++ b/docs/onboarding/08-day-2-operations.zh.md
@@ -12,14 +12,15 @@
 
 ### 升级到新的 LTBase release
 
-1. 如果你想先同步较新的模板工作流或脚本，请在部署仓库干净的本地 `main` 分支上运行 `./scripts/sync-template-upstream.sh`。
-2. 处理可能出现的 merge conflict，并审查同步进来的模板变更。
-3. 更新 GitHub variables 中的 `LTBASE_RELEASE_ID`，或在工作流中直接传入新的 `release_id`。
-4. 运行 preview 工作流。
-5. 审查 Pulumi preview 输出。
-6. 针对新 release 触发一次 `rollout.yml`。
-7. 在审批下一个受保护目标环境前，验证当前已部署 stack。
-8. 按顺序审批每一跳，直到 promotion path 完成。
+1. 如果你想先拿到模板中的最新同步工具本身，请在部署仓库干净的本地 `main` 分支上运行 `./scripts/update-sync-template-tooling.sh`。
+2. 如果你还想同步较新的模板管理文件，再在同一个干净的本地 `main` 分支上运行 `./scripts/sync-template-upstream.sh`。
+3. 审查同步进来的模板变更。模板同步会保留本地 `.env`、`infra/Pulumi.*.yaml`、由 deployment repo 自行维护的 `infra/auth-providers.*.json`，以及同步工具自己的脚本与测试文件。
+4. 更新 GitHub variables 中的 `LTBASE_RELEASE_ID`，或在工作流中直接传入新的 `release_id`。
+5. 运行 preview 工作流。
+6. 审查 Pulumi preview 输出。
+7. 针对新 release 触发一次 `rollout.yml`。
+8. 在审批下一个受保护目标环境前，验证当前已部署 stack。
+9. 按顺序审批每一跳，直到 promotion path 完成。
 
 ### 在变更前重新执行 preview
 
@@ -35,6 +36,7 @@
 - 不要提交 `.env`
 - 不要绕过生产审批 gate
 - 保持 `LTBASE_RELEASES_TOKEN` 仅具备下载 release 的最小权限
+- 只在干净的本地 `main` 分支上运行 `scripts/update-sync-template-tooling.sh`
 - 只在干净的本地 `main` 分支上运行 `scripts/sync-template-upstream.sh`
 
 ## 预期结果

--- a/scripts/update-sync-template-tooling.sh
+++ b/scripts/update-sync-template-tooling.sh
@@ -7,17 +7,6 @@ UPSTREAM_URL="https://github.com/Lychee-Technology/ltbase-private-deployment.git
 BRANCH="main"
 ARCHIVE_PATH="sync-template-upstream.tar"
 
-required_source_paths=(
-  ".github/workflows"
-  "docs"
-  "scripts"
-  "test"
-  "infra"
-  "env.template"
-  ".gitignore"
-  "__ref__"
-)
-
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --upstream-name)
@@ -45,7 +34,7 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 if [[ -n "$(git status --porcelain)" ]]; then
-  echo "working tree is not clean; commit or stash your changes before syncing" >&2
+  echo "working tree is not clean; commit or stash your changes before updating sync tooling" >&2
   exit 1
 fi
 
@@ -73,23 +62,17 @@ git archive --format=tar --output "${ARCHIVE_PATH}" "${UPSTREAM_NAME}/${BRANCH}"
 mkdir -p "${temp_root}"
 tar -xf "${ARCHIVE_PATH}" -C "${temp_root}"
 
-for path in "${required_source_paths[@]}"; do
+for path in scripts/sync-template-upstream.sh test/sync-template-upstream-test.sh; do
   if [[ ! -e "${temp_root}/${path}" ]]; then
     echo "missing upstream path: ${path}" >&2
     exit 1
   fi
 done
 
-rsync -a --delete \
-  --exclude '.git/' \
-  --exclude 'dist/' \
-  --exclude '.DS_Store' \
-  --exclude '.env' \
-  --exclude '.env.*' \
-  --exclude 'infra/Pulumi.*.yaml' \
-  --exclude 'infra/auth-providers.*.json' \
-  --exclude 'scripts/sync-template-upstream.sh' \
-  --exclude 'test/sync-template-upstream-test.sh' \
-  "${temp_root}/" "./"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
 
-printf 'synced %s/%s into %s\n' "${UPSTREAM_NAME}" "${BRANCH}" "${BRANCH}"
+cp "${temp_root}/scripts/sync-template-upstream.sh" "${repo_root}/scripts/sync-template-upstream.sh"
+cp "${temp_root}/test/sync-template-upstream-test.sh" "${repo_root}/test/sync-template-upstream-test.sh"
+
+printf 'updated sync tooling from %s/%s\n' "${UPSTREAM_NAME}" "${BRANCH}"

--- a/test/sync-template-upstream-test.sh
+++ b/test/sync-template-upstream-test.sh
@@ -143,7 +143,7 @@ run_success_case() {
   assert_log_contains "${log_file}" "git fetch upstream"
   assert_log_contains "${log_file}" "git archive --format=tar --output sync-template-upstream.tar upstream/main"
   assert_log_contains "${log_file}" "tar -xf sync-template-upstream.tar"
-  assert_log_contains "${log_file}" "rsync -a --delete --exclude .git/ --exclude dist/ --exclude .DS_Store --exclude .env --exclude .env.* --exclude infra/Pulumi.*.yaml --exclude scripts/sync-template-upstream.sh --exclude test/sync-template-upstream-test.sh ${temp_dir}/upstream-checkout/ ./"
+  assert_log_contains "${log_file}" "rsync -a --delete --exclude .git/ --exclude dist/ --exclude .DS_Store --exclude .env --exclude .env.* --exclude infra/Pulumi.*.yaml --exclude infra/auth-providers.*.json --exclude scripts/sync-template-upstream.sh --exclude test/sync-template-upstream-test.sh ${temp_dir}/upstream-checkout/ ./"
   assert_log_not_contains "${log_file}" "git merge --no-edit upstream/main"
 }
 

--- a/test/update-sync-template-tooling-test.sh
+++ b/test/update-sync-template-tooling-test.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/scripts/update-sync-template-tooling.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_log_contains() {
+  local path="$1"
+  local needle="$2"
+  if ! grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+assert_log_not_contains() {
+  local path="$1"
+  local needle="$2"
+  if grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to not contain: ${needle}"
+  fi
+}
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+log_file="${temp_dir}/commands.log"
+touch "${log_file}"
+
+setup_fake_bin() {
+  local fake_bin="$1"
+
+  mkdir -p "${fake_bin}"
+
+  cat >"${fake_bin}/git" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'git %s\n' "$*" >>"${COMMAND_LOG}"
+
+case "$*" in
+  "rev-parse --is-inside-work-tree")
+    printf 'true\n'
+    exit 0
+    ;;
+  "status --porcelain")
+    printf '\n'
+    exit 0
+    ;;
+  "rev-parse --abbrev-ref HEAD")
+    printf 'main\n'
+    exit 0
+    ;;
+  "remote get-url upstream")
+    exit 2
+    ;;
+  "remote add upstream https://github.com/Lychee-Technology/ltbase-private-deployment.git")
+    exit 0
+    ;;
+  "fetch upstream")
+    exit 0
+    ;;
+  "archive --format=tar --output sync-template-upstream.tar upstream/main")
+    exit 0
+    ;;
+esac
+
+exit 0
+EOF
+  chmod +x "${fake_bin}/git"
+
+  cat >"${fake_bin}/tar" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'tar %s\n' "$*" >>"${COMMAND_LOG}"
+if [[ "$*" == "-xf sync-template-upstream.tar -C ${TEMP_ROOT}/upstream-checkout" ]]; then
+  mkdir -p "${TEMP_ROOT}/upstream-checkout/scripts" "${TEMP_ROOT}/upstream-checkout/test"
+  : >"${TEMP_ROOT}/upstream-checkout/scripts/sync-template-upstream.sh"
+  : >"${TEMP_ROOT}/upstream-checkout/test/sync-template-upstream-test.sh"
+fi
+exit 0
+EOF
+  chmod +x "${fake_bin}/tar"
+
+  cat >"${fake_bin}/cp" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'cp %s\n' "$*" >>"${COMMAND_LOG}"
+exit 0
+EOF
+  chmod +x "${fake_bin}/cp"
+
+  cat >"${fake_bin}/mktemp" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "-d" ]]; then
+  printf '%s\n' "${TEMP_ROOT}/upstream-checkout"
+  mkdir -p "${TEMP_ROOT}/upstream-checkout"
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "${fake_bin}/mktemp"
+
+  cat >"${fake_bin}/rsync" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'rsync %s\n' "$*" >>"${COMMAND_LOG}"
+exit 0
+EOF
+  chmod +x "${fake_bin}/rsync"
+}
+
+if [[ ! -x "${SCRIPT_PATH}" ]]; then
+  fail "missing executable script: ${SCRIPT_PATH}"
+fi
+
+fake_bin="${temp_dir}/bin"
+setup_fake_bin "${fake_bin}"
+
+if ! output="$(PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" TEMP_ROOT="${temp_dir}" "${SCRIPT_PATH}" 2>&1)"; then
+  fail "expected script to succeed, got: ${output}"
+fi
+
+assert_log_contains "${log_file}" "git rev-parse --is-inside-work-tree"
+assert_log_contains "${log_file}" "git status --porcelain"
+assert_log_contains "${log_file}" "git rev-parse --abbrev-ref HEAD"
+assert_log_contains "${log_file}" "git remote get-url upstream"
+assert_log_contains "${log_file}" "git remote add upstream https://github.com/Lychee-Technology/ltbase-private-deployment.git"
+assert_log_contains "${log_file}" "git fetch upstream"
+assert_log_contains "${log_file}" "git archive --format=tar --output sync-template-upstream.tar upstream/main"
+assert_log_contains "${log_file}" "tar -xf sync-template-upstream.tar -C ${temp_dir}/upstream-checkout"
+assert_log_contains "${log_file}" "cp ${temp_dir}/upstream-checkout/scripts/sync-template-upstream.sh ${ROOT_DIR}/scripts/sync-template-upstream.sh"
+assert_log_contains "${log_file}" "cp ${temp_dir}/upstream-checkout/test/sync-template-upstream-test.sh ${ROOT_DIR}/test/sync-template-upstream-test.sh"
+assert_log_not_contains "${log_file}" "rsync "
+
+printf 'PASS: update-sync-template-tooling tests\n'


### PR DESCRIPTION
## Summary
- add `scripts/update-sync-template-tooling.sh` to update `sync-template-upstream.sh` and its regression test without self-overwriting during template sync
- keep `scripts/sync-template-upstream.sh` from deleting customer-owned `infra/auth-providers.*.json`
- document the two-step maintenance flow in README, BOOTSTRAP, and day-2 operations docs

## Test Plan
- `bash test/update-sync-template-tooling-test.sh`
- `bash test/sync-template-upstream-test.sh`
- `bash test/rollout-workflows-test.sh`
- `bash test/bootstrap-deployment-repo-test.sh`
- `go test ./...` (from `infra/`)