### PR TITLE
feat: publish infra binaries to binaries repo

### DIFF
--- a/.github/workflows/build-infra-binary.yml
+++ b/.github/workflows/build-infra-binary.yml
@@ -5,13 +5,26 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'infra/**'
+      - '.github/workflows/build-infra-binary.yml'
 
 permissions:
   contents: read
 
 jobs:
   build:
-    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: linux-amd64
+            runner: ubuntu-latest
+            goarch: amd64
+          - arch: linux-arm64
+            runner: ubuntu-24.04-arm
+            goarch: arm64
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
 
@@ -23,38 +36,73 @@ jobs:
       - name: Build infra binary
         working-directory: infra
         run: |
-          mkdir -p .pulumi/bin
-          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
-            go build -buildvcs=false -o .pulumi/bin/ltbase-infra ./cmd/ltbase-infra
+          mkdir -p dist/${{ matrix.arch }}
+          GOOS=linux GOARCH=${{ matrix.goarch }} CGO_ENABLED=0 \
+            go build -buildvcs=false -o dist/${{ matrix.arch }}/ltbase-infra ./cmd/ltbase-infra
 
-      - name: Write binary manifest
+      - name: Package release asset
         working-directory: infra
         run: |
-          sha256="$(shasum -a 256 .pulumi/bin/ltbase-infra | awk '{print $1}')"
-          go_version="$(go version | awk '{print $3}')"
+          tarball="ltbase-blueprint-binaries-${{ matrix.arch }}.tar.gz"
+          tar -C dist/${{ matrix.arch }} -czf "${tarball}" ltbase-infra
+
+      - name: Prepare artifact payload
+        run: |
+          rm -rf dist/release-${{ matrix.arch }}
+          mkdir -p dist/release-${{ matrix.arch }}
+          cp infra/ltbase-blueprint-binaries-${{ matrix.arch }}.tar.gz dist/release-${{ matrix.arch }}/
+          printf '%s\n' "$(go version | awk '{print $3}')" > dist/release-${{ matrix.arch }}/go-version-${{ matrix.arch }}.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.arch }}
+          path: dist/release-${{ matrix.arch }}/*
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          path: dist/release
+
+      - name: Build release manifest
+        run: |
+          release_tag="r$(date -u +"%Y%m%dT%H%M%SZ")"
+          amd64_file="ltbase-blueprint-binaries-linux-amd64.tar.gz"
+          arm64_file="ltbase-blueprint-binaries-linux-arm64.tar.gz"
+          amd64_sha="$(shasum -a 256 dist/release/release-linux-amd64/${amd64_file} | awk '{print $1}')"
+          arm64_sha="$(shasum -a 256 dist/release/release-linux-arm64/${arm64_file} | awk '{print $1}')"
+          amd64_go="$(cat dist/release/release-linux-amd64/go-version-linux-amd64.txt)"
+          arm64_go="$(cat dist/release/release-linux-arm64/go-version-linux-arm64.txt)"
           built_at="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
           jq -n \
             --arg source_repository "${GITHUB_REPOSITORY}" \
             --arg source_commit "${GITHUB_SHA}" \
             --arg source_ref "${GITHUB_REF_NAME}" \
-            --arg project "ltbase-infra" \
-            --arg binary_name "ltbase-infra" \
-            --arg os "linux" \
-            --arg arch "arm64" \
-            --arg sha256 "${sha256}" \
-            --arg go_version "${go_version}" \
+            --arg release_tag "${release_tag}" \
+            --arg amd64_file "${amd64_file}" \
+            --arg amd64_sha "${amd64_sha}" \
+            --arg amd64_go "${amd64_go}" \
+            --arg arm64_file "${arm64_file}" \
+            --arg arm64_sha "${arm64_sha}" \
+            --arg arm64_go "${arm64_go}" \
             --arg built_at "${built_at}" \
-            '{source_repository:$source_repository,source_commit:$source_commit,source_ref:$source_ref,project:$project,binary_name:$binary_name,os:$os,arch:$arch,sha256:$sha256,go_version:$go_version,built_at:$built_at}' \
-            > manifest.json
+            '{source_repository:$source_repository,source_commit:$source_commit,source_ref:$source_ref,release_tag:$release_tag,artifacts:[{file:$amd64_file,arch:"linux-amd64",sha256:$amd64_sha,go_version:$amd64_go,built_at:$built_at},{file:$arm64_file,arch:"linux-arm64",sha256:$arm64_sha,go_version:$arm64_go,built_at:$built_at}]}' \
+            > dist/release/manifest.json
+          printf 'release_tag=%s\n' "${release_tag}" >> "$GITHUB_ENV"
 
-      - name: Prepare artifact payload
+      - name: Publish binaries release
+        env:
+          GH_TOKEN: ${{ secrets.LTBASE_PRIVATE_DEPLOYMENT_BINARIES_TOKEN }}
         run: |
-          rm -rf dist/infra-binary-artifact
-          mkdir -p dist/infra-binary-artifact
-          cp infra/.pulumi/bin/ltbase-infra dist/infra-binary-artifact/ltbase-infra
-          cp infra/manifest.json dist/infra-binary-artifact/manifest.json
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: infra-binary-linux-arm64-${{ github.sha }}
-          path: dist/infra-binary-artifact/*
+          gh release create "${release_tag}" \
+            --repo "Lychee-Technology/ltbase-private-deployment-binaries" \
+            --title "${release_tag}" \
+            --notes "Prebuilt infra binaries for ${GITHUB_REPOSITORY}@${GITHUB_SHA}" \
+            dist/release/release-linux-amd64/ltbase-blueprint-binaries-linux-amd64.tar.gz \
+            dist/release/release-linux-arm64/ltbase-blueprint-binaries-linux-arm64.tar.gz \
+            dist/release/manifest.json

--- a/.github/workflows/build-infra-binary.yml
+++ b/.github/workflows/build-infra-binary.yml
@@ -43,14 +43,14 @@ jobs:
       - name: Package release asset
         working-directory: infra
         run: |
-          tarball="ltbase-blueprint-binaries-${{ matrix.arch }}.tar.gz"
+          tarball="ltbase-infra-bin-${{ matrix.arch }}.tar.gz"
           tar -C dist/${{ matrix.arch }} -czf "${tarball}" ltbase-infra
 
       - name: Prepare artifact payload
         run: |
           rm -rf dist/release-${{ matrix.arch }}
           mkdir -p dist/release-${{ matrix.arch }}
-          cp infra/ltbase-blueprint-binaries-${{ matrix.arch }}.tar.gz dist/release-${{ matrix.arch }}/
+          cp infra/ltbase-infra-bin-${{ matrix.arch }}.tar.gz dist/release-${{ matrix.arch }}/
           printf '%s\n' "$(go version | awk '{print $3}')" > dist/release-${{ matrix.arch }}/go-version-${{ matrix.arch }}.txt
 
       - uses: actions/upload-artifact@v4
@@ -72,8 +72,8 @@ jobs:
       - name: Build release manifest
         run: |
           release_tag="r$(date -u +"%Y%m%dT%H%M%SZ")"
-          amd64_file="ltbase-blueprint-binaries-linux-amd64.tar.gz"
-          arm64_file="ltbase-blueprint-binaries-linux-arm64.tar.gz"
+          amd64_file="ltbase-infra-bin-linux-amd64.tar.gz"
+          arm64_file="ltbase-infra-bin-linux-arm64.tar.gz"
           amd64_sha="$(shasum -a 256 dist/release/release-linux-amd64/${amd64_file} | awk '{print $1}')"
           arm64_sha="$(shasum -a 256 dist/release/release-linux-arm64/${arm64_file} | awk '{print $1}')"
           amd64_go="$(cat dist/release/release-linux-amd64/go-version-linux-amd64.txt)"
@@ -103,6 +103,6 @@ jobs:
             --repo "Lychee-Technology/ltbase-private-deployment-binaries" \
             --title "${release_tag}" \
             --notes "Prebuilt infra binaries for ${GITHUB_REPOSITORY}@${GITHUB_SHA}" \
-            dist/release/release-linux-amd64/ltbase-blueprint-binaries-linux-amd64.tar.gz \
-            dist/release/release-linux-arm64/ltbase-blueprint-binaries-linux-arm64.tar.gz \
+            dist/release/release-linux-amd64/ltbase-infra-bin-linux-amd64.tar.gz \
+            dist/release/release-linux-arm64/ltbase-infra-bin-linux-arm64.tar.gz \
             dist/release/manifest.json

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Use `./scripts/update-sync-template-tooling.sh` first when you want the latest s
 ## Deployment Principles
 
 - the deployment repository downloads official LTBase releases instead of building the application source code
-- official workflows may also download a commit-bound prebuilt `ltbase-infra` binary from the blueprint repository to avoid recompiling the Pulumi Go program on every run
+- official workflows may also download a commit-bound prebuilt `ltbase-infra` binary from `Lychee-Technology/ltbase-private-deployment-binaries` to avoid recompiling the Pulumi Go program on every run
 - customers own the GitHub repository, AWS account resources, and deployment approvals
 - bootstrap scripts prepare repository state and deployment configuration
 - the shared Pulumi backend bucket is created once and lives in the AWS account for the first stack in `PROMOTION_PATH`
@@ -108,6 +108,7 @@ Use `./scripts/update-sync-template-tooling.sh` first when you want the latest s
 - keep local `.env` files private and out of version control
 - use the documentation in `docs/` as the source of truth for customer onboarding
 - keep `infra/.pulumi/bin/ltbase-infra` out of version control; the wrapper can recreate it locally and official workflows may preinstall it temporarily
+- publishing into `ltbase-private-deployment-binaries` requires a repo secret named `LTBASE_PRIVATE_DEPLOYMENT_BINARIES_TOKEN`
 - if a later repository version changes the managed DSQL lifecycle, follow the docs shipped with that version
 - operators must keep Cloudflare SSL mode on `Full (strict)` and enable Authenticated Origin Pulls for the API hostnames
 - once the mTLS rollout is applied, direct `execute-api` access is expected to fail by design

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -101,7 +101,7 @@ Manual path:
 
 - keep `.env` private and outside version control
 - the deployment repository downloads official LTBase releases; it does not build the app itself
-- official workflows may install a commit-bound prebuilt `ltbase-infra` binary from the same blueprint repository before running Pulumi; if no matching artifact exists, the repo's `infra/scripts/pulumi-wrapper.sh` falls back to local source build
+- official workflows may install a commit-bound prebuilt `ltbase-infra` binary from `ltbase-private-deployment-binaries` before running Pulumi; if no matching release exists, the repo's `infra/scripts/pulumi-wrapper.sh` falls back to local source build
 - preview is manual in the customer repo because live credentials are customer-owned
 - manual preview only supports the first stack in `PROMOTION_PATH`
 - protected target environments are guarded by per-stack GitHub environment approval gates during rollout

--- a/docs/superpowers/plans/2026-04-11-prebuilt-infra-binaries.md
+++ b/docs/superpowers/plans/2026-04-11-prebuilt-infra-binaries.md
@@ -1,0 +1,170 @@
+# Prebuilt Infra Binaries Distribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish commit-bound multi-arch Pulumi infra binaries to a dedicated public repo named `ltbase-private-deployment-binaries`, then make `ltbase-deploy-workflows` consume those releases with a safe source-build fallback.
+
+**Architecture:** `ltbase-private-deployment` remains the source-of-truth blueprint repo and gains a publisher workflow that builds `linux-amd64` and `linux-arm64` binaries only when build-relevant inputs change. Those binaries are released into the new public repo `ltbase-private-deployment-binaries` under timestamp tags with a manifest that records the source repo and commit. `ltbase-deploy-workflows` queries that binaries repo by manifest, installs the exact matching binary for the current runner architecture, and falls back to the existing blueprint wrapper when no trusted match exists.
+
+**Tech Stack:** Pulumi Go, GitHub Actions, GitHub Releases, GitHub CLI, Bash, jq, Markdown
+
+**Spec:** `docs/superpowers/specs/2026-04-11-prebuilt-infra-binaries-design.md`
+
+---
+
+## Affected Repos
+
+| Repo | Responsibility |
+|------|----------------|
+| `Lychee-Technology/ltbase-private-deployment` | Build multi-arch blueprint binaries and publish them into the binaries repo |
+| `Lychee-Technology/ltbase-private-deployment-binaries` | Public release-only repo that stores timestamp-tagged binary releases and release metadata |
+| `Lychee-Technology/ltbase-deploy-workflows` | Query the binaries repo, install the matching binary, and preserve source-build fallback |
+
+## Release Contract
+
+**Repo:** `Lychee-Technology/ltbase-private-deployment-binaries`
+
+**Tag format:** `r<timestamp>`
+
+**Release assets:**
+
+- `ltbase-infra-bin-linux-amd64.tar.gz`
+- `ltbase-infra-bin-linux-arm64.tar.gz`
+- `manifest.json`
+
+**`manifest.json` fields:**
+
+- `source_repository`
+- `source_commit`
+- `source_ref`
+- `release_tag`
+- `artifacts[]`
+- per artifact:
+  - `file`
+  - `arch`
+  - `sha256`
+  - `go_version`
+  - `built_at`
+
+**Consumer matching rules:**
+
+- `source_repository` must equal the checked-out blueprint repo
+- `source_commit` must equal the checked-out blueprint commit exactly
+- `arch` must equal the runner architecture expressed as `linux-amd64` or `linux-arm64`
+- the downloaded tarball checksum must equal the manifest checksum before installation
+
+---
+
+## File Map
+
+| File | Responsibility |
+|------|---------------|
+| `ltbase-private-deployment/.github/workflows/build-infra-binary.yml` | Build/publish multi-arch binaries to the binaries repo only when build-relevant inputs change |
+| `ltbase-private-deployment/infra/scripts/pulumi-wrapper.sh` | Preserve source-build fallback after binaries-repo consumption is added |
+| `ltbase-private-deployment/README.md` | Explain the binaries repo publication path and fallback behavior |
+| `ltbase-private-deployment/docs/BOOTSTRAP.md` | Explain that official workflows may use binaries from the public binaries repo |
+| `ltbase-private-deployment/test/prebuilt-infra-binary-test.sh` | Assert publish workflow contract and wrapper behavior |
+| `ltbase-private-deployment-binaries/README.md` | Document the repo purpose, release contract, and consumer expectations |
+| `ltbase-private-deployment-binaries/.gitignore` | Keep the repo release-only and exclude local scratch files |
+| `ltbase-deploy-workflows/.github/actions/install-prebuilt-infra-binary/action.yml` | Accept binaries-repo coordinates and install the matching release asset |
+| `ltbase-deploy-workflows/.github/actions/install-prebuilt-infra-binary/install.sh` | Query releases, fetch manifest, validate checksum, unpack, and install |
+| `ltbase-deploy-workflows/.github/workflows/preview-stack.yml` | Pass binaries-repo settings into the installer action before Pulumi preview |
+| `ltbase-deploy-workflows/.github/workflows/rollout-hop.yml` | Pass binaries-repo settings into the installer action before Pulumi up/refresh |
+| `ltbase-deploy-workflows/README.md` | Document binaries-repo lookup, architecture matching, and fallback semantics |
+| `ltbase-deploy-workflows/test/install-prebuilt-infra-binary-test.sh` | Cover manifest lookup, arch matching, checksum mismatch, and fallback behavior |
+| `ltbase-deploy-workflows/test/generic-workflows-test.sh` | Assert reusable workflows wire the binaries repo installer path |
+
+---
+
+### Task 1: Bootstrap the new public binaries repo contract
+
+**Files:**
+- Create: `ltbase-private-deployment-binaries/README.md`
+- Create: `ltbase-private-deployment-binaries/.gitignore`
+
+- [ ] Create the GitHub repository `Lychee-Technology/ltbase-private-deployment-binaries` as a public repository intended for releases only.
+- [ ] Add a `README.md` that states the repo stores prebuilt blueprint binaries only, not blueprint source code.
+- [ ] Document the release contract in `README.md`, including the tag format `r<timestamp>`, the two tarball names, and `manifest.json`.
+- [ ] Add a minimal `.gitignore` that keeps local scratch files out of the repo while leaving release assets to GitHub Releases instead of git history.
+- [ ] Verify the repo has releases enabled and that the automation identity to be used from `ltbase-private-deployment` has permission to create releases there.
+
+### Task 2: Convert the blueprint publisher from local artifacts to binaries-repo releases
+
+**Files:**
+- Modify: `ltbase-private-deployment/.github/workflows/build-infra-binary.yml`
+- Modify: `ltbase-private-deployment/README.md`
+- Modify: `ltbase-private-deployment/docs/BOOTSTRAP.md`
+- Modify: `ltbase-private-deployment/test/prebuilt-infra-binary-test.sh`
+
+- [ ] Extend `build-infra-binary.yml` to build a two-entry matrix for `linux-amd64` and `linux-arm64`.
+- [ ] Add path filters so automatic publication runs only when build-relevant blueprint inputs change, starting with `infra/**` and the workflow file itself.
+- [ ] Package the produced binary for each matrix entry into `ltbase-infra-bin-linux-<arch>.tar.gz` with a single `ltbase-infra` executable at the tar root.
+- [ ] Generate a single `manifest.json` describing the source repo, source commit, source ref, release tag, and both artifact entries.
+- [ ] Replace the local `upload-artifact` publishing step with release creation and asset upload into `Lychee-Technology/ltbase-private-deployment-binaries` using a dedicated token.
+- [ ] Use a timestamp-derived tag like `r20260411T120102Z` and never overwrite prior releases.
+- [ ] Update docs so they explain that official workflows now look in `ltbase-private-deployment-binaries` first and only fall back to source build when no matching release is available.
+- [ ] Update `test/prebuilt-infra-binary-test.sh` so it asserts the new tarball names, timestamp-tag language, manifest fields, and two-arch expectation.
+
+### Task 3: Preserve the blueprint wrapper as the correctness fallback
+
+**Files:**
+- Modify: `ltbase-private-deployment/infra/scripts/pulumi-wrapper.sh`
+- Modify: `ltbase-private-deployment/test/prebuilt-infra-binary-test.sh`
+
+- [ ] Keep `infra/scripts/pulumi-wrapper.sh` responsible for local source build fallback when `infra/.pulumi/bin/ltbase-infra` is missing.
+- [ ] Do not teach the wrapper about releases, manifests, or remote lookups; the wrapper should stay local and deterministic.
+- [ ] Extend the test so one case proves a preinstalled binary skips rebuild, and another case proves the wrapper still rebuilds locally when no binary has been installed.
+
+### Task 4: Teach reusable workflows to search the binaries repo by manifest
+
+**Files:**
+- Modify: `ltbase-deploy-workflows/.github/actions/install-prebuilt-infra-binary/action.yml`
+- Modify: `ltbase-deploy-workflows/.github/actions/install-prebuilt-infra-binary/install.sh`
+- Modify: `ltbase-deploy-workflows/.github/workflows/preview-stack.yml`
+- Modify: `ltbase-deploy-workflows/.github/workflows/rollout-hop.yml`
+- Modify: `ltbase-deploy-workflows/README.md`
+- Modify: `ltbase-deploy-workflows/test/install-prebuilt-infra-binary-test.sh`
+- Modify: `ltbase-deploy-workflows/test/generic-workflows-test.sh`
+
+- [ ] Add installer action inputs for `binaries-repo`, `token`, and any small lookup knobs needed to keep the action generic.
+- [ ] Make the install script determine the runner architecture and normalize it to `linux-amd64` or `linux-arm64`.
+- [ ] Query recent releases from `Lychee-Technology/ltbase-private-deployment-binaries`, inspect `manifest.json`, and select the release whose manifest matches the checked-out source repo and commit exactly.
+- [ ] Download the matching tarball, verify its checksum against the manifest entry, unpack it, and install `ltbase-infra` into `blueprint/<working-directory>/.pulumi/bin/ltbase-infra`.
+- [ ] Keep all negative cases non-breaking: missing release, missing manifest, missing matching arch, or checksum mismatch must all set `installed=false` and return success so the wrapper can build from source.
+- [ ] Wire the updated installer into `preview-stack.yml` and `rollout-hop.yml` before Pulumi execution, passing the default binaries repo name and the required secret token.
+- [ ] Update README and workflow tests so they describe the binaries repo lookup path, manifest matching, and fallback behavior clearly.
+
+### Task 5: Add explicit secret and operator contract for cross-repo publishing and download
+
+**Files:**
+- Modify: `ltbase-private-deployment/README.md`
+- Modify: `ltbase-private-deployment/docs/BOOTSTRAP.md`
+- Modify: `ltbase-deploy-workflows/README.md`
+
+- [ ] Document the producer-side secret required for `ltbase-private-deployment` to create releases in `ltbase-private-deployment-binaries`.
+- [ ] Document the consumer-side secret required for `ltbase-deploy-workflows` to read release assets from `ltbase-private-deployment-binaries`.
+- [ ] State explicitly that binaries repo publication is an optimization path, not the correctness path, and that source-build fallback remains authoritative.
+- [ ] State explicitly that `ltbase-releases` remains the application release channel and is unchanged by this plan.
+
+### Task 6: Verify release publication and consumer fallback end to end
+
+**Files:**
+- Verify: `ltbase-private-deployment/.github/workflows/build-infra-binary.yml`
+- Verify: `ltbase-deploy-workflows/.github/actions/install-prebuilt-infra-binary/install.sh`
+- Verify: `ltbase-deploy-workflows/.github/workflows/preview-stack.yml`
+- Verify: `ltbase-deploy-workflows/.github/workflows/rollout-hop.yml`
+
+- [ ] Run the updated blueprint publisher once on a build-relevant commit and confirm it creates a release in `ltbase-private-deployment-binaries` tagged `r<timestamp>`.
+- [ ] Confirm the release contains exactly the two tarballs plus `manifest.json`.
+- [ ] Confirm the manifest records the source repo and commit correctly.
+- [ ] Run the reusable workflow installer tests and confirm they cover commit mismatch, missing arch, checksum mismatch, and success cases.
+- [ ] Run preview or rollout once on an ARM runner and confirm logs show the binary came from `ltbase-private-deployment-binaries` when a matching release exists.
+- [ ] Force a commit that has no published release and confirm the workflow still succeeds through the wrapper-based source build fallback.
+
+---
+
+## Suggested Issue Split
+
+1. `ltbase-private-deployment`: publish multi-arch blueprint binaries into `ltbase-private-deployment-binaries`
+2. `ltbase-deploy-workflows`: consume `ltbase-private-deployment-binaries` releases by manifest and preserve fallback
+3. `ltbase-private-deployment`: bootstrap the new public repo `ltbase-private-deployment-binaries` and document its contract

--- a/docs/superpowers/specs/2026-04-11-prebuilt-infra-binaries-design.md
+++ b/docs/superpowers/specs/2026-04-11-prebuilt-infra-binaries-design.md
@@ -1,0 +1,270 @@
+# Prebuilt Infra Binaries Distribution Design
+
+## Purpose
+
+Move prebuilt Pulumi infra binaries out of blueprint-local GitHub Actions artifacts and into a dedicated public distribution repository so official workflows can consume stable multi-arch binaries without tying their lifecycle to `ltbase-private-deployment` releases.
+
+The immediate target is the LTBase private deployment blueprint flow:
+
+- producer source repo: `ltbase-private-deployment`
+- binary distribution repo: `ltbase-private-deployment-binaries`
+- consumer workflow repo: `ltbase-deploy-workflows`
+
+## Background
+
+Phase 1 added commit-bound prebuilt infra binaries directly in the blueprint repositories as GitHub Actions artifacts. That solved repeated recompilation of the Pulumi Go program, but it has three limitations:
+
+1. artifact retention is not a long-term distribution mechanism
+2. artifacts are awkward for multi-arch publishing and discovery
+3. the blueprint source repo should not become the long-term binary registry
+
+The user wants a dedicated public repository for binaries with these rules:
+
+- repo name: `ltbase-private-deployment-binaries`
+- release tag format: `r<timestamp>`
+- asset names:
+  - `ltbase-infra-bin-linux-amd64.tar.gz`
+  - `ltbase-infra-bin-linux-arm64.tar.gz`
+
+The user also wants to avoid recompiling on every unrelated blueprint repo update and to support both Linux x64 and ARM64.
+
+## Scope
+
+This design covers:
+
+- publishing prebuilt infra binaries from `ltbase-private-deployment` into `ltbase-private-deployment-binaries`
+- release and manifest contract for binary discovery
+- multi-arch binary publishing for `linux/amd64` and `linux/arm64`
+- consumption logic in `ltbase-deploy-workflows`
+- fallback behavior when no matching binary exists
+
+It does not cover:
+
+- moving application release assets out of `ltbase-releases`
+- customer fork publication into the new binaries repo
+- signing, attestations, or provenance beyond checksums in this version
+- deprecating the existing source-build fallback
+
+## Decisions
+
+### 1. Use a dedicated public binaries repo
+
+Prebuilt infra binaries will live in a separate public repository named `ltbase-private-deployment-binaries`.
+
+Rationale:
+
+- keeps blueprint source and binary distribution separate
+- avoids polluting `ltbase-private-deployment` with high-volume machine-oriented releases
+- avoids mixing blueprint binaries into `ltbase-releases`, which is reserved for official application release assets
+
+### 2. Publish by source commit, not by application release ID
+
+The binary identity is tied to the exact blueprint source commit that produced it.
+
+The binary is not an application release asset. It is a build artifact for the Pulumi program owned by the blueprint repo. Matching must therefore use:
+
+- source repository
+- source commit
+- target architecture
+
+Tag names such as `r<timestamp>` are only containers for publication. They are not semantic version identifiers for the consumer.
+
+### 3. Support two Linux architectures in version 1
+
+The binaries repo will publish:
+
+- `linux/amd64`
+- `linux/arm64`
+
+These map to the two expected runtime targets for CI and operational flexibility.
+
+### 4. Publish only when build-relevant inputs change
+
+Automatic publishing from `ltbase-private-deployment` should trigger only when changes can affect the compiled Pulumi program or its execution contract.
+
+Initial path filter:
+
+- `infra/**`
+- `.github/workflows/build-infra-binary*.yml`
+- `docs/` excluded
+- top-level docs and onboarding changes excluded unless they also touch infra build inputs
+
+This avoids recompiling on documentation-only or unrelated template maintenance changes.
+
+### 5. Keep source-build fallback as the correctness path
+
+`ltbase-deploy-workflows` will treat the binaries repo as an optimization layer only.
+
+If the workflow cannot find a matching binary for the exact source commit and current architecture, or if checksum validation fails, it must continue with the existing wrapper-based source build path.
+
+This preserves correctness and keeps official workflows resilient during publication lag or transient release lookup failures.
+
+### 6. Use timestamp tags plus manifest-driven lookup
+
+Each publication in `ltbase-private-deployment-binaries` creates a new release tagged `r<timestamp>`.
+
+Consumers must not infer semantics from the tag. They must inspect `manifest.json` to find a binary whose:
+
+- `source_repository` matches the current blueprint repo
+- `source_commit` matches the checked-out commit exactly
+- `arch` matches the current runner architecture
+
+This keeps the tag format simple while making matching explicit and future-proof.
+
+## Architecture
+
+## Producer side: `ltbase-private-deployment`
+
+The blueprint repo keeps owning the source code and the build recipe.
+
+Producer workflow responsibilities:
+
+1. detect whether a push or manual run should publish binaries
+2. build `ltbase-infra` for `linux/amd64` and `linux/arm64`
+3. package each binary as:
+   - `ltbase-infra-bin-linux-amd64.tar.gz`
+   - `ltbase-infra-bin-linux-arm64.tar.gz`
+4. generate a single `manifest.json`
+5. create a release in `ltbase-private-deployment-binaries` tagged `r<timestamp>`
+6. upload both tarballs plus `manifest.json`
+
+The producer must publish metadata that allows exact source-commit lookup. It should not require the consumer to guess which release belongs to which source commit.
+
+## Distribution side: `ltbase-private-deployment-binaries`
+
+This repository is a release-only distribution channel for public blueprint binaries.
+
+Expected contents per release:
+
+- `ltbase-infra-bin-linux-amd64.tar.gz`
+- `ltbase-infra-bin-linux-arm64.tar.gz`
+- `manifest.json`
+
+The repo should not store blueprint source code.
+
+## Consumer side: `ltbase-deploy-workflows`
+
+The reusable workflows gain a lookup path that:
+
+1. identifies the checked-out blueprint repository and commit
+2. determines the runner architecture
+3. queries `ltbase-private-deployment-binaries` releases
+4. downloads `manifest.json` from candidate releases
+5. finds the matching artifact by source repo, source commit, and arch
+6. downloads the corresponding tarball
+7. verifies checksum
+8. installs `ltbase-infra` into `blueprint/<working_directory>/.pulumi/bin/ltbase-infra`
+
+If any step fails to produce a trustworthy exact match, the workflow emits `installed=false` and leaves the current wrapper path to build from source.
+
+## Manifest contract
+
+Each release includes one `manifest.json` with this shape:
+
+```json
+{
+  "source_repository": "Lychee-Technology/ltbase-private-deployment",
+  "source_commit": "<git sha>",
+  "source_ref": "main",
+  "release_tag": "r20260411T120102Z",
+  "artifacts": [
+    {
+      "file": "ltbase-infra-bin-linux-amd64.tar.gz",
+      "arch": "linux-amd64",
+      "sha256": "...",
+      "go_version": "go1.x.y",
+      "built_at": "2026-04-11T12:01:02Z"
+    },
+    {
+      "file": "ltbase-infra-bin-linux-arm64.tar.gz",
+      "arch": "linux-arm64",
+      "sha256": "...",
+      "go_version": "go1.x.y",
+      "built_at": "2026-04-11T12:01:02Z"
+    }
+  ]
+}
+```
+
+Notes:
+
+- `source_commit` is the primary identity field for consumers
+- `release_tag` is recorded for auditability only
+- `arch` values should use the same strings as the asset suffixes to avoid translation ambiguity
+
+## Data flow
+
+1. A change lands in `ltbase-private-deployment` that affects infra build output.
+2. The producer workflow builds both Linux binaries.
+3. The workflow creates a release in `ltbase-private-deployment-binaries` tagged `r<timestamp>`.
+4. The release publishes both tarballs and `manifest.json`.
+5. A reusable workflow in `ltbase-deploy-workflows` checks out the blueprint repo.
+6. Before Pulumi runs, it looks for a matching binary in `ltbase-private-deployment-binaries`.
+7. If it finds a release whose manifest matches the checked-out source commit and current architecture, it downloads and installs the binary.
+8. If it does not find one, or validation fails, the blueprint wrapper builds from source.
+
+## Error handling and operator experience
+
+Expected situations:
+
+- no matching binary exists yet for the current commit
+- binary release publication is delayed relative to source push
+- checksum mismatch or malformed manifest
+- target architecture not published
+
+All of these should degrade to source build, not workflow failure.
+
+Workflow logs should clearly say whether execution used:
+
+- prebuilt binary from `ltbase-private-deployment-binaries`, or
+- source-build fallback via `infra/scripts/pulumi-wrapper.sh`
+
+## Testing
+
+### Producer tests
+
+- validate release packaging names for both architectures
+- validate `manifest.json` fields and checksums
+- validate path filters only publish when build-relevant inputs change
+
+### Consumer tests
+
+- install succeeds when source repo, source commit, and arch all match
+- install skips when commit differs
+- install skips when arch is missing
+- install skips on checksum mismatch
+- fallback path remains green when no release matches
+
+### End-to-end verification
+
+- publish one release from `ltbase-private-deployment` into `ltbase-private-deployment-binaries`
+- confirm `ltbase-deploy-workflows` can download `linux-arm64` on the ARM runner path
+- confirm forcing a commit without a published binary still succeeds via source build fallback
+
+## Trade-offs
+
+Pros:
+
+- clean separation between blueprint source and binary distribution
+- long-lived multi-arch binary retention
+- exact source-commit matching remains possible
+- reusable workflows stay resilient through fallback
+
+Cons:
+
+- one more repository and publication token to manage
+- consumer logic becomes release-search based instead of local-artifact based
+- timestamp-tagged releases are machine-oriented and not especially human-friendly
+
+## Rollout plan
+
+### Phase 2A
+
+- create `ltbase-private-deployment-binaries`
+- make `ltbase-private-deployment` publish both architectures there
+- make `ltbase-deploy-workflows` query the binaries repo first, then fall back to source build
+
+### Phase 2B
+
+- decide whether `demo01` or other official blueprint repos should publish to the same binaries repo using the same manifest contract
+- keep the contract generic enough to support multiple source repositories without changing consumer semantics

--- a/infra/scripts/pulumi-wrapper.sh
+++ b/infra/scripts/pulumi-wrapper.sh
@@ -9,8 +9,7 @@ cd "${infra_dir}"
 mkdir -p .pulumi/bin
 
 if [[ ! -x .pulumi/bin/ltbase-infra ]]; then
-  GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
-    go build -buildvcs=false -o .pulumi/bin/ltbase-infra ./cmd/ltbase-infra
+  CGO_ENABLED=0 go build -buildvcs=false -o .pulumi/bin/ltbase-infra ./cmd/ltbase-infra
 fi
 
 exec pulumi "$@"

--- a/test/prebuilt-infra-binary-test.sh
+++ b/test/prebuilt-infra-binary-test.sh
@@ -39,10 +39,16 @@ assert_file_contains "${GITIGNORE_PATH}" "infra/.pulumi/"
 
 assert_file_contains "${WORKFLOW_PATH}" "workflow_dispatch:"
 assert_file_contains "${WORKFLOW_PATH}" "push:"
-assert_file_contains "${WORKFLOW_PATH}" "runs-on: ubuntu-24.04-arm"
-assert_file_contains "${WORKFLOW_PATH}" 'name: infra-binary-linux-arm64-${{ github.sha }}'
+assert_file_contains "${WORKFLOW_PATH}" "paths:"
+assert_file_contains "${WORKFLOW_PATH}" "matrix:"
+assert_file_contains "${WORKFLOW_PATH}" "linux-amd64"
+assert_file_contains "${WORKFLOW_PATH}" "linux-arm64"
+assert_file_contains "${WORKFLOW_PATH}" "ltbase-private-deployment-binaries"
+assert_file_contains "${WORKFLOW_PATH}" 'r$(date -u +"%Y%m%dT%H%M%SZ")'
+assert_file_contains "${WORKFLOW_PATH}" "ltbase-blueprint-binaries-linux-amd64.tar.gz"
+assert_file_contains "${WORKFLOW_PATH}" "ltbase-blueprint-binaries-linux-arm64.tar.gz"
 assert_file_contains "${WORKFLOW_PATH}" "manifest.json"
-assert_file_contains "${WORKFLOW_PATH}" ".pulumi/bin/ltbase-infra"
+assert_file_contains "${WORKFLOW_PATH}" "release_tag"
 
 temp_dir="$(mktemp -d)"
 trap 'rm -rf "${temp_dir}"' EXIT
@@ -101,5 +107,8 @@ PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" "${temp_dir}/infra/scripts/pu
 
 assert_log_contains "${log_file}" "go build -buildvcs=false -o .pulumi/bin/ltbase-infra ./cmd/ltbase-infra"
 assert_log_contains "${log_file}" "pulumi up --stack devo"
+
+assert_file_contains "${ROOT_DIR}/README.md" "ltbase-private-deployment-binaries"
+assert_file_contains "${ROOT_DIR}/docs/BOOTSTRAP.md" "ltbase-private-deployment-binaries"
 
 printf 'PASS: prebuilt infra binary tests\n'

--- a/test/prebuilt-infra-binary-test.sh
+++ b/test/prebuilt-infra-binary-test.sh
@@ -45,8 +45,8 @@ assert_file_contains "${WORKFLOW_PATH}" "linux-amd64"
 assert_file_contains "${WORKFLOW_PATH}" "linux-arm64"
 assert_file_contains "${WORKFLOW_PATH}" "ltbase-private-deployment-binaries"
 assert_file_contains "${WORKFLOW_PATH}" 'r$(date -u +"%Y%m%dT%H%M%SZ")'
-assert_file_contains "${WORKFLOW_PATH}" "ltbase-blueprint-binaries-linux-amd64.tar.gz"
-assert_file_contains "${WORKFLOW_PATH}" "ltbase-blueprint-binaries-linux-arm64.tar.gz"
+assert_file_contains "${WORKFLOW_PATH}" "ltbase-infra-bin-linux-amd64.tar.gz"
+assert_file_contains "${WORKFLOW_PATH}" "ltbase-infra-bin-linux-arm64.tar.gz"
 assert_file_contains "${WORKFLOW_PATH}" "manifest.json"
 assert_file_contains "${WORKFLOW_PATH}" "release_tag"
 


### PR DESCRIPTION
## Summary
- publish blueprint binaries to `Lychee-Technology/ltbase-private-deployment-binaries` instead of blueprint-local action artifacts
- build and package both `linux-amd64` and `linux-arm64`, then publish them under timestamped releases with a manifest keyed by source commit
- keep `infra/scripts/pulumi-wrapper.sh` as the source-build fallback and document the new token/repo contract

## Testing
- `go test ./...` in `infra`
- `for f in test/*.sh; do bash "$f"; done`

## Validation
- real publish workflow passed: `https://github.com/Lychee-Technology/ltbase-private-deployment/actions/runs/24297643753`
- real binaries release created in `Lychee-Technology/ltbase-private-deployment-binaries`: `r20260412T032201Z`
- latest release contains:
  - `ltbase-infra-bin-linux-amd64.tar.gz`
  - `ltbase-infra-bin-linux-arm64.tar.gz`
  - `manifest.json`

## Linked Issue
- Closes #49
- Refs #50
