### PR TITLE
feat: add prebuilt infra binary workflow

### DIFF
--- a/.github/workflows/build-infra-binary.yml
+++ b/.github/workflows/build-infra-binary.yml
@@ -1,0 +1,60 @@
+name: Build Infra Binary
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: infra/go.mod
+          cache-dependency-path: infra/go.sum
+
+      - name: Build infra binary
+        working-directory: infra
+        run: |
+          mkdir -p .pulumi/bin
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
+            go build -buildvcs=false -o .pulumi/bin/ltbase-infra ./cmd/ltbase-infra
+
+      - name: Write binary manifest
+        working-directory: infra
+        run: |
+          sha256="$(shasum -a 256 .pulumi/bin/ltbase-infra | awk '{print $1}')"
+          go_version="$(go version | awk '{print $3}')"
+          built_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          jq -n \
+            --arg source_repository "${GITHUB_REPOSITORY}" \
+            --arg source_commit "${GITHUB_SHA}" \
+            --arg source_ref "${GITHUB_REF_NAME}" \
+            --arg project "ltbase-infra" \
+            --arg binary_name "ltbase-infra" \
+            --arg os "linux" \
+            --arg arch "arm64" \
+            --arg sha256 "${sha256}" \
+            --arg go_version "${go_version}" \
+            --arg built_at "${built_at}" \
+            '{source_repository:$source_repository,source_commit:$source_commit,source_ref:$source_ref,project:$project,binary_name:$binary_name,os:$os,arch:$arch,sha256:$sha256,go_version:$go_version,built_at:$built_at}' \
+            > manifest.json
+
+      - name: Prepare artifact payload
+        run: |
+          rm -rf dist/infra-binary-artifact
+          mkdir -p dist/infra-binary-artifact
+          cp infra/.pulumi/bin/ltbase-infra dist/infra-binary-artifact/ltbase-infra
+          cp infra/manifest.json dist/infra-binary-artifact/manifest.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: infra-binary-linux-arm64-${{ github.sha }}
+          path: dist/infra-binary-artifact/*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env.*
 .worktrees/
 dist/
+infra/.pulumi/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ It is not the LTBase application source repository.
 
 - thin wrapper workflows that call the public reusable LTBase deployment workflows
 - bootstrap scripts for GitHub repository setup, AWS foundation setup, and Pulumi stack configuration
+- a Pulumi program wrapper at `infra/scripts/pulumi-wrapper.sh` that uses a prebuilt binary when available and falls back to local source build when it is not
 - example deployment inputs such as `env.template`
 - customer onboarding and bootstrap documentation
 
@@ -94,6 +95,7 @@ Use `./scripts/update-sync-template-tooling.sh` first when you want the latest s
 ## Deployment Principles
 
 - the deployment repository downloads official LTBase releases instead of building the application source code
+- official workflows may also download a commit-bound prebuilt `ltbase-infra` binary from the blueprint repository to avoid recompiling the Pulumi Go program on every run
 - customers own the GitHub repository, AWS account resources, and deployment approvals
 - bootstrap scripts prepare repository state and deployment configuration
 - the shared Pulumi backend bucket is created once and lives in the AWS account for the first stack in `PROMOTION_PATH`
@@ -105,6 +107,7 @@ Use `./scripts/update-sync-template-tooling.sh` first when you want the latest s
 
 - keep local `.env` files private and out of version control
 - use the documentation in `docs/` as the source of truth for customer onboarding
+- keep `infra/.pulumi/bin/ltbase-infra` out of version control; the wrapper can recreate it locally and official workflows may preinstall it temporarily
 - if a later repository version changes the managed DSQL lifecycle, follow the docs shipped with that version
 - operators must keep Cloudflare SSL mode on `Full (strict)` and enable Authenticated Origin Pulls for the API hostnames
 - once the mTLS rollout is applied, direct `execute-api` access is expected to fail by design

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -101,6 +101,7 @@ Manual path:
 
 - keep `.env` private and outside version control
 - the deployment repository downloads official LTBase releases; it does not build the app itself
+- official workflows may install a commit-bound prebuilt `ltbase-infra` binary from the same blueprint repository before running Pulumi; if no matching artifact exists, the repo's `infra/scripts/pulumi-wrapper.sh` falls back to local source build
 - preview is manual in the customer repo because live credentials are customer-owned
 - manual preview only supports the first stack in `PROMOTION_PATH`
 - protected target environments are guarded by per-stack GitHub environment approval gates during rollout

--- a/infra/Pulumi.yaml
+++ b/infra/Pulumi.yaml
@@ -1,4 +1,7 @@
 name: ltbase-infra
-runtime: go
+runtime:
+  name: go
+  options:
+    binary: ./.pulumi/bin/ltbase-infra
 description: LTBase IaC managed with Pulumi and Go
 main: ./cmd/ltbase-infra

--- a/infra/scripts/pulumi-wrapper.sh
+++ b/infra/scripts/pulumi-wrapper.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+infra_dir="$(cd "${script_dir}/.." && pwd)"
+
+cd "${infra_dir}"
+mkdir -p .pulumi/bin
+
+if [[ ! -x .pulumi/bin/ltbase-infra ]]; then
+  GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
+    go build -buildvcs=false -o .pulumi/bin/ltbase-infra ./cmd/ltbase-infra
+fi
+
+exec pulumi "$@"

--- a/test/prebuilt-infra-binary-test.sh
+++ b/test/prebuilt-infra-binary-test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PULUMI_PROJECT="${ROOT_DIR}/infra/Pulumi.yaml"
+WRAPPER_PATH="${ROOT_DIR}/infra/scripts/pulumi-wrapper.sh"
+WORKFLOW_PATH="${ROOT_DIR}/.github/workflows/build-infra-binary.yml"
+GITIGNORE_PATH="${ROOT_DIR}/.gitignore"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local path="$1"
+  local needle="$2"
+  if [[ ! -f "${path}" ]]; then
+    fail "missing file: ${path}"
+  fi
+  if ! grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+assert_log_contains() {
+  local path="$1"
+  local needle="$2"
+  if ! grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+assert_file_contains "${PULUMI_PROJECT}" "name: go"
+assert_file_contains "${PULUMI_PROJECT}" "options:"
+assert_file_contains "${PULUMI_PROJECT}" "binary: ./.pulumi/bin/ltbase-infra"
+assert_file_contains "${GITIGNORE_PATH}" "infra/.pulumi/"
+
+assert_file_contains "${WORKFLOW_PATH}" "workflow_dispatch:"
+assert_file_contains "${WORKFLOW_PATH}" "push:"
+assert_file_contains "${WORKFLOW_PATH}" "runs-on: ubuntu-24.04-arm"
+assert_file_contains "${WORKFLOW_PATH}" 'name: infra-binary-linux-arm64-${{ github.sha }}'
+assert_file_contains "${WORKFLOW_PATH}" "manifest.json"
+assert_file_contains "${WORKFLOW_PATH}" ".pulumi/bin/ltbase-infra"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+fake_bin="${temp_dir}/bin"
+log_file="${temp_dir}/commands.log"
+mkdir -p "${fake_bin}" "${temp_dir}/infra/.pulumi/bin" "${temp_dir}/infra/scripts"
+touch "${log_file}"
+
+cat >"${fake_bin}/go" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'go %s\n' "$*" >>"${COMMAND_LOG}"
+output_path=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o)
+      output_path="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [[ -n "${output_path}" ]]; then
+  mkdir -p "$(dirname "${output_path}")"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"${output_path}"
+  chmod +x "${output_path}"
+fi
+EOF
+chmod +x "${fake_bin}/go"
+
+cat >"${fake_bin}/pulumi" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'pulumi %s\n' "$*" >>"${COMMAND_LOG}"
+EOF
+chmod +x "${fake_bin}/pulumi"
+
+cp "${WRAPPER_PATH}" "${temp_dir}/infra/scripts/pulumi-wrapper.sh"
+chmod +x "${temp_dir}/infra/scripts/pulumi-wrapper.sh"
+
+printf '#!/usr/bin/env bash\nexit 0\n' >"${temp_dir}/infra/.pulumi/bin/ltbase-infra"
+chmod +x "${temp_dir}/infra/.pulumi/bin/ltbase-infra"
+
+PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" "${temp_dir}/infra/scripts/pulumi-wrapper.sh" preview --stack devo
+
+assert_log_contains "${log_file}" "pulumi preview --stack devo"
+if grep -Fq "go build" "${log_file}"; then
+  fail "wrapper should not rebuild when the binary already exists"
+fi
+
+: >"${log_file}"
+rm -f "${temp_dir}/infra/.pulumi/bin/ltbase-infra"
+PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" "${temp_dir}/infra/scripts/pulumi-wrapper.sh" up --stack devo
+
+assert_log_contains "${log_file}" "go build -buildvcs=false -o .pulumi/bin/ltbase-infra ./cmd/ltbase-infra"
+assert_log_contains "${log_file}" "pulumi up --stack devo"
+
+printf 'PASS: prebuilt infra binary tests\n'


### PR DESCRIPTION
## Summary
- switch the Pulumi Go project to a fixed binary path and add `infra/scripts/pulumi-wrapper.sh` as the source-build fallback
- add a commit-bound `build-infra-binary.yml` workflow that publishes `infra-binary-linux-arm64-<commit>` with `ltbase-infra` and `manifest.json`
- document the prebuilt-binary path and add regression coverage for wrapper behavior and artifact shape

## Testing
- `go test ./...` in `infra`
- `for f in test/*.sh; do bash "$f"; done`

## Linked Issue
- Closes #47
