### PR TITLE
fix: reduce deployment script log noise

### DIFF
--- a/scripts/bootstrap-all.sh
+++ b/scripts/bootstrap-all.sh
@@ -42,10 +42,19 @@ if [[ "${MODE}" != "apply" ]]; then
   exit 1
 fi
 
-"${script_dir}/create-deployment-repo.sh" --env-file "${ENV_FILE}"
-"${script_dir}/render-bootstrap-policies.sh" --env-file "${ENV_FILE}"
-"${script_dir}/bootstrap-aws-foundation.sh" --env-file "${ENV_FILE}"
-"${script_dir}/bootstrap-oidc-discovery-companion.sh" --env-file "${ENV_FILE}"
+bootstrap_env_info "ensuring deployment repository"
+bootstrap_env_run_quiet "${script_dir}/create-deployment-repo.sh" --env-file "${ENV_FILE}"
+
+bootstrap_env_info "rendering bootstrap policies"
+bootstrap_env_run_quiet "${script_dir}/render-bootstrap-policies.sh" --env-file "${ENV_FILE}"
+
+bootstrap_env_info "bootstrapping AWS foundation"
+bootstrap_env_run_quiet "${script_dir}/bootstrap-aws-foundation.sh" --env-file "${ENV_FILE}"
+
+bootstrap_env_info "ensuring OIDC discovery companion"
+bootstrap_env_run_quiet "${script_dir}/bootstrap-oidc-discovery-companion.sh" --env-file "${ENV_FILE}"
+
 while IFS= read -r stack; do
-  "${script_dir}/bootstrap-deployment-repo.sh" --env-file "${ENV_FILE}" --stack "${stack}" --infra-dir "${INFRA_DIR}"
+  bootstrap_env_info "configuring stack ${stack}"
+  bootstrap_env_run_quiet "${script_dir}/bootstrap-deployment-repo.sh" --env-file "${ENV_FILE}" --stack "${stack}" --infra-dir "${INFRA_DIR}"
 done < <(bootstrap_env_each_stack)

--- a/scripts/bootstrap-aws-foundation.sh
+++ b/scripts/bootstrap-aws-foundation.sh
@@ -32,6 +32,26 @@ script_dir="$(cd "$(dirname "$0")" && pwd)"
 source "${script_dir}/lib/bootstrap-env.sh"
 bootstrap_env_load "${ENV_FILE}"
 
+capture_stdout_quiet() {
+  local destination_var="$1"
+  local output command_status stderr_file
+  shift
+
+  stderr_file="$(mktemp)"
+  if output="$("$@" 2>"${stderr_file}")"; then
+    rm -f "${stderr_file}"
+    printf -v "${destination_var}" '%s' "${output}"
+    return 0
+  fi
+
+  command_status=$?
+  if [[ -s "${stderr_file}" ]]; then
+    cat "${stderr_file}" >&2
+  fi
+  rm -f "${stderr_file}"
+  return "${command_status}"
+}
+
 required_vars=(DEPLOYMENT_REPO AWS_REGION_DEVO AWS_REGION_PROD AWS_ACCOUNT_ID_DEVO AWS_ACCOUNT_ID_PROD AWS_ROLE_NAME_DEVO AWS_ROLE_NAME_PROD PULUMI_STATE_BUCKET PULUMI_KMS_ALIAS)
 for name in "${required_vars[@]}"; do
   if [[ -z "${!name:-}" ]]; then
@@ -66,6 +86,7 @@ first_stack="$(bootstrap_env_csv_first "${PROMOTION_PATH:-${STACKS}}")"
 first_region="$(bootstrap_env_resolve_stack_value AWS_REGION "${first_stack}")"
 
 while IFS= read -r stack; do
+  bootstrap_env_info "Validating AWS credentials for stack: ${stack}"
   bootstrap_env_require_aws_credentials_for_stack "${stack}"
   stack_upper="$(bootstrap_env_stack_upper "${stack}")"
   stack_region="$(bootstrap_env_resolve_stack_value AWS_REGION "${stack}")"
@@ -148,37 +169,39 @@ EOF
 }
 EOF
 
+  bootstrap_env_info "Reconciling IAM and KMS resources for stack: ${stack}"
   if ! bootstrap_env_aws_command_for_stack "${stack}" iam get-open-id-connect-provider --open-id-connect-provider-arn "${provider_arn}" >/dev/null 2>&1; then
-    bootstrap_env_aws_command_for_stack "${stack}" iam create-open-id-connect-provider --url https://token.actions.githubusercontent.com --client-id-list sts.amazonaws.com >/dev/null
+    bootstrap_env_run_quiet bootstrap_env_aws_command_for_stack "${stack}" iam create-open-id-connect-provider --url https://token.actions.githubusercontent.com --client-id-list sts.amazonaws.com
   fi
 
   if ! bootstrap_env_aws_command_for_stack "${stack}" iam get-role --role-name "${stack_role_name}" >/dev/null 2>&1; then
-    bootstrap_env_aws_command_for_stack "${stack}" iam create-role --role-name "${stack_role_name}" --assume-role-policy-document "file://${trust_policy_path}" >/dev/null
+    bootstrap_env_run_quiet bootstrap_env_aws_command_for_stack "${stack}" iam create-role --role-name "${stack_role_name}" --assume-role-policy-document "file://${trust_policy_path}"
   fi
 
-  bootstrap_env_aws_command_for_stack "${stack}" iam update-assume-role-policy --role-name "${stack_role_name}" --policy-document "file://${trust_policy_path}" >/dev/null
-  bootstrap_env_aws_command_for_stack "${stack}" iam put-role-policy --role-name "${stack_role_name}" --policy-name LTBaseDeploymentAccess --policy-document "file://${role_policy_path}" >/dev/null
+  bootstrap_env_run_quiet bootstrap_env_aws_command_for_stack "${stack}" iam update-assume-role-policy --role-name "${stack_role_name}" --policy-document "file://${trust_policy_path}"
+  bootstrap_env_run_quiet bootstrap_env_aws_command_for_stack "${stack}" iam put-role-policy --role-name "${stack_role_name}" --policy-name LTBaseDeploymentAccess --policy-document "file://${role_policy_path}"
 
-  alias_json="$(bootstrap_env_aws_command_for_stack "${stack}" kms list-aliases --region "${stack_region}" --output json)"
+  capture_stdout_quiet alias_json bootstrap_env_aws_command_for_stack "${stack}" kms list-aliases --region "${stack_region}" --output json
   key_id="$(python3 -c 'import json,sys; aliases=json.load(sys.stdin).get("Aliases", []); target="'"${PULUMI_KMS_ALIAS}"'"; match=next((a for a in aliases if a.get("AliasName")==target and a.get("TargetKeyId")), None); print(match.get("TargetKeyId", "") if match else "")' <<<"${alias_json}")"
 
   if [[ -z "${key_id}" ]]; then
-    key_id="$(bootstrap_env_aws_command_for_stack "${stack}" kms create-key --region "${stack_region}" --description "Pulumi secrets for LTBase private deployment" --query 'KeyMetadata.KeyId' --output text)"
-    bootstrap_env_aws_command_for_stack "${stack}" kms create-alias --region "${stack_region}" --alias-name "${PULUMI_KMS_ALIAS}" --target-key-id "${key_id}" >/dev/null
+    capture_stdout_quiet key_id bootstrap_env_aws_command_for_stack "${stack}" kms create-key --region "${stack_region}" --description "Pulumi secrets for LTBase private deployment" --query 'KeyMetadata.KeyId' --output text
+    bootstrap_env_run_quiet bootstrap_env_aws_command_for_stack "${stack}" kms create-alias --region "${stack_region}" --alias-name "${PULUMI_KMS_ALIAS}" --target-key-id "${key_id}"
   fi
 
   printf 'AWS_ROLE_ARN_%s=%s\n' "${stack_upper}" "${stack_role_arn}" >>"${summary_path}"
   printf 'PULUMI_SECRETS_PROVIDER_%s=awskms://%s?region=%s\n' "${stack_upper}" "${PULUMI_KMS_ALIAS}" "${stack_region}" >>"${summary_path}"
 done < <(bootstrap_env_each_stack)
 
+bootstrap_env_info "Ensuring shared Pulumi state bucket: ${PULUMI_STATE_BUCKET}"
 if ! bootstrap_env_aws_command_for_stack "${first_stack}" s3api head-bucket --bucket "${PULUMI_STATE_BUCKET}" >/dev/null 2>&1; then
   if [[ "${first_region}" == "us-east-1" ]]; then
-    bootstrap_env_aws_command_for_stack "${first_stack}" s3api create-bucket --bucket "${PULUMI_STATE_BUCKET}" >/dev/null
+    bootstrap_env_run_quiet bootstrap_env_aws_command_for_stack "${first_stack}" s3api create-bucket --bucket "${PULUMI_STATE_BUCKET}"
   else
-    bootstrap_env_aws_command_for_stack "${first_stack}" s3api create-bucket --bucket "${PULUMI_STATE_BUCKET}" --region "${first_region}" --create-bucket-configuration "LocationConstraint=${first_region}" >/dev/null
+    bootstrap_env_run_quiet bootstrap_env_aws_command_for_stack "${first_stack}" s3api create-bucket --bucket "${PULUMI_STATE_BUCKET}" --region "${first_region}" --create-bucket-configuration "LocationConstraint=${first_region}"
   fi
 fi
 
-bootstrap_env_aws_command_for_stack "${first_stack}" s3api put-bucket-versioning --bucket "${PULUMI_STATE_BUCKET}" --versioning-configuration Status=Enabled >/dev/null
-bootstrap_env_aws_command_for_stack "${first_stack}" s3api put-bucket-encryption --bucket "${PULUMI_STATE_BUCKET}" --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}' >/dev/null
-bootstrap_env_aws_command_for_stack "${first_stack}" s3api put-public-access-block --bucket "${PULUMI_STATE_BUCKET}" --public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true >/dev/null
+bootstrap_env_run_quiet bootstrap_env_aws_command_for_stack "${first_stack}" s3api put-bucket-versioning --bucket "${PULUMI_STATE_BUCKET}" --versioning-configuration Status=Enabled
+bootstrap_env_run_quiet bootstrap_env_aws_command_for_stack "${first_stack}" s3api put-bucket-encryption --bucket "${PULUMI_STATE_BUCKET}" --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
+bootstrap_env_run_quiet bootstrap_env_aws_command_for_stack "${first_stack}" s3api put-public-access-block --bucket "${PULUMI_STATE_BUCKET}" --public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true

--- a/scripts/bootstrap-deployment-repo.sh
+++ b/scripts/bootstrap-deployment-repo.sh
@@ -54,26 +54,27 @@ if ! bootstrap_env_require_stack_values "${STACK}" AWS_REGION AWS_ROLE_ARN PULUM
   exit 1
 fi
 
+bootstrap_env_info "configuring repository variables and secrets for ${DEPLOYMENT_REPO}"
 while IFS= read -r target_stack; do
   target_upper="$(bootstrap_env_stack_upper "${target_stack}")"
   target_region="$(bootstrap_env_resolve_stack_value AWS_REGION "${target_stack}")"
   target_secrets_provider="$(bootstrap_env_resolve_stack_value PULUMI_SECRETS_PROVIDER "${target_stack}")"
   target_role_arn="$(bootstrap_env_resolve_stack_value AWS_ROLE_ARN "${target_stack}")"
 
-  gh variable set "AWS_REGION_${target_upper}" --repo "${DEPLOYMENT_REPO}" --body "${target_region}"
-  gh variable set "PULUMI_SECRETS_PROVIDER_${target_upper}" --repo "${DEPLOYMENT_REPO}" --body "${target_secrets_provider}"
-  gh secret set "AWS_ROLE_ARN_${target_upper}" --repo "${DEPLOYMENT_REPO}" --body "${target_role_arn}"
+  bootstrap_env_run_quiet gh variable set "AWS_REGION_${target_upper}" --repo "${DEPLOYMENT_REPO}" --body "${target_region}"
+  bootstrap_env_run_quiet gh variable set "PULUMI_SECRETS_PROVIDER_${target_upper}" --repo "${DEPLOYMENT_REPO}" --body "${target_secrets_provider}"
+  bootstrap_env_run_quiet gh secret set "AWS_ROLE_ARN_${target_upper}" --repo "${DEPLOYMENT_REPO}" --body "${target_role_arn}"
 done < <(bootstrap_env_each_stack)
 
-gh variable set PULUMI_BACKEND_URL --repo "${DEPLOYMENT_REPO}" --body "${PULUMI_BACKEND_URL}"
-gh variable set LTBASE_RELEASES_REPO --repo "${DEPLOYMENT_REPO}" --body "${LTBASE_RELEASES_REPO}"
-gh variable set LTBASE_RELEASE_ID --repo "${DEPLOYMENT_REPO}" --body "${LTBASE_RELEASE_ID}"
-gh variable set STACKS --repo "${DEPLOYMENT_REPO}" --body "${STACKS}"
-gh variable set PROMOTION_PATH --repo "${DEPLOYMENT_REPO}" --body "${PROMOTION_PATH}"
-gh variable set PREVIEW_DEFAULT_STACK --repo "${DEPLOYMENT_REPO}" --body "${PREVIEW_DEFAULT_STACK}"
+bootstrap_env_run_quiet gh variable set PULUMI_BACKEND_URL --repo "${DEPLOYMENT_REPO}" --body "${PULUMI_BACKEND_URL}"
+bootstrap_env_run_quiet gh variable set LTBASE_RELEASES_REPO --repo "${DEPLOYMENT_REPO}" --body "${LTBASE_RELEASES_REPO}"
+bootstrap_env_run_quiet gh variable set LTBASE_RELEASE_ID --repo "${DEPLOYMENT_REPO}" --body "${LTBASE_RELEASE_ID}"
+bootstrap_env_run_quiet gh variable set STACKS --repo "${DEPLOYMENT_REPO}" --body "${STACKS}"
+bootstrap_env_run_quiet gh variable set PROMOTION_PATH --repo "${DEPLOYMENT_REPO}" --body "${PROMOTION_PATH}"
+bootstrap_env_run_quiet gh variable set PREVIEW_DEFAULT_STACK --repo "${DEPLOYMENT_REPO}" --body "${PREVIEW_DEFAULT_STACK}"
 
-gh secret set LTBASE_RELEASES_TOKEN --repo "${DEPLOYMENT_REPO}" --body "${LTBASE_RELEASES_TOKEN}"
-gh secret set CLOUDFLARE_API_TOKEN --repo "${DEPLOYMENT_REPO}" --body "${CLOUDFLARE_API_TOKEN}"
+bootstrap_env_run_quiet gh secret set LTBASE_RELEASES_TOKEN --repo "${DEPLOYMENT_REPO}" --body "${LTBASE_RELEASES_TOKEN}"
+bootstrap_env_run_quiet gh secret set CLOUDFLARE_API_TOKEN --repo "${DEPLOYMENT_REPO}" --body "${CLOUDFLARE_API_TOKEN}"
 
 selected_region="$(bootstrap_env_resolve_stack_value AWS_REGION "${STACK}")"
 backend_stack="$(bootstrap_env_csv_first "${PROMOTION_PATH:-${STACKS}}")"
@@ -102,31 +103,43 @@ while IFS= read -r token; do
 done < <(bootstrap_env_stack_runtime_env "${STACK}")
 
 pushd "${INFRA_DIR}" >/dev/null
-"${backend_env[@]}" pulumi login "${PULUMI_BACKEND_URL}"
-if ! "${stack_env[@]}" pulumi stack select "${STACK}" >/dev/null 2>&1; then
-  "${stack_env[@]}" pulumi stack init "${STACK}" --secrets-provider "${selected_secrets_provider}"
+bootstrap_env_info "configuring Pulumi stack ${STACK}"
+bootstrap_env_run_quiet "${backend_env[@]}" pulumi login "${PULUMI_BACKEND_URL}"
+stack_select_output=""
+if stack_select_output="$("${stack_env[@]}" pulumi stack select "${STACK}" 2>&1)"; then
+  :
+else
+  stack_select_status=$?
+  if [[ "${stack_select_output}" == *"no stack named"*"found"* ]]; then
+    bootstrap_env_run_quiet "${stack_env[@]}" pulumi stack init "${STACK}" --secrets-provider "${selected_secrets_provider}"
+  else
+    if [[ -n "${stack_select_output}" ]]; then
+      printf '%s\n' "${stack_select_output}" >&2
+    fi
+    exit "${stack_select_status}"
+  fi
 fi
-"${stack_env[@]}" pulumi config set awsRegion "${selected_region}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set runtimeBucket "${selected_runtime_bucket}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set tableName "${selected_table_name}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set mtlsTruststoreFile "${MTLS_TRUSTSTORE_FILE}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set mtlsTruststoreKey "${MTLS_TRUSTSTORE_KEY}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set apiDomain "${selected_api_domain}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set controlPlaneDomain "${selected_control_domain}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set authDomain "${selected_auth_domain}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set projectId "${selected_project_id}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set authProviderConfigFile "${selected_auth_provider_config_file}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set cloudflareZoneId "${CLOUDFLARE_ZONE_ID}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set oidcIssuerUrl "${selected_oidc_issuer_url}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set jwksUrl "${selected_jwks_url}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set githubOidcProviderArn "${selected_github_oidc_provider_arn}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set githubOrg "${GITHUB_ORG}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set githubRepo "${GITHUB_REPO}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set releaseId "${LTBASE_RELEASE_ID}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set dsqlPort "${DSQL_PORT}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set dsqlDB "${DSQL_DB}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set dsqlUser "${DSQL_USER}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set dsqlProjectSchema "${DSQL_PROJECT_SCHEMA}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set geminiModel "${GEMINI_MODEL}" --stack "${STACK}"
-"${stack_env[@]}" pulumi config set --secret geminiApiKey "${GEMINI_API_KEY}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set awsRegion "${selected_region}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set runtimeBucket "${selected_runtime_bucket}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set tableName "${selected_table_name}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set mtlsTruststoreFile "${MTLS_TRUSTSTORE_FILE}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set mtlsTruststoreKey "${MTLS_TRUSTSTORE_KEY}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set apiDomain "${selected_api_domain}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set controlPlaneDomain "${selected_control_domain}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set authDomain "${selected_auth_domain}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set projectId "${selected_project_id}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set authProviderConfigFile "${selected_auth_provider_config_file}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set cloudflareZoneId "${CLOUDFLARE_ZONE_ID}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set oidcIssuerUrl "${selected_oidc_issuer_url}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set jwksUrl "${selected_jwks_url}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set githubOidcProviderArn "${selected_github_oidc_provider_arn}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set githubOrg "${GITHUB_ORG}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set githubRepo "${GITHUB_REPO}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set releaseId "${LTBASE_RELEASE_ID}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set dsqlPort "${DSQL_PORT}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set dsqlDB "${DSQL_DB}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set dsqlUser "${DSQL_USER}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set dsqlProjectSchema "${DSQL_PROJECT_SCHEMA}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set geminiModel "${GEMINI_MODEL}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set --secret geminiApiKey "${GEMINI_API_KEY}" --stack "${STACK}"
 popd >/dev/null

--- a/scripts/bootstrap-oidc-discovery-companion.sh
+++ b/scripts/bootstrap-oidc-discovery-companion.sh
@@ -32,6 +32,26 @@ script_dir="$(cd "$(dirname "$0")" && pwd)"
 source "${script_dir}/lib/bootstrap-env.sh"
 bootstrap_env_load "${ENV_FILE}"
 
+capture_stdout_quiet() {
+  local destination_var="$1"
+  local output command_status stderr_file
+  shift
+
+  stderr_file="$(mktemp)"
+  if output="$("$@" 2>"${stderr_file}")"; then
+    rm -f "${stderr_file}"
+    printf -v "${destination_var}" '%s' "${output}"
+    return 0
+  fi
+
+  command_status=$?
+  if [[ -s "${stderr_file}" ]]; then
+    cat "${stderr_file}" >&2
+  fi
+  rm -f "${stderr_file}"
+  return "${command_status}"
+}
+
 required_vars=(GITHUB_OWNER DEPLOYMENT_REPO_NAME DEPLOYMENT_REPO_VISIBILITY OIDC_DISCOVERY_DOMAIN CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN CLOUDFLARE_ZONE_ID OIDC_DISCOVERY_TEMPLATE_REPO OIDC_DISCOVERY_REPO_NAME OIDC_DISCOVERY_REPO OIDC_DISCOVERY_PAGES_PROJECT)
 bootstrap_env_require_vars "${required_vars[@]}"
 
@@ -84,10 +104,21 @@ sys.exit(0 if payload.get("success") is True else 1)
 cloudflare_get_exists() {
   local action="$1"
   local url="$2"
-  local response_file status response
+  local response_file status response curl_status
 
   response_file="$(mktemp)"
-  status="$(curl -sS -o "${response_file}" -w '%{http_code}' "${cloudflare_headers[@]}" "${url}")" || status="$?"
+  if capture_stdout_quiet status curl -sS -o "${response_file}" -w '%{http_code}' "${cloudflare_headers[@]}" "${url}"; then
+    :
+  else
+    curl_status=$?
+    response="$(<"${response_file}")"
+    rm -f "${response_file}"
+    printf 'Cloudflare API request failed: %s\n' "${action}" >&2
+    if [[ -n "${response}" ]]; then
+      printf '%s\n' "${response}" >&2
+    fi
+    exit "${curl_status}"
+  fi
   response="$(<"${response_file}")"
   rm -f "${response_file}"
 
@@ -131,10 +162,21 @@ cloudflare_post() {
   local action="$1"
   local url="$2"
   local payload="$3"
-  local response_file status response
+  local response_file status response curl_status
 
   response_file="$(mktemp)"
-  status="$(curl -sS -o "${response_file}" -w '%{http_code}' -X POST "${cloudflare_headers[@]}" "${url}" --data "${payload}")" || status="$?"
+  if capture_stdout_quiet status curl -sS -o "${response_file}" -w '%{http_code}' -X POST "${cloudflare_headers[@]}" "${url}" --data "${payload}"; then
+    :
+  else
+    curl_status=$?
+    response="$(<"${response_file}")"
+    rm -f "${response_file}"
+    printf 'Cloudflare API request failed: %s\n' "${action}" >&2
+    if [[ -n "${response}" ]]; then
+      printf '%s\n' "${response}" >&2
+    fi
+    exit "${curl_status}"
+  fi
   response="$(<"${response_file}")"
   rm -f "${response_file}"
 
@@ -152,10 +194,21 @@ cloudflare_post() {
 cloudflare_get_json() {
   local action="$1"
   local url="$2"
-  local response_file status response
+  local response_file status response curl_status
 
   response_file="$(mktemp)"
-  status="$(curl -sS -o "${response_file}" -w '%{http_code}' "${cloudflare_headers[@]}" "${url}")" || status="$?"
+  if capture_stdout_quiet status curl -sS -o "${response_file}" -w '%{http_code}' "${cloudflare_headers[@]}" "${url}"; then
+    :
+  else
+    curl_status=$?
+    response="$(<"${response_file}")"
+    rm -f "${response_file}"
+    printf 'Cloudflare API request failed: %s\n' "${action}" >&2
+    if [[ -n "${response}" ]]; then
+      printf '%s\n' "${response}" >&2
+    fi
+    exit "${curl_status}"
+  fi
   response="$(<"${response_file}")"
   rm -f "${response_file}"
 
@@ -174,7 +227,7 @@ cloudflare_get_json() {
 ensure_oidc_discovery_dns_record() {
   local dns_lookup_response record_state
 
-  dns_lookup_response="$(cloudflare_get_json "get DNS CNAME" "${dns_lookup_url}")"
+  dns_lookup_response="$(cloudflare_get_json "get DNS records" "${dns_lookup_url}")"
   record_state="$(printf '%s' "${dns_lookup_response}" | python3 -c '
 import json
 import sys
@@ -182,26 +235,28 @@ import sys
 name = sys.argv[1]
 target = sys.argv[2]
 payload = json.load(sys.stdin)
-records = payload.get("result") or []
+records = [record for record in (payload.get("result") or []) if (record.get("name") or "") == name]
 
 if not records:
     print("missing")
     sys.exit(0)
 
-record = records[0]
-record_type = (record.get("type") or "").upper()
-record_name = record.get("name") or ""
-record_content = record.get("content") or ""
+for record in records:
+    record_type = (record.get("type") or "").upper()
+    record_content = record.get("content") or ""
 
-if record_type != "CNAME":
-    print(f"conflict_type:{record_type}")
-    sys.exit(0)
+    if record_type != "CNAME":
+        print(f"conflict_type:{record_type}")
+        sys.exit(0)
 
-if record_name != name or record_content != target:
+    if record_content == target:
+        print("matching")
+        sys.exit(0)
+
     print(f"conflict_target:{record_content}")
     sys.exit(0)
 
-print("matching")
+print("missing")
 ' "${OIDC_DISCOVERY_DOMAIN}" "${oidc_pages_target}")"
 
   case "${record_state}" in
@@ -245,12 +300,18 @@ pages_domain_url="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACC
 pages_domains_url="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${OIDC_DISCOVERY_PAGES_PROJECT}/domains"
 oidc_pages_target="${OIDC_DISCOVERY_PAGES_PROJECT}.pages.dev"
 dns_records_url="https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records"
-dns_lookup_url="${dns_records_url}?type=CNAME&name=${OIDC_DISCOVERY_DOMAIN}"
+dns_lookup_url="${dns_records_url}?name=${OIDC_DISCOVERY_DOMAIN}"
 
+bootstrap_env_info "Ensuring OIDC discovery repository: ${OIDC_DISCOVERY_REPO}"
 repo_view_output=""
-if ! repo_view_output="$(gh repo view "${OIDC_DISCOVERY_REPO}" 2>&1)"; then
+repo_view_error_file="$(mktemp)"
+if gh repo view "${OIDC_DISCOVERY_REPO}" >/dev/null 2>"${repo_view_error_file}"; then
+  rm -f "${repo_view_error_file}"
+else
+  repo_view_output="$(<"${repo_view_error_file}")"
+  rm -f "${repo_view_error_file}"
   if github_repo_missing "${repo_view_output}"; then
-    gh repo create "${OIDC_DISCOVERY_REPO}" --template "${OIDC_DISCOVERY_TEMPLATE_REPO}" ${visibility_flag} --description "LTBase OIDC discovery companion for ${DEPLOYMENT_REPO_NAME}" --clone=false
+    bootstrap_env_run_quiet gh repo create "${OIDC_DISCOVERY_REPO}" --template "${OIDC_DISCOVERY_TEMPLATE_REPO}" "${visibility_flag}" --description "LTBase OIDC discovery companion for ${DEPLOYMENT_REPO_NAME}" --clone=false
   else
     printf 'GitHub repo lookup failed: %s\n' "${OIDC_DISCOVERY_REPO}" >&2
     printf '%s\n' "${repo_view_output}" >&2
@@ -258,10 +319,11 @@ if ! repo_view_output="$(gh repo view "${OIDC_DISCOVERY_REPO}" 2>&1)"; then
   fi
 fi
 
-repo_metadata="$(gh api "repos/${OIDC_DISCOVERY_REPO}")"
+capture_stdout_quiet repo_metadata gh api "repos/${OIDC_DISCOVERY_REPO}"
 default_branch="$(python3 -c 'import json, sys; data = json.load(sys.stdin); print(data.get("default_branch", "main"))' <<<"${repo_metadata}"
 )"
 
+bootstrap_env_info "Ensuring Pages project: ${OIDC_DISCOVERY_PAGES_PROJECT}"
 if ! cloudflare_get_exists "get Pages project" "${pages_project_url}"; then
   project_payload="$(python3 - "${OIDC_DISCOVERY_PAGES_PROJECT}" "${GITHUB_OWNER}" "${OIDC_DISCOVERY_REPO_NAME}" "${default_branch}" <<'PY'
 import json
@@ -286,6 +348,7 @@ PY
   cloudflare_post "create Pages project" "${pages_projects_url}" "${project_payload}"
 fi
 
+bootstrap_env_info "Ensuring Pages domain: ${OIDC_DISCOVERY_DOMAIN}"
 if ! cloudflare_get_exists "get Pages custom domain" "${pages_domain_url}"; then
   domain_payload="$(python3 - "${OIDC_DISCOVERY_DOMAIN}" <<'PY'
 import json
@@ -297,13 +360,15 @@ PY
   cloudflare_post "create Pages custom domain" "${pages_domains_url}" "${domain_payload}"
 fi
 
+bootstrap_env_info "Reconciling DNS for OIDC discovery domain: ${OIDC_DISCOVERY_DOMAIN}"
 ensure_oidc_discovery_dns_record
 
-gh variable set OIDC_DISCOVERY_DOMAIN --repo "${OIDC_DISCOVERY_REPO}" --body "${OIDC_DISCOVERY_DOMAIN}"
-gh variable set OIDC_DISCOVERY_STACK_CONFIG --repo "${OIDC_DISCOVERY_REPO}" --body "${oidc_stack_config}"
-gh variable set CLOUDFLARE_ACCOUNT_ID --repo "${OIDC_DISCOVERY_REPO}" --body "${CLOUDFLARE_ACCOUNT_ID}"
-gh variable set OIDC_DISCOVERY_PAGES_PROJECT --repo "${OIDC_DISCOVERY_REPO}" --body "${OIDC_DISCOVERY_PAGES_PROJECT}"
-gh secret set CLOUDFLARE_API_TOKEN --repo "${OIDC_DISCOVERY_REPO}" --body "${CLOUDFLARE_API_TOKEN}"
+bootstrap_env_info "Configuring companion repository variables and secrets"
+bootstrap_env_run_quiet gh variable set OIDC_DISCOVERY_DOMAIN --repo "${OIDC_DISCOVERY_REPO}" --body "${OIDC_DISCOVERY_DOMAIN}"
+bootstrap_env_run_quiet gh variable set OIDC_DISCOVERY_STACK_CONFIG --repo "${OIDC_DISCOVERY_REPO}" --body "${oidc_stack_config}"
+bootstrap_env_run_quiet gh variable set CLOUDFLARE_ACCOUNT_ID --repo "${OIDC_DISCOVERY_REPO}" --body "${CLOUDFLARE_ACCOUNT_ID}"
+bootstrap_env_run_quiet gh variable set OIDC_DISCOVERY_PAGES_PROJECT --repo "${OIDC_DISCOVERY_REPO}" --body "${OIDC_DISCOVERY_PAGES_PROJECT}"
+bootstrap_env_run_quiet gh secret set CLOUDFLARE_API_TOKEN --repo "${OIDC_DISCOVERY_REPO}" --body "${CLOUDFLARE_API_TOKEN}"
 
 create_or_update_discovery_role() {
   local stack="$1"
@@ -362,16 +427,17 @@ EOF
 }
 EOF
 
+  bootstrap_env_info "Reconciling OIDC discovery IAM role for stack: ${stack}"
   if ! bootstrap_env_aws_command_for_stack "${stack}" iam get-open-id-connect-provider --open-id-connect-provider-arn "${provider_arn}" >/dev/null 2>&1; then
-    bootstrap_env_aws_command_for_stack "${stack}" iam create-open-id-connect-provider --url https://token.actions.githubusercontent.com --client-id-list sts.amazonaws.com >/dev/null
+    bootstrap_env_run_quiet bootstrap_env_aws_command_for_stack "${stack}" iam create-open-id-connect-provider --url https://token.actions.githubusercontent.com --client-id-list sts.amazonaws.com
   fi
 
   if ! bootstrap_env_aws_command_for_stack "${stack}" iam get-role --role-name "${role_name}" >/dev/null 2>&1; then
-    bootstrap_env_aws_command_for_stack "${stack}" iam create-role --role-name "${role_name}" --assume-role-policy-document "file://${trust_policy_path}" >/dev/null
+    bootstrap_env_run_quiet bootstrap_env_aws_command_for_stack "${stack}" iam create-role --role-name "${role_name}" --assume-role-policy-document "file://${trust_policy_path}"
   fi
 
-  bootstrap_env_aws_command_for_stack "${stack}" iam update-assume-role-policy --role-name "${role_name}" --policy-document "file://${trust_policy_path}" >/dev/null
-  bootstrap_env_aws_command_for_stack "${stack}" iam put-role-policy --role-name "${role_name}" --policy-name LTBaseOIDCDiscoveryAccess --policy-document "file://${role_policy_path}" >/dev/null
+  bootstrap_env_run_quiet bootstrap_env_aws_command_for_stack "${stack}" iam update-assume-role-policy --role-name "${role_name}" --policy-document "file://${trust_policy_path}"
+  bootstrap_env_run_quiet bootstrap_env_aws_command_for_stack "${stack}" iam put-role-policy --role-name "${role_name}" --policy-name LTBaseOIDCDiscoveryAccess --policy-document "file://${role_policy_path}"
 
   cat >>"${companion_summary}" <<EOF
 OIDC_DISCOVERY_AWS_ROLE_ARN_${upper_name}=${role_arn}

--- a/scripts/create-deployment-repo.sh
+++ b/scripts/create-deployment-repo.sh
@@ -27,6 +27,46 @@ script_dir="$(cd "$(dirname "$0")" && pwd)"
 source "${script_dir}/lib/bootstrap-env.sh"
 bootstrap_env_load "${ENV_FILE}"
 
+capture_stdout_quiet() {
+  local destination_var="$1"
+  local output command_status stderr_file
+  shift
+
+  stderr_file="$(mktemp)"
+  if output="$("$@" 2>"${stderr_file}")"; then
+    rm -f "${stderr_file}"
+    printf -v "${destination_var}" '%s' "${output}"
+    return 0
+  fi
+
+  command_status=$?
+  if [[ -s "${stderr_file}" ]]; then
+    cat "${stderr_file}" >&2
+  fi
+  rm -f "${stderr_file}"
+  return "${command_status}"
+}
+
+github_repo_missing() {
+  local output="$1"
+
+  python3 -c '
+import sys
+
+output = sys.stdin.read().lower()
+if "could not resolve to a repository" in output:
+    sys.exit(0)
+
+if "http 404" in output and "repo" in output:
+    sys.exit(0)
+
+if "repository was not found" in output:
+    sys.exit(0)
+
+sys.exit(1)
+' <<<"${output}"
+}
+
 required_vars=(TEMPLATE_REPO GITHUB_OWNER DEPLOYMENT_REPO_NAME DEPLOYMENT_REPO_VISIBILITY DEPLOYMENT_REPO_DESCRIPTION DEPLOYMENT_REPO)
 for name in "${required_vars[@]}"; do
   if [[ -z "${!name:-}" ]]; then
@@ -45,24 +85,38 @@ if [[ "${DEPLOYMENT_REPO_VISIBILITY}" == "public" ]]; then
   expected_private="false"
 fi
 
-if gh repo view "${DEPLOYMENT_REPO}" >/dev/null 2>&1; then
-  actual_private="$(gh api "repos/${DEPLOYMENT_REPO}" --jq '.private')"
+bootstrap_env_info "Ensuring deployment repository: ${DEPLOYMENT_REPO}"
+repo_view_output=""
+repo_view_error_file="$(mktemp)"
+if gh repo view "${DEPLOYMENT_REPO}" >/dev/null 2>"${repo_view_error_file}"; then
+  rm -f "${repo_view_error_file}"
+  capture_stdout_quiet actual_private gh api "repos/${DEPLOYMENT_REPO}" --jq '.private'
   if [[ "${actual_private}" != "${expected_private}" ]]; then
     echo "existing repository visibility mismatch for ${DEPLOYMENT_REPO}: expected ${DEPLOYMENT_REPO_VISIBILITY}" >&2
     exit 1
   fi
 else
-  gh repo create "${DEPLOYMENT_REPO}" --template "${TEMPLATE_REPO}" ${visibility_flag} --description "${DEPLOYMENT_REPO_DESCRIPTION}" --clone=false
+  repo_view_output="$(<"${repo_view_error_file}")"
+  rm -f "${repo_view_error_file}"
+  if github_repo_missing "${repo_view_output}"; then
+    bootstrap_env_run_quiet gh repo create "${DEPLOYMENT_REPO}" --template "${TEMPLATE_REPO}" "${visibility_flag}" --description "${DEPLOYMENT_REPO_DESCRIPTION}" --clone=false
+  else
+    printf 'GitHub repo lookup failed: %s\n' "${DEPLOYMENT_REPO}" >&2
+    printf '%s\n' "${repo_view_output}" >&2
+    exit 1
+  fi
 fi
 
 promotion_index=0
 while IFS= read -r stack; do
   if [[ "${promotion_index}" -gt 0 ]]; then
-    gh api "repos/${DEPLOYMENT_REPO}/environments/${stack}" --method PUT >/dev/null
+    bootstrap_env_info "Ensuring protected deployment environment: ${stack}"
+    bootstrap_env_run_quiet gh api "repos/${DEPLOYMENT_REPO}/environments/${stack}" --method PUT
   fi
   promotion_index=$((promotion_index + 1))
 done < <(bootstrap_env_each_stack "${PROMOTION_PATH}")
 
 if [[ "${promotion_index}" -eq 0 && -n "${PROD_ENVIRONMENT_NAME:-}" ]]; then
-  gh api "repos/${DEPLOYMENT_REPO}/environments/${PROD_ENVIRONMENT_NAME}" --method PUT >/dev/null
+  bootstrap_env_info "Ensuring protected deployment environment: ${PROD_ENVIRONMENT_NAME}"
+  bootstrap_env_run_quiet gh api "repos/${DEPLOYMENT_REPO}/environments/${PROD_ENVIRONMENT_NAME}" --method PUT
 fi

--- a/scripts/evaluate-and-continue.sh
+++ b/scripts/evaluate-and-continue.sh
@@ -82,6 +82,49 @@ run_logged() {
   "$@"
 }
 
+run_logged_quiet() {
+  printf '%s\n' "$*" >>"${actions_log}"
+  bootstrap_env_run_quiet "$@"
+}
+
+capture_stdout_quiet() {
+  local destination_var="$1"
+  local output command_status stderr_file
+  shift
+
+  stderr_file="$(mktemp)"
+  if output="$("$@" 2>"${stderr_file}")"; then
+    rm -f "${stderr_file}"
+    printf -v "${destination_var}" '%s' "${output}"
+    return 0
+  fi
+
+  command_status=$?
+  if [[ -s "${stderr_file}" ]]; then
+    cat "${stderr_file}" >&2
+  fi
+  rm -f "${stderr_file}"
+  return "${command_status}"
+}
+
+capture_stdout_probe() {
+  local destination_var="$1"
+  local output command_status stderr_file
+  shift
+
+  stderr_file="$(mktemp)"
+  if output="$("$@" 2>"${stderr_file}")"; then
+    rm -f "${stderr_file}"
+    printf -v "${destination_var}" '%s' "${output}"
+    return 0
+  fi
+
+  command_status=$?
+  rm -f "${stderr_file}"
+  printf -v "${destination_var}" '%s' "${output}"
+  return "${command_status}"
+}
+
 json_name_list_contains() {
   local json_input="$1"
   local needle="$2"
@@ -114,7 +157,7 @@ foundation_present_for_stack() {
   if ! bootstrap_env_aws_command_for_stack "${stack}" iam get-role --role-name "${role_name}" >/dev/null 2>&1; then
     return 1
   fi
-  alias_json="$(bootstrap_env_aws_command_for_stack "${stack}" kms list-aliases --region "${region}" --output json)"
+  capture_stdout_quiet alias_json bootstrap_env_aws_command_for_stack "${stack}" kms list-aliases --region "${region}" --output json
   python3 - "${PULUMI_KMS_ALIAS}" <<'PY' <<<"${alias_json}"
 import json
 import sys
@@ -131,15 +174,15 @@ shared_foundation_present() {
   if [[ -z "${first_stack}" ]]; then
     return 1
   fi
-  bootstrap_env_aws_command_for_stack "${first_stack}" s3api head-bucket --bucket "${PULUMI_STATE_BUCKET}" >/dev/null 2>&1
+  bootstrap_env_run_quiet bootstrap_env_aws_command_for_stack "${first_stack}" s3api head-bucket --bucket "${PULUMI_STATE_BUCKET}" >/dev/null 2>&1
 }
 
 repo_exists() {
-  gh repo view "${DEPLOYMENT_REPO}" >/dev/null 2>&1
+  bootstrap_env_run_quiet gh repo view "${DEPLOYMENT_REPO}" >/dev/null 2>&1
 }
 
 oidc_companion_repo_exists() {
-  gh repo view "${OIDC_DISCOVERY_REPO}" >/dev/null 2>&1
+  bootstrap_env_run_quiet gh repo view "${OIDC_DISCOVERY_REPO}" >/dev/null 2>&1
 }
 
 promotion_environments_present() {
@@ -147,7 +190,7 @@ promotion_environments_present() {
   local stack
   while IFS= read -r stack; do
     if [[ "${promotion_index}" -gt 0 ]]; then
-      if ! gh api "repos/${DEPLOYMENT_REPO}/environments/${stack}" >/dev/null 2>&1; then
+      if ! bootstrap_env_run_quiet gh api "repos/${DEPLOYMENT_REPO}/environments/${stack}" >/dev/null 2>&1; then
         return 1
       fi
     fi
@@ -163,8 +206,8 @@ repo_config_present() {
     return 1
   fi
 
-  variable_json="$(gh variable list --repo "${DEPLOYMENT_REPO}" --json name)"
-  secret_json="$(gh secret list --repo "${DEPLOYMENT_REPO}" --json name)"
+  capture_stdout_quiet variable_json gh variable list --repo "${DEPLOYMENT_REPO}" --json name
+  capture_stdout_quiet secret_json gh secret list --repo "${DEPLOYMENT_REPO}" --json name
 
   for required_var in PULUMI_BACKEND_URL LTBASE_RELEASES_REPO LTBASE_RELEASE_ID STACKS PROMOTION_PATH PREVIEW_DEFAULT_STACK; do
     if ! json_name_list_contains "${variable_json}" "${required_var}"; then
@@ -205,7 +248,7 @@ oidc_companion_repo_config_present() {
     return 1
   fi
 
-  variable_json="$(gh variable list --repo "${OIDC_DISCOVERY_REPO}" --json name)"
+  capture_stdout_quiet variable_json gh variable list --repo "${OIDC_DISCOVERY_REPO}" --json name
   if ! json_name_list_contains "${variable_json}" "OIDC_DISCOVERY_DOMAIN"; then
     return 1
   fi
@@ -216,25 +259,60 @@ oidc_companion_repo_config_present() {
   return 0
 }
 
+cloudflare_json_success() {
+  local response="$1"
+
+  printf '%s' "${response}" | python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except json.JSONDecodeError:
+    sys.exit(1)
+
+sys.exit(0 if payload.get("success") is True else 1)
+'
+}
+
+cloudflare_get_success_json() {
+  local response_file status="" response
+
+  response_file="$(mktemp)"
+  capture_stdout_probe status curl -fsS -o "${response_file}" -w '%{http_code}' "$@" || {
+    rm -f "${response_file}"
+    return 1
+  }
+  response="$(<"${response_file}")"
+  rm -f "${response_file}"
+
+  if [[ ! "${status}" =~ ^2 ]]; then
+    return 1
+  fi
+
+  cloudflare_json_success "${response}" || return 1
+  printf '%s' "${response}"
+}
+
 cloudflare_pages_project_present() {
-  curl -fsS \
+  cloudflare_get_success_json \
     -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
     -H "Content-Type: application/json" \
-    "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${OIDC_DISCOVERY_PAGES_PROJECT}" >/dev/null 2>&1
+    "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${OIDC_DISCOVERY_PAGES_PROJECT}" >/dev/null
 }
 
 cloudflare_pages_domain_present() {
-  curl -fsS \
+  cloudflare_get_success_json \
     -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
     -H "Content-Type: application/json" \
-    "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${OIDC_DISCOVERY_PAGES_PROJECT}/domains/${OIDC_DISCOVERY_DOMAIN}" >/dev/null 2>&1
+    "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${OIDC_DISCOVERY_PAGES_PROJECT}/domains/${OIDC_DISCOVERY_DOMAIN}" >/dev/null
 }
 
 cloudflare_oidc_pages_dns_present() {
   local response expected_target
 
   expected_target="${OIDC_DISCOVERY_PAGES_PROJECT}.pages.dev"
-  response="$(curl -fsS \
+  response="$(cloudflare_get_success_json \
     -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
     -H "Content-Type: application/json" \
     "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records?type=CNAME&name=${OIDC_DISCOVERY_DOMAIN}")" || return 1
@@ -534,12 +612,15 @@ run_force_actions() {
   fi
 
   if [[ "${needs_foundation}" == "true" ]]; then
+    bootstrap_env_info "Rendering bootstrap IAM policies"
     run_logged "${script_dir}/render-bootstrap-policies.sh" --env-file "${ENV_FILE}"
+    bootstrap_env_info "Reconciling shared AWS foundation"
     run_logged "${script_dir}/bootstrap-aws-foundation.sh" --env-file "${ENV_FILE}"
   fi
 
   if [[ "${needs_repo}" == "true" ]]; then
     if ! repo_exists; then
+      bootstrap_env_info "Ensuring deployment repository bootstrap"
       run_logged "${script_dir}/create-deployment-repo.sh" --env-file "${ENV_FILE}"
     fi
 
@@ -547,7 +628,8 @@ run_force_actions() {
       case "${status}" in
         needs_foundation|needs_repo_config|needs_stack_bootstrap)
           if [[ "${SCOPE}" != "foundation" ]]; then
-            run_logged "${script_dir}/bootstrap-deployment-repo.sh" --env-file "${ENV_FILE}" --stack "${stack}" --infra-dir "${INFRA_DIR}"
+            bootstrap_env_info "Reconciling deployment repository stack bootstrap: ${stack}"
+            run_logged_quiet "${script_dir}/bootstrap-deployment-repo.sh" --env-file "${ENV_FILE}" --stack "${stack}" --infra-dir "${INFRA_DIR}"
           fi
           ;;
       esac
@@ -559,8 +641,9 @@ run_force_actions() {
     local promotion_index=0
     while IFS= read -r stack; do
       if [[ "${promotion_index}" -gt 0 ]]; then
-        if ! gh api "repos/${DEPLOYMENT_REPO}/environments/${stack}" >/dev/null 2>&1; then
-          run_logged gh api "repos/${DEPLOYMENT_REPO}/environments/${stack}" --method PUT
+        if ! bootstrap_env_run_quiet gh api "repos/${DEPLOYMENT_REPO}/environments/${stack}" >/dev/null 2>&1; then
+          bootstrap_env_info "Ensuring protected deployment environment: ${stack}"
+          run_logged_quiet gh api "repos/${DEPLOYMENT_REPO}/environments/${stack}" --method PUT
         fi
       fi
       promotion_index=$((promotion_index + 1))
@@ -568,6 +651,7 @@ run_force_actions() {
   fi
 
   if [[ "${needs_oidc_companion}" == "true" && "${SCOPE}" != "foundation" ]]; then
+    bootstrap_env_info "Reconciling OIDC discovery companion"
     run_logged "${script_dir}/bootstrap-oidc-discovery-companion.sh" --env-file "${ENV_FILE}"
   fi
 
@@ -575,19 +659,22 @@ run_force_actions() {
   if [[ "${has_dsql_reconcile}" == "true" && "${SCOPE}" != "foundation" ]]; then
     while IFS=$'\t' read -r stack status; do
       if [[ "${status}" == "needs_dsql_reconcile" ]]; then
-        run_logged "${script_dir}/reconcile-managed-dsql-endpoint.sh" --env-file "${ENV_FILE}" --stack "${stack}" --infra-dir "${INFRA_DIR}"
+        bootstrap_env_info "Reconciling managed DSQL endpoint: ${stack}"
+        run_logged_quiet "${script_dir}/reconcile-managed-dsql-endpoint.sh" --env-file "${ENV_FILE}" --stack "${stack}" --infra-dir "${INFRA_DIR}"
       fi
     done <"${state_file}"
   fi
 
   # Bug #20: resume rollout from the first incomplete stack instead of starting over
   if [[ "${has_needs_rollout}" == "true" && -n "${RELEASE_ID}" && "${SCOPE}" != "foundation" ]]; then
-    run_logged gh workflow run rollout-hop.yml --repo "${DEPLOYMENT_REPO}" \
+    bootstrap_env_info "Dispatching rollout workflow: rollout-hop.yml"
+    run_logged_quiet gh workflow run rollout-hop.yml --repo "${DEPLOYMENT_REPO}" \
       -f release_id="${RELEASE_ID}" \
       -f target_stack="${first_needs_rollout_stack}" \
       -f continue_chain=true
   elif [[ -n "${RELEASE_ID}" && "${SCOPE}" != "foundation" ]]; then
-    run_logged gh workflow run rollout.yml --repo "${DEPLOYMENT_REPO}" -f release_id="${RELEASE_ID}"
+    bootstrap_env_info "Dispatching rollout workflow: rollout.yml"
+    run_logged_quiet gh workflow run rollout.yml --repo "${DEPLOYMENT_REPO}" -f release_id="${RELEASE_ID}"
   fi
 }
 

--- a/scripts/lib/bootstrap-env.sh
+++ b/scripts/lib/bootstrap-env.sh
@@ -2,6 +2,45 @@
 
 set -euo pipefail
 
+bootstrap_env_info() {
+  printf '[info] %s\n' "$*"
+}
+
+bootstrap_env_run_quiet() {
+  local output status
+
+  if output="$("$@" 2>&1)"; then
+    return 0
+  else
+    status=$?
+  fi
+
+  if [[ -n "${output}" ]]; then
+    printf '%s\n' "${output}" >&2
+  fi
+
+  return "${status}"
+}
+
+bootstrap_env_capture_quiet() {
+  local destination_var="$1"
+  local output status
+  shift
+
+  if output="$("$@" 2>&1)"; then
+    printf -v "${destination_var}" '%s' "${output}"
+    return 0
+  else
+    status=$?
+  fi
+
+  if [[ -n "${output}" ]]; then
+    printf '%s\n' "${output}" >&2
+  fi
+
+  return "${status}"
+}
+
 bootstrap_env_normalize_csv() {
   printf '%s' "${1:-}" | tr -d '[:space:]'
 }

--- a/scripts/sync-template-upstream.sh
+++ b/scripts/sync-template-upstream.sh
@@ -2,6 +2,33 @@
 
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/lib/bootstrap-env.sh"
+
+capture_stdout_quiet() {
+  local destination_var="$1"
+  local stderr_file output status
+  shift
+
+  stderr_file="$(mktemp)"
+  if output="$("$@" 2>"${stderr_file}")"; then
+    printf -v "${destination_var}" '%s' "${output}"
+    rm -f "${stderr_file}"
+    return 0
+  else
+    status=$?
+  fi
+
+  if [[ -s "${stderr_file}" ]]; then
+    while IFS= read -r line; do
+      printf '%s\n' "${line}" >&2
+    done <"${stderr_file}"
+  fi
+  rm -f "${stderr_file}"
+  return "${status}"
+}
+
 UPSTREAM_NAME="upstream"
 UPSTREAM_URL="https://github.com/Lychee-Technology/ltbase-private-deployment.git"
 BRANCH="main"
@@ -9,15 +36,38 @@ ARCHIVE_PATH="sync-template-upstream.tar"
 
 build_fingerprint() {
   local root="$1"
+  local paths paths_file hash_output status
 
-  {
-    find "${root}/infra" -type f | LC_ALL=C sort
-    printf '%s\n' "${root}/.github/workflows/build-infra-binary.yml"
-  } | while read -r path; do
-    printf '== %s ==\n' "${path#${root}/}"
-    cat "${path}"
-    printf '\n'
-  done | shasum -a 256 | awk '{print "sha256:" $1}'
+  capture_stdout_quiet paths find "${root}/infra" -type f || return $?
+
+  paths_file="$(mktemp)"
+  if [[ -n "${paths}" ]]; then
+    printf '%s\n' "${paths}" > "${paths_file}"
+  fi
+
+  capture_stdout_quiet hash_output bash -c '
+    root="$1"
+    paths_file="$2"
+
+    {
+      if [[ -s "${paths_file}" ]]; then
+        LC_ALL=C sort "${paths_file}"
+      fi
+      printf "%s\n" "${root}/.github/workflows/build-infra-binary.yml"
+    } | while IFS= read -r path; do
+      printf "== %s ==\n" "${path#${root}/}"
+      cat "${path}"
+      printf "\n"
+    done | shasum -a 256
+  ' _ "${root}" "${paths_file}" || {
+    status=$?
+    rm -f "${paths_file}"
+    return "${status}"
+  }
+
+  rm -f "${paths_file}"
+
+  printf 'sha256:%s\n' "${hash_output%% *}"
 }
 
 required_source_paths=(
@@ -57,12 +107,13 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   exit 1
 fi
 
-if [[ -n "$(git status --porcelain)" ]]; then
+capture_stdout_quiet git_status git status --porcelain
+if [[ -n "${git_status}" ]]; then
   echo "working tree is not clean; commit or stash your changes before syncing" >&2
   exit 1
 fi
 
-current_branch="$(git rev-parse --abbrev-ref HEAD)"
+capture_stdout_quiet current_branch git rev-parse --abbrev-ref HEAD
 if [[ "${current_branch}" != "${BRANCH}" ]]; then
   echo "current branch must be ${BRANCH}; found ${current_branch}" >&2
   exit 1
@@ -74,18 +125,19 @@ if existing_url="$(git remote get-url "${UPSTREAM_NAME}" 2>/dev/null)"; then
     exit 1
   fi
 else
-  git remote add "${UPSTREAM_NAME}" "${UPSTREAM_URL}"
+  bootstrap_env_run_quiet git remote add "${UPSTREAM_NAME}" "${UPSTREAM_URL}"
 fi
 
-git fetch "${UPSTREAM_NAME}"
-upstream_commit="$(git rev-parse "${UPSTREAM_NAME}/${BRANCH}")"
+bootstrap_env_info "fetching upstream template from ${UPSTREAM_NAME}/${BRANCH}"
+bootstrap_env_run_quiet git fetch "${UPSTREAM_NAME}"
+capture_stdout_quiet upstream_commit git rev-parse "${UPSTREAM_NAME}/${BRANCH}"
 
 temp_root="$(mktemp -d)"
 trap 'rm -rf "${temp_root}" "${ARCHIVE_PATH}"' EXIT
 
-git archive --format=tar --output "${ARCHIVE_PATH}" "${UPSTREAM_NAME}/${BRANCH}"
+bootstrap_env_run_quiet git archive --format=tar --output "${ARCHIVE_PATH}" "${UPSTREAM_NAME}/${BRANCH}"
 mkdir -p "${temp_root}"
-tar -xf "${ARCHIVE_PATH}" -C "${temp_root}"
+bootstrap_env_run_quiet tar -xf "${ARCHIVE_PATH}" -C "${temp_root}"
 
 for path in "${required_source_paths[@]}"; do
   if [[ ! -e "${temp_root}/${path}" ]]; then
@@ -97,17 +149,19 @@ done
 fingerprint="$(build_fingerprint "${temp_root}")"
 
 mkdir -p "${temp_root}/__ref__"
-jq -n \
+bootstrap_env_info "refreshing provenance metadata"
+capture_stdout_quiet provenance_json jq -n \
   --arg template_repository "Lychee-Technology/ltbase-private-deployment" \
   --arg template_ref "${BRANCH}" \
   --arg template_commit "${upstream_commit}" \
   --arg build_fingerprint "${fingerprint}" \
   --arg generated_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
   --arg generator "scripts/sync-template-upstream.sh" \
-  '{template_repository:$template_repository,template_ref:$template_ref,template_commit:$template_commit,build_fingerprint:$build_fingerprint,generated_at:$generated_at,generator:$generator}' \
-  > "${temp_root}/__ref__/template-provenance.json"
+  '{template_repository:$template_repository,template_ref:$template_ref,template_commit:$template_commit,build_fingerprint:$build_fingerprint,generated_at:$generated_at,generator:$generator}'
+printf '%s\n' "${provenance_json}" > "${temp_root}/__ref__/template-provenance.json"
 
-rsync -a --delete \
+bootstrap_env_info "syncing template-managed files"
+bootstrap_env_run_quiet rsync -a --delete \
   --exclude '.git/' \
   --exclude 'dist/' \
   --exclude '.DS_Store' \

--- a/scripts/update-sync-template-tooling.sh
+++ b/scripts/update-sync-template-tooling.sh
@@ -2,6 +2,33 @@
 
 set -euo pipefail
 
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/lib/bootstrap-env.sh"
+
+capture_stdout_quiet() {
+  local destination_var="$1"
+  local stderr_file output status
+  shift
+
+  stderr_file="$(mktemp)"
+  if output="$("$@" 2>"${stderr_file}")"; then
+    printf -v "${destination_var}" '%s' "${output}"
+    rm -f "${stderr_file}"
+    return 0
+  else
+    status=$?
+  fi
+
+  if [[ -s "${stderr_file}" ]]; then
+    while IFS= read -r line; do
+      printf '%s\n' "${line}" >&2
+    done <"${stderr_file}"
+  fi
+  rm -f "${stderr_file}"
+  return "${status}"
+}
+
 UPSTREAM_NAME="upstream"
 UPSTREAM_URL="https://github.com/Lychee-Technology/ltbase-private-deployment.git"
 BRANCH="main"
@@ -33,12 +60,13 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   exit 1
 fi
 
-if [[ -n "$(git status --porcelain)" ]]; then
+capture_stdout_quiet git_status git status --porcelain
+if [[ -n "${git_status}" ]]; then
   echo "working tree is not clean; commit or stash your changes before updating sync tooling" >&2
   exit 1
 fi
 
-current_branch="$(git rev-parse --abbrev-ref HEAD)"
+capture_stdout_quiet current_branch git rev-parse --abbrev-ref HEAD
 if [[ "${current_branch}" != "${BRANCH}" ]]; then
   echo "current branch must be ${BRANCH}; found ${current_branch}" >&2
   exit 1
@@ -50,17 +78,18 @@ if existing_url="$(git remote get-url "${UPSTREAM_NAME}" 2>/dev/null)"; then
     exit 1
   fi
 else
-  git remote add "${UPSTREAM_NAME}" "${UPSTREAM_URL}"
+  bootstrap_env_run_quiet git remote add "${UPSTREAM_NAME}" "${UPSTREAM_URL}"
 fi
 
-git fetch "${UPSTREAM_NAME}"
+bootstrap_env_info "fetching upstream template from ${UPSTREAM_NAME}/${BRANCH}"
+bootstrap_env_run_quiet git fetch "${UPSTREAM_NAME}"
 
 temp_root="$(mktemp -d)"
 trap 'rm -rf "${temp_root}" "${ARCHIVE_PATH}"' EXIT
 
-git archive --format=tar --output "${ARCHIVE_PATH}" "${UPSTREAM_NAME}/${BRANCH}"
+bootstrap_env_run_quiet git archive --format=tar --output "${ARCHIVE_PATH}" "${UPSTREAM_NAME}/${BRANCH}"
 mkdir -p "${temp_root}"
-tar -xf "${ARCHIVE_PATH}" -C "${temp_root}"
+bootstrap_env_run_quiet tar -xf "${ARCHIVE_PATH}" -C "${temp_root}"
 
 for path in scripts/sync-template-upstream.sh test/sync-template-upstream-test.sh; do
   if [[ ! -e "${temp_root}/${path}" ]]; then
@@ -69,10 +98,10 @@ for path in scripts/sync-template-upstream.sh test/sync-template-upstream-test.s
   fi
 done
 
-script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "${script_dir}/.." && pwd)"
 
-cp "${temp_root}/scripts/sync-template-upstream.sh" "${repo_root}/scripts/sync-template-upstream.sh"
-cp "${temp_root}/test/sync-template-upstream-test.sh" "${repo_root}/test/sync-template-upstream-test.sh"
+bootstrap_env_info "updating local sync helper files"
+bootstrap_env_run_quiet cp "${temp_root}/scripts/sync-template-upstream.sh" "${repo_root}/scripts/sync-template-upstream.sh"
+bootstrap_env_run_quiet cp "${temp_root}/test/sync-template-upstream-test.sh" "${repo_root}/test/sync-template-upstream-test.sh"
 
 printf 'updated sync tooling from %s/%s\n' "${UPSTREAM_NAME}" "${BRANCH}"

--- a/test/bootstrap-all-test.sh
+++ b/test/bootstrap-all-test.sh
@@ -39,7 +39,12 @@ create_stub() {
   cat >"${repo_copy}/scripts/${name}" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
+printf 'NOISY STDOUT from ${name}\n'
+printf 'NOISY STDERR from ${name}\n' >&2
 printf '%s %s\n' '${name}' "\$*" >>"${log_file}"
+if [[ "\${FAIL_SCRIPT:-}" == "${name}" ]]; then
+  exit 1
+fi
 EOF
   chmod +x "${repo_copy}/scripts/${name}"
 }
@@ -109,6 +114,16 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
     fail "expected orchestrator to succeed when implemented, got: ${output}"
   fi
 
+  assert_log_contains <(printf '%s' "${output}") "[info] ensuring deployment repository"
+  assert_log_contains <(printf '%s' "${output}") "[info] rendering bootstrap policies"
+  assert_log_contains <(printf '%s' "${output}") "[info] bootstrapping AWS foundation"
+  assert_log_contains <(printf '%s' "${output}") "[info] ensuring OIDC discovery companion"
+  assert_log_contains <(printf '%s' "${output}") "[info] configuring stack devo"
+  assert_log_contains <(printf '%s' "${output}") "[info] configuring stack staging"
+  assert_log_contains <(printf '%s' "${output}") "[info] configuring stack prod"
+  assert_log_not_contains <(printf '%s' "${output}") "NOISY STDOUT"
+  assert_log_not_contains <(printf '%s' "${output}") "NOISY STDERR"
+
   assert_log_contains "${log_file}" "create-deployment-repo.sh --env-file ${temp_dir}/.env"
   assert_log_contains "${log_file}" "render-bootstrap-policies.sh --env-file ${temp_dir}/.env"
   assert_log_contains "${log_file}" "bootstrap-aws-foundation.sh --env-file ${temp_dir}/.env"
@@ -119,6 +134,15 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
   assert_log_not_contains "${log_file}" "reconcile-managed-dsql-endpoint.sh --env-file ${temp_dir}/.env --stack devo --infra-dir ${temp_dir}/infra"
   assert_log_not_contains "${log_file}" "reconcile-managed-dsql-endpoint.sh --env-file ${temp_dir}/.env --stack staging --infra-dir ${temp_dir}/infra"
   assert_log_not_contains "${log_file}" "reconcile-managed-dsql-endpoint.sh --env-file ${temp_dir}/.env --stack prod --infra-dir ${temp_dir}/infra"
+
+  if output="$(FAIL_SCRIPT="bootstrap-aws-foundation.sh" "${repo_copy}/scripts/bootstrap-all.sh" --env-file "${temp_dir}/.env" --mode apply --infra-dir "${temp_dir}/infra" 2>&1)"; then
+    rm -rf "${temp_dir}"
+    fail "expected orchestrator to fail when a child script fails"
+  fi
+
+  assert_log_contains <(printf '%s' "${output}") "[info] bootstrapping AWS foundation"
+  assert_log_contains <(printf '%s' "${output}") "NOISY STDOUT from bootstrap-aws-foundation.sh"
+  assert_log_contains <(printf '%s' "${output}") "NOISY STDERR from bootstrap-aws-foundation.sh"
 else
   fail "missing executable script: ${SCRIPT_PATH}"
 fi

--- a/test/bootstrap-aws-foundation-test.sh
+++ b/test/bootstrap-aws-foundation-test.sh
@@ -92,6 +92,7 @@ if [[ "\${args[0]:-} \${args[1]:-}" == "sts get-caller-identity" ]]; then
     printf 'An error occurred (InvalidClientTokenId) when calling the GetCallerIdentity operation: The security token included in the request is invalid.\n' >&2
     exit 254
   fi
+  printf 'NOISY_AWS_STDERR sts success\n' >&2
   printf '{"Account":"123456789012"}'
   exit 0
 fi
@@ -102,10 +103,12 @@ if [[ "\${args[0]:-} \${args[1]:-}" == "s3api head-bucket" ]]; then
   exit 1
 fi
 if [[ "\${args[0]:-} \${args[1]:-}" == "kms list-aliases" ]]; then
+  printf 'NOISY_AWS_STDERR kms list success\n' >&2
   printf '{"Aliases":[]}'
   exit 0
 fi
 if [[ "\${args[0]:-} \${args[1]:-}" == "kms create-key" ]]; then
+  printf 'NOISY_AWS_STDERR kms create success\n' >&2
   printf 'key-123\n'
   exit 0
 fi
@@ -126,8 +129,11 @@ if [[ "\${args[0]:-} \${args[1]:-}" == "iam create-role" ]]; then
   else
     printf '{"Role":{"Arn":"arn:aws:iam::123456789012:role/ltbase-deploy-devo"}}'
   fi
+  printf 'NOISY_AWS_STDERR iam create-role success\n' >&2
   exit 0
 fi
+printf 'NOISY_AWS_STDOUT generic success\n'
+printf 'NOISY_AWS_STDERR generic success\n' >&2
 exit 0
 EOF
 chmod +x "${fake_bin}/aws"
@@ -172,6 +178,11 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
   assert_file_contains "${temp_dir}/dist/devo-role-policy.json" "\"Action\": \"*\""
   assert_file_contains "${temp_dir}/dist/devo-role-policy.json" "\"Resource\": \"*\""
   assert_file_not_contains "${temp_dir}/dist/devo-trust-policy.json" "arn:aws:iam::210987654321:oidc-provider"
+  assert_log_contains <(printf '%s' "${output}") "[info] Validating AWS credentials for stack: devo"
+  assert_log_contains <(printf '%s' "${output}") "[info] Reconciling IAM and KMS resources for stack: prod"
+  assert_log_contains <(printf '%s' "${output}") "[info] Ensuring shared Pulumi state bucket: test-pulumi-state"
+  assert_log_not_contains <(printf '%s' "${output}") "NOISY_AWS_STDOUT"
+  assert_log_not_contains <(printf '%s' "${output}") "NOISY_AWS_STDERR"
 else
   fail "missing executable script: ${SCRIPT_PATH}"
 fi
@@ -224,13 +235,17 @@ if [[ "\${args[0]:-}" == "--profile" ]]; then
   args=("\${args[@]:2}")
 fi
 if [[ "\${args[0]:-} \${args[1]:-}" == "sts get-caller-identity" ]]; then
+  printf 'NOISY_AWS_STDERR sts success\n' >&2
   printf '{"Account":"123456789012"}'
   exit 0
 fi
 if [[ "\${args[0]:-} \${args[1]:-}" == "kms list-aliases" ]]; then
+  printf 'NOISY_AWS_STDERR kms list success\n' >&2
   printf '{"Aliases":[{"AliasName":"alias/test-pulumi-secrets","TargetKeyId":"key-existing"}]}'
   exit 0
 fi
+printf 'NOISY_AWS_STDOUT generic success\n'
+printf 'NOISY_AWS_STDERR generic success\n' >&2
 exit 0
 EOF
 chmod +x "${fake_bin}/aws-reuse"
@@ -252,6 +267,8 @@ assert_file_not_contains "${log_file}" "iam create-role"
 assert_file_not_contains "${log_file}" "kms create-key"
 assert_file_not_contains "${log_file}" "kms create-alias"
 assert_file_not_contains "${log_file}" "s3api create-bucket"
+assert_log_not_contains <(printf '%s' "${output}") "NOISY_AWS_STDOUT"
+assert_log_not_contains <(printf '%s' "${output}") "NOISY_AWS_STDERR"
 
 cp "${fake_bin}/aws-base" "${fake_bin}/aws"
 : >"${log_file}"

--- a/test/bootstrap-deployment-repo-test.sh
+++ b/test/bootstrap-deployment-repo-test.sh
@@ -26,6 +26,14 @@ assert_log_not_contains() {
   fi
 }
 
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  if [[ "${expected}" != "${actual}" ]]; then
+    fail "expected '${expected}', got '${actual}'"
+  fi
+}
+
 temp_dir="$(mktemp -d)"
 fake_bin="${temp_dir}/bin"
 log_file="${temp_dir}/commands.log"
@@ -88,15 +96,37 @@ EOF
 cat >"${fake_bin}/gh" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
+printf 'NOISY GH STDOUT %s\n' "\$*"
+printf 'NOISY GH STDERR %s\n' "\$*" >&2
 printf 'gh %s\n' "\$*" >>"${log_file}"
+if [[ "\${GH_FAIL_FIRST:-0}" == "1" ]]; then
+  exit 1
+fi
 EOF
 chmod +x "${fake_bin}/gh"
 
 cat >"${fake_bin}/pulumi" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
+printf 'NOISY PULUMI STDOUT %s\n' "\$*"
+printf 'NOISY PULUMI STDERR %s\n' "\$*" >&2
 printf 'PWD=%s AWS_REGION=%s AWS_DEFAULT_REGION=%s AWS_PROFILE=%s pulumi %s\n' "\$PWD" "\${AWS_REGION:-}" "\${AWS_DEFAULT_REGION:-}" "\${AWS_PROFILE:-}" "\$*" >>"${log_file}"
 if [[ "\$1 \$2" == "stack select" ]]; then
+  case "\${PULUMI_STACK_SELECT_MODE:-missing}" in
+    missing)
+      printf 'error: no stack named %s found\n' "\${3:-}" >&2
+      exit 1
+      ;;
+    unexpected)
+      printf 'error: backend unavailable\n' >&2
+      exit 1
+      ;;
+    existing)
+      exit 0
+      ;;
+  esac
+fi
+if [[ "\${PULUMI_FAIL_COMMAND:-}" == "\$*" ]]; then
   exit 1
 fi
 exit 0
@@ -108,6 +138,13 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
     rm -rf "${temp_dir}"
     fail "expected script to succeed when implemented, got: ${output}"
   fi
+
+  assert_log_contains <(printf '%s' "${output}") "[info] configuring repository variables and secrets for Lychee-Technology/ltbase-private-deployment"
+  assert_log_contains <(printf '%s' "${output}") "[info] configuring Pulumi stack prod"
+  assert_log_not_contains <(printf '%s' "${output}") "NOISY GH STDOUT"
+  assert_log_not_contains <(printf '%s' "${output}") "NOISY GH STDERR"
+  assert_log_not_contains <(printf '%s' "${output}") "NOISY PULUMI STDOUT"
+  assert_log_not_contains <(printf '%s' "${output}") "NOISY PULUMI STDERR"
 
   assert_log_contains "${log_file}" "gh variable set AWS_REGION_DEVO --repo Lychee-Technology/ltbase-private-deployment --body ap-northeast-1"
   assert_log_contains "${log_file}" "gh variable set AWS_REGION_STAGING --repo Lychee-Technology/ltbase-private-deployment --body us-east-1"
@@ -136,6 +173,49 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
   assert_log_not_contains "${log_file}" "pulumi up --stack prod --yes --skip-preview"
   assert_log_not_contains "${log_file}" "pulumi config set dsqlEndpoint"
   assert_log_not_contains "${log_file}" "aws dsql get-cluster"
+
+  if output="$(GH_FAIL_FIRST=1 PATH="${fake_bin}:$PATH" "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --stack prod --infra-dir "${temp_dir}/infra" 2>&1)"; then
+    rm -rf "${temp_dir}"
+    fail "expected script to fail when gh fails"
+  fi
+
+  first_output_line="$(printf '%s\n' "${output}" | sed -n '1p')"
+  assert_equals "[info] configuring repository variables and secrets for Lychee-Technology/ltbase-private-deployment" "${first_output_line}"
+  assert_log_contains <(printf '%s' "${output}") "NOISY GH STDOUT variable set AWS_REGION_DEVO --repo Lychee-Technology/ltbase-private-deployment --body ap-northeast-1"
+  assert_log_contains <(printf '%s' "${output}") "NOISY GH STDERR variable set AWS_REGION_DEVO --repo Lychee-Technology/ltbase-private-deployment --body ap-northeast-1"
+
+  if output="$(PULUMI_FAIL_COMMAND="config set runtimeBucket ltbase-private-deployment-runtime-prod --stack prod" PATH="${fake_bin}:$PATH" "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --stack prod --infra-dir "${temp_dir}/infra" 2>&1)"; then
+    rm -rf "${temp_dir}"
+    fail "expected script to fail when pulumi fails"
+  fi
+
+  assert_log_contains <(printf '%s' "${output}") "[info] configuring Pulumi stack prod"
+  assert_log_contains <(printf '%s' "${output}") "NOISY PULUMI STDOUT config set runtimeBucket ltbase-private-deployment-runtime-prod --stack prod"
+  assert_log_contains <(printf '%s' "${output}") "NOISY PULUMI STDERR config set runtimeBucket ltbase-private-deployment-runtime-prod --stack prod"
+
+  : >"${log_file}"
+  if ! output="$(PULUMI_STACK_SELECT_MODE=existing PATH="${fake_bin}:$PATH" "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --stack prod --infra-dir "${temp_dir}/infra" 2>&1)"; then
+    rm -rf "${temp_dir}"
+    fail "expected script to succeed when stack already exists, got: ${output}"
+  fi
+
+  assert_log_contains <(printf '%s' "${output}") "[info] configuring Pulumi stack prod"
+  assert_log_not_contains <(printf '%s' "${output}") "NOISY PULUMI STDOUT"
+  assert_log_not_contains <(printf '%s' "${output}") "NOISY PULUMI STDERR"
+  assert_log_contains "${log_file}" "pulumi stack select prod"
+  assert_log_not_contains "${log_file}" "pulumi stack init prod --secrets-provider awskms://alias/test-pulumi-secrets?region=us-west-2"
+
+  : >"${log_file}"
+  if output="$(PULUMI_STACK_SELECT_MODE=unexpected PATH="${fake_bin}:$PATH" "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --stack prod --infra-dir "${temp_dir}/infra" 2>&1)"; then
+    rm -rf "${temp_dir}"
+    fail "expected script to fail when stack select fails unexpectedly"
+  fi
+
+  assert_log_contains <(printf '%s' "${output}") "[info] configuring Pulumi stack prod"
+  assert_log_contains <(printf '%s' "${output}") "NOISY PULUMI STDOUT stack select prod"
+  assert_log_contains <(printf '%s' "${output}") "NOISY PULUMI STDERR stack select prod"
+  assert_log_contains <(printf '%s' "${output}") "error: backend unavailable"
+  assert_log_not_contains "${log_file}" "pulumi stack init prod --secrets-provider awskms://alias/test-pulumi-secrets?region=us-west-2"
 else
   fail "missing executable script: ${SCRIPT_PATH}"
 fi

--- a/test/bootstrap-env-test.sh
+++ b/test/bootstrap-env-test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LIB_PATH="${ROOT_DIR}/scripts/lib/bootstrap-env.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+  if [[ "${actual}" != "${expected}" ]]; then
+    fail "${message}: expected [${expected}], got [${actual}]"
+  fi
+}
+
+assert_file_eq() {
+  local expected="$1"
+  local path="$2"
+  local message="$3"
+  local actual
+  actual="$(<"${path}")"
+  assert_eq "${expected}" "${actual}" "${message}"
+}
+
+source "${LIB_PATH}"
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+stdout_file="${temp_dir}/stdout"
+stderr_file="${temp_dir}/stderr"
+
+bootstrap_env_info 'hello world' >"${stdout_file}" 2>"${stderr_file}"
+assert_file_eq '[info] hello world' "${stdout_file}" 'bootstrap_env_info should write info logs to stdout'
+assert_file_eq '' "${stderr_file}" 'bootstrap_env_info should not write to stderr'
+
+: >"${stdout_file}"
+: >"${stderr_file}"
+bootstrap_env_run_quiet bash -c 'printf "visible stdout\n"; printf "visible stderr\n" >&2' >"${stdout_file}" 2>"${stderr_file}"
+assert_file_eq '' "${stdout_file}" 'bootstrap_env_run_quiet should suppress stdout on success'
+assert_file_eq '' "${stderr_file}" 'bootstrap_env_run_quiet should suppress stderr on success'
+
+: >"${stdout_file}"
+: >"${stderr_file}"
+set +e
+bootstrap_env_run_quiet bash -c 'printf "failed stdout\n"; printf "failed stderr\n" >&2; exit 23' >"${stdout_file}" 2>"${stderr_file}"
+status=$?
+set -e
+assert_eq '23' "${status}" 'bootstrap_env_run_quiet should preserve failing exit status'
+assert_file_eq '' "${stdout_file}" 'bootstrap_env_run_quiet should not replay output to stdout on failure'
+assert_file_eq $'failed stdout\nfailed stderr' "${stderr_file}" 'bootstrap_env_run_quiet should replay combined output to stderr on failure'
+
+captured=''
+: >"${stdout_file}"
+: >"${stderr_file}"
+bootstrap_env_capture_quiet captured bash -c 'printf "captured stdout\n"; printf "captured stderr\n" >&2' >"${stdout_file}" 2>"${stderr_file}"
+assert_eq $'captured stdout\ncaptured stderr' "${captured}" 'bootstrap_env_capture_quiet should capture combined output on success'
+assert_file_eq '' "${stdout_file}" 'bootstrap_env_capture_quiet should stay silent on success stdout'
+assert_file_eq '' "${stderr_file}" 'bootstrap_env_capture_quiet should stay silent on success stderr'
+
+captured='unchanged'
+: >"${stdout_file}"
+: >"${stderr_file}"
+set +e
+bootstrap_env_capture_quiet captured bash -c 'printf "capture failed stdout\n"; printf "capture failed stderr\n" >&2; exit 17' >"${stdout_file}" 2>"${stderr_file}"
+status=$?
+set -e
+assert_eq '17' "${status}" 'bootstrap_env_capture_quiet should preserve failing exit status'
+assert_eq 'unchanged' "${captured}" 'bootstrap_env_capture_quiet should not overwrite the destination variable on failure'
+assert_file_eq '' "${stdout_file}" 'bootstrap_env_capture_quiet should not replay output to stdout on failure'
+assert_file_eq $'capture failed stdout\ncapture failed stderr' "${stderr_file}" 'bootstrap_env_capture_quiet should replay combined output to stderr on failure'
+
+printf 'PASS: bootstrap-env tests\n'

--- a/test/bootstrap-oidc-discovery-companion-test.sh
+++ b/test/bootstrap-oidc-discovery-companion-test.sh
@@ -73,6 +73,8 @@ cmd="${1:-}"
 sub="${2:-}"
 if [[ "${cmd} ${sub}" == "repo view" ]]; then
   if [[ "${GH_REPO_VIEW_EXISTS:-false}" == "true" ]]; then
+    printf 'NOISY_GH_STDOUT repo view success\n'
+    printf 'NOISY_GH_STDERR repo view success\n' >&2
     printf 'customer-org/customer-ltbase-oidc-discovery\n'
     exit 0
   fi
@@ -91,9 +93,12 @@ if [[ "${cmd} ${sub}" == "repo view" ]]; then
   exit 1
 fi
 if [[ "${cmd} ${sub}" == "api repos/customer-org/customer-ltbase-oidc-discovery" ]]; then
+  printf 'NOISY_GH_STDERR repo metadata success\n' >&2
   printf '{"default_branch":"main","private":false}'
   exit 0
 fi
+printf 'NOISY_GH_STDOUT generic success\n'
+printf 'NOISY_GH_STDERR generic success\n' >&2
 exit 0
 EOF
 chmod +x "${fake_bin}/gh"
@@ -109,6 +114,8 @@ fi
 if [[ "${args[0]:-} ${args[1]:-}" == "iam get-role" ]]; then
   exit 255
 fi
+printf 'NOISY_AWS_STDOUT generic success\n'
+printf 'NOISY_AWS_STDERR generic success\n' >&2
 exit 0
 EOF
 chmod +x "${fake_bin}/aws"
@@ -150,7 +157,7 @@ done
 body='{"success":true}'
 status='200'
 
-dns_lookup_url='https://api.cloudflare.com/client/v4/zones/zone-123/dns_records?type=CNAME&name=oidc.customer.example.com'
+dns_lookup_url='https://api.cloudflare.com/client/v4/zones/zone-123/dns_records?name=oidc.customer.example.com'
 dns_create_url='https://api.cloudflare.com/client/v4/zones/zone-123/dns_records'
 dns_expected_content='customer-ltbase-oidc-discovery.pages.dev'
 
@@ -167,7 +174,7 @@ if [[ "${method}" == "GET" && "${url}" == "${dns_lookup_url}" ]]; then
     body='{"success":true,"result":[{"id":"dns-1","type":"CNAME","name":"oidc.customer.example.com","content":"wrong-target.pages.dev"}]}'
     status='200'
   elif [[ "${CURL_DNS_CONFLICT_WRONG_TYPE:-false}" == "true" ]]; then
-    body='{"success":true,"result":[{"id":"dns-1","type":"TXT","name":"oidc.customer.example.com","content":"customer-ltbase-oidc-discovery.pages.dev"}]}'
+    body='{"success":true,"result":[{"id":"dns-1","type":"TXT","name":"oidc.customer.example.com","content":"some-text-value"},{"id":"dns-2","type":"CNAME","name":"other.customer.example.com","content":"customer-ltbase-oidc-discovery.pages.dev"}]}'
     status='200'
   elif [[ "${CURL_DNS_MATCHING_RECORD:-false}" == "true" ]]; then
     body='{"success":true,"result":[{"id":"dns-1","type":"CNAME","name":"oidc.customer.example.com","content":"customer-ltbase-oidc-discovery.pages.dev"}]}'
@@ -201,6 +208,11 @@ if [[ "${method}" == "POST" && "${url}" == "${dns_create_url}" && "${CURL_FAIL_D
   status='200'
 fi
 
+if [[ "${method}" == "POST" && "${CURL_TRANSPORT_FAILURE_POST:-false}" == "true" && "${url}" == *"/pages/projects" ]]; then
+  printf 'curl: (7) Failed to connect to api.cloudflare.com port 443\n' >&2
+  exit 7
+fi
+
 if [[ "${method}" == "POST" && "${CURL_FAIL_POST_SUCCESS:-true}" == "false" ]]; then
   body='{"success":false,"errors":[{"message":"simulated failure"}]}'
   status='200'
@@ -219,6 +231,7 @@ fi
 
 if [[ -n "${write_out}" ]]; then
   if [[ "${write_out}" == '%{http_code}' ]]; then
+    printf 'NOISY_CURL_STDERR http code success\n' >&2
     printf '%s' "${status}"
   else
     printf '%s' "${write_out}"
@@ -227,6 +240,8 @@ if [[ -n "${write_out}" ]]; then
 fi
 
 if [[ "${status}" =~ ^2 ]]; then
+  printf 'NOISY_CURL_STDOUT generic success\n'
+  printf 'NOISY_CURL_STDERR generic success\n' >&2
   exit 0
 fi
 
@@ -245,7 +260,7 @@ fi
 assert_log_contains "${log_file}" "gh repo create customer-org/customer-ltbase-oidc-discovery --template Lychee-Technology/ltbase-oidc-discovery-template --private --description LTBase OIDC discovery companion for customer-ltbase --clone=false"
 assert_log_contains "${log_file}" "https://api.cloudflare.com/client/v4/accounts/cf-account-123/pages/projects"
 assert_log_contains "${log_file}" "https://api.cloudflare.com/client/v4/accounts/cf-account-123/pages/projects/customer-ltbase-oidc-discovery/domains"
-assert_log_contains "${log_file}" "https://api.cloudflare.com/client/v4/zones/zone-123/dns_records?type=CNAME&name=oidc.customer.example.com"
+assert_log_contains "${log_file}" "https://api.cloudflare.com/client/v4/zones/zone-123/dns_records?name=oidc.customer.example.com"
 assert_log_contains "${log_file}" "https://api.cloudflare.com/client/v4/zones/zone-123/dns_records"
 assert_log_contains "${log_file}" "gh variable set OIDC_DISCOVERY_DOMAIN --repo customer-org/customer-ltbase-oidc-discovery --body oidc.customer.example.com"
 assert_log_contains "${log_file}" "gh variable set OIDC_DISCOVERY_STACK_CONFIG --repo customer-org/customer-ltbase-oidc-discovery --body {\"devo\":{\"aws_region\":\"ap-northeast-1\",\"aws_role_arn\":\"arn:aws:iam::123456789012:role/customer-ltbase-oidc-discovery-devo\",\"kms_auth_key_alias\":\"alias/ltbase-oidc-discovery-devo-authservice\"},\"prod\":{\"aws_region\":\"us-west-2\",\"aws_role_arn\":\"arn:aws:iam::210987654321:role/customer-ltbase-oidc-discovery-prod\",\"kms_auth_key_alias\":\"alias/ltbase-oidc-discovery-prod-authservice\"}}"
@@ -262,6 +277,18 @@ assert_file_contains "${temp_dir}/dist/oidc-discovery-companion.env" "OIDC_DISCO
 assert_file_contains "${temp_dir}/dist/oidc-discovery-companion.env" "OIDC_DISCOVERY_DOMAIN=oidc.customer.example.com"
 assert_file_contains "${temp_dir}/dist/oidc-discovery-companion.env" "OIDC_ISSUER_URL_DEVO=https://oidc.customer.example.com/devo"
 assert_file_contains "${temp_dir}/dist/oidc-discovery-companion.env" "JWKS_URL_PROD=https://oidc.customer.example.com/prod/.well-known/jwks.json"
+assert_log_contains <(printf '%s' "${output}") "[info] Ensuring OIDC discovery repository: customer-org/customer-ltbase-oidc-discovery"
+assert_log_contains <(printf '%s' "${output}") "[info] Ensuring Pages project: customer-ltbase-oidc-discovery"
+assert_log_contains <(printf '%s' "${output}") "[info] Ensuring Pages domain: oidc.customer.example.com"
+assert_log_contains <(printf '%s' "${output}") "[info] Reconciling DNS for OIDC discovery domain: oidc.customer.example.com"
+assert_log_contains <(printf '%s' "${output}") "[info] Configuring companion repository variables and secrets"
+assert_log_contains <(printf '%s' "${output}") "[info] Reconciling OIDC discovery IAM role for stack: devo"
+assert_log_not_contains <(printf '%s' "${output}") "NOISY_GH_STDOUT"
+assert_log_not_contains <(printf '%s' "${output}") "NOISY_GH_STDERR"
+assert_log_not_contains <(printf '%s' "${output}") "NOISY_CURL_STDOUT"
+assert_log_not_contains <(printf '%s' "${output}") "NOISY_CURL_STDERR"
+assert_log_not_contains <(printf '%s' "${output}") "NOISY_AWS_STDOUT"
+assert_log_not_contains <(printf '%s' "${output}") "NOISY_AWS_STDERR"
 
 cat >"${temp_dir}/invalid-domain.env" <<'EOF'
 STACKS=devo,prod
@@ -372,6 +399,15 @@ fi
 
 assert_log_contains "${temp_dir}/cloudflare-get-auth-failure.log" "Cloudflare API request failed: get Pages project (HTTP 403)"
 assert_log_not_contains "${log_file}" "https://api.cloudflare.com/client/v4/accounts/cf-account-123/pages/projects --data"
+
+: >"${log_file}"
+if PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" CURL_TRANSPORT_FAILURE_POST=true "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --output-dir "${temp_dir}/dist-transport-failed-post" >"${temp_dir}/cloudflare-transport-failure-post.log" 2>&1; then
+  fail "expected Cloudflare POST transport failure to fail"
+fi
+
+assert_log_contains "${temp_dir}/cloudflare-transport-failure-post.log" "Cloudflare API request failed: create Pages project"
+assert_log_contains "${temp_dir}/cloudflare-transport-failure-post.log" "curl: (7) Failed to connect"
+assert_log_not_contains "${log_file}" "gh variable set CLOUDFLARE_ACCOUNT_ID --repo customer-org/customer-ltbase-oidc-discovery --body cf-account-123"
 
 : >"${log_file}"
 if PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" CURL_GET_SUCCESS_FALSE=true "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --output-dir "${temp_dir}/dist-success-false-get" >"${temp_dir}/cloudflare-success-false-get.log" 2>&1; then

--- a/test/create-deployment-repo-test.sh
+++ b/test/create-deployment-repo-test.sh
@@ -49,21 +49,33 @@ scenario="\${GH_SCENARIO:-missing}"
 
 if [[ "\${1:-} \${2:-}" == "repo view" ]]; then
   if [[ "\${scenario}" == "missing" ]]; then
+    printf 'GraphQL: Could not resolve to a Repository with the name customer-org/customer-ltbase.\n' >&2
     exit 1
   fi
+  if [[ "\${scenario}" == "repo-view-error" ]]; then
+    printf 'HTTP 500: GitHub service unavailable\n' >&2
+    exit 1
+  fi
+  printf 'NOISY_GH_STDOUT repo view success\n'
+  printf 'NOISY_GH_STDERR repo view success\n' >&2
   exit 0
 fi
 
 if [[ "\${1:-} \${2:-} \${3:-}" == "api repos/customer-org/customer-ltbase --jq" ]]; then
   if [[ "\${scenario}" == "existing-private" ]]; then
+    printf 'NOISY_GH_STDERR repo private lookup success\n' >&2
     printf 'true\n'
     exit 0
   fi
   if [[ "\${scenario}" == "existing-public" ]]; then
+    printf 'NOISY_GH_STDERR repo private lookup success\n' >&2
     printf 'false\n'
     exit 0
   fi
 fi
+
+printf 'NOISY_GH_STDOUT generic success\n'
+printf 'NOISY_GH_STDERR generic success\n' >&2
 EOF
 chmod +x "${fake_bin}/gh"
 
@@ -75,6 +87,10 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
 
   assert_log_contains "${log_file}" "gh repo create customer-org/customer-ltbase --template Lychee-Technology/ltbase-private-deployment --private --description Customer LTBase deployment repo --clone=false"
   assert_log_contains "${log_file}" "gh api repos/customer-org/customer-ltbase/environments/prod --method PUT"
+  assert_log_contains <(printf '%s' "${output}") "[info] Ensuring deployment repository: customer-org/customer-ltbase"
+  assert_log_contains <(printf '%s' "${output}") "[info] Ensuring protected deployment environment: prod"
+  assert_log_not_contains <(printf '%s' "${output}") "NOISY_GH_STDOUT"
+  assert_log_not_contains <(printf '%s' "${output}") "NOISY_GH_STDERR"
 
   : >"${log_file}"
   if ! output="$(PATH="${fake_bin}:$PATH" GH_SCENARIO=existing-private "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" 2>&1)"; then
@@ -86,6 +102,9 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
   assert_log_contains "${log_file}" "gh api repos/customer-org/customer-ltbase --jq .private"
   assert_log_not_contains "${log_file}" "gh repo create customer-org/customer-ltbase --template Lychee-Technology/ltbase-private-deployment --private --description Customer LTBase deployment repo --clone=false"
   assert_log_contains "${log_file}" "gh api repos/customer-org/customer-ltbase/environments/prod --method PUT"
+  assert_log_contains <(printf '%s' "${output}") "[info] Ensuring deployment repository: customer-org/customer-ltbase"
+  assert_log_not_contains <(printf '%s' "${output}") "NOISY_GH_STDOUT"
+  assert_log_not_contains <(printf '%s' "${output}") "NOISY_GH_STDERR"
 
   : >"${log_file}"
   if output="$(PATH="${fake_bin}:$PATH" GH_SCENARIO=existing-public "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" 2>&1)"; then
@@ -97,6 +116,18 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
     rm -rf "${temp_dir}"
     fail "expected mismatch error, got: ${output}"
   fi
+
+  : >"${log_file}"
+  if output="$(PATH="${fake_bin}:$PATH" GH_SCENARIO=repo-view-error "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" 2>&1)"; then
+    rm -rf "${temp_dir}"
+    fail "expected repo lookup failure to fail"
+  fi
+
+  if [[ "${output}" != *"GitHub repo lookup failed"* ]] || [[ "${output}" != *"HTTP 500: GitHub service unavailable"* ]]; then
+    rm -rf "${temp_dir}"
+    fail "expected repo view failure output, got: ${output}"
+  fi
+  assert_log_not_contains "${log_file}" "gh repo create customer-org/customer-ltbase --template Lychee-Technology/ltbase-private-deployment --private --description Customer LTBase deployment repo --clone=false"
 else
   fail "missing executable script: ${SCRIPT_PATH}"
 fi

--- a/test/evaluate-and-continue-test.sh
+++ b/test/evaluate-and-continue-test.sh
@@ -29,6 +29,14 @@ assert_log_contains() {
   fi
 }
 
+assert_log_not_contains() {
+  local path="$1"
+  local needle="$2"
+  if grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to not contain: ${needle}"
+  fi
+}
+
 write_env() {
   local path="$1"
   cat >"${path}" <<'EOF'
@@ -240,8 +248,12 @@ if [[ "${cmd} ${sub}" == "secret list" ]]; then
   exit 0
 fi
 if [[ "${cmd} ${sub}" == "workflow run" ]]; then
+  printf 'NOISY_GH_STDOUT workflow success\n'
+  printf 'NOISY_GH_STDERR workflow success\n' >&2
   exit 0
 fi
+printf 'NOISY_GH_STDOUT generic success\n'
+printf 'NOISY_GH_STDERR generic success\n' >&2
 exit 0
 EOF
   chmod +x "${fake_bin}/gh"
@@ -263,6 +275,7 @@ case "${SCENARIO}:${command_key}" in
     exit 1
     ;;
   foundation_missing:kms\ list-aliases)
+    printf 'NOISY_AWS_STDERR kms list success\n' >&2
     printf '{"Aliases":[]}'
     exit 0
     ;;
@@ -273,6 +286,7 @@ case "${SCENARIO}:${command_key}" in
     exit 1
     ;;
   bootstrap_force:kms\ list-aliases)
+    printf 'NOISY_AWS_STDERR kms list success\n' >&2
     printf '{"Aliases":[]}'
     exit 0
     ;;
@@ -283,18 +297,24 @@ case "${SCENARIO}:${command_key}" in
     exit 0
     ;;
   bootstrap_force:kms\ create-key)
+    printf 'NOISY_AWS_STDERR kms create success\n' >&2
     printf 'key-123\n'
     exit 0
     ;;
   *:kms\ list-aliases)
+    printf 'NOISY_AWS_STDERR kms list success\n' >&2
     printf '{"Aliases":[{"AliasName":"alias/test-pulumi-secrets","TargetKeyId":"key-123"}]}'
     exit 0
     ;;
   *:dsql\ get-cluster)
+    printf 'NOISY_AWS_STDOUT dsql success\n'
+    printf 'NOISY_AWS_STDERR dsql success\n' >&2
     printf 'managed.%s.endpoint.example.com\n' "${STACK_HINT:-devo}"
     exit 0
     ;;
 esac
+printf 'NOISY_AWS_STDOUT generic success\n'
+printf 'NOISY_AWS_STDERR generic success\n' >&2
 exit 0
 EOF
   chmod +x "${fake_bin}/aws"
@@ -333,10 +353,54 @@ while [[ ${index} -lt ${#args[@]} ]]; do
   esac
 done
 if [[ "${SCENARIO}" == "oidc_companion_missing" && "${method}" == "GET" && "${url}" == *"/pages/projects/customer-ltbase-oidc-discovery" ]]; then
+  printf 'NOISY_CURL_STDERR expected missing project\n' >&2
   exit 22
 fi
 if [[ "${SCENARIO}" == "oidc_companion_missing" && "${method}" == "GET" && "${url}" == *"/pages/projects/customer-ltbase-oidc-discovery/domains/oidc.customer.example.com" ]]; then
+  printf 'NOISY_CURL_STDERR expected missing domain\n' >&2
   exit 22
+fi
+if [[ "${SCENARIO}" == "oidc_project_success_false" && "${method}" == "GET" && "${url}" == *"/pages/projects/customer-ltbase-oidc-discovery" ]]; then
+  if [[ -n "${output_file}" ]]; then
+    printf '{"success":false,"errors":[{"message":"project state unavailable"}]}' >"${output_file}"
+  else
+    printf '{"success":false,"errors":[{"message":"project state unavailable"}]}'
+  fi
+  if [[ "${write_format}" == "%{http_code}" ]]; then
+    printf 'NOISY_CURL_STDERR http code success\n' >&2
+    printf '200'
+  fi
+  printf 'NOISY_CURL_STDOUT generic success\n'
+  printf 'NOISY_CURL_STDERR generic success\n' >&2
+  exit 0
+fi
+if [[ "${SCENARIO}" == "oidc_domain_success_false" && "${method}" == "GET" && "${url}" == *"/pages/projects/customer-ltbase-oidc-discovery/domains/oidc.customer.example.com" ]]; then
+  if [[ -n "${output_file}" ]]; then
+    printf '{"success":false,"errors":[{"message":"domain state unavailable"}]}' >"${output_file}"
+  else
+    printf '{"success":false,"errors":[{"message":"domain state unavailable"}]}'
+  fi
+  if [[ "${write_format}" == "%{http_code}" ]]; then
+    printf 'NOISY_CURL_STDERR http code success\n' >&2
+    printf '200'
+  fi
+  printf 'NOISY_CURL_STDOUT generic success\n'
+  printf 'NOISY_CURL_STDERR generic success\n' >&2
+  exit 0
+fi
+if [[ "${SCENARIO}" == "oidc_dns_success_false" && "${method}" == "GET" && "${url}" == *"/zones/zone-123/dns_records?type=CNAME&name=oidc.customer.example.com" ]]; then
+  if [[ -n "${output_file}" ]]; then
+    printf '{"success":false,"errors":[{"message":"dns state unavailable"}]}' >"${output_file}"
+  else
+    printf '{"success":false,"errors":[{"message":"dns state unavailable"}]}'
+  fi
+  if [[ "${write_format}" == "%{http_code}" ]]; then
+    printf 'NOISY_CURL_STDERR http code success\n' >&2
+    printf '200'
+  fi
+  printf 'NOISY_CURL_STDOUT generic success\n'
+  printf 'NOISY_CURL_STDERR generic success\n' >&2
+  exit 0
 fi
 if [[ "${SCENARIO}" == "oidc_missing_dns" && "${method}" == "GET" && "${url}" == *"/zones/zone-123/dns_records?type=CNAME&name=oidc.customer.example.com" ]]; then
   if [[ -n "${output_file}" ]]; then
@@ -345,8 +409,11 @@ if [[ "${SCENARIO}" == "oidc_missing_dns" && "${method}" == "GET" && "${url}" ==
     printf '{"success":true,"result":[]}'
   fi
   if [[ "${write_format}" == "%{http_code}" ]]; then
+    printf 'NOISY_CURL_STDERR http code success\n' >&2
     printf '200'
   fi
+  printf 'NOISY_CURL_STDOUT generic success\n'
+  printf 'NOISY_CURL_STDERR generic success\n' >&2
   exit 0
 fi
 if [[ -n "${output_file}" ]]; then
@@ -355,8 +422,11 @@ else
   printf '{"success":true}'
 fi
 if [[ "${write_format}" == "%{http_code}" ]]; then
+  printf 'NOISY_CURL_STDERR http code success\n' >&2
   printf '200'
 fi
+printf 'NOISY_CURL_STDOUT generic success\n'
+printf 'NOISY_CURL_STDERR generic success\n' >&2
 EOF
   chmod +x "${fake_bin}/curl"
 
@@ -378,15 +448,20 @@ stack_name() {
 }
 
 if [[ "${1:-}" == "login" ]]; then
+  printf 'NOISY_PULUMI_STDOUT login success\n'
+  printf 'NOISY_PULUMI_STDERR login success\n' >&2
   exit 0
 fi
 if [[ "${1:-} ${2:-}" == "stack select" ]]; then
   if [[ "${SCENARIO}" == "bootstrap_force" ]]; then
+    printf 'error: no stack named %s found\n' "$(stack_name "$@")" >&2
     exit 1
   fi
   exit 0
 fi
 if [[ "${1:-} ${2:-}" == "stack init" ]]; then
+  printf 'NOISY_PULUMI_STDOUT stack init success\n'
+  printf 'NOISY_PULUMI_STDERR stack init success\n' >&2
   exit 0
 fi
 if [[ "${1:-} ${2:-} ${3:-} ${4:-}" == "stack output dsqlClusterIdentifier --stack" ]]; then
@@ -430,8 +505,12 @@ if [[ "${1:-} ${2:-} ${3:-} ${4:-}" == "config get mtlsTruststoreKey --stack" ]]
   exit 0
 fi
 if [[ "${1:-} ${2:-}" == "config set" || "${1:-} ${2:-}" == "config rm" ]]; then
+  printf 'NOISY_PULUMI_STDOUT config success\n'
+  printf 'NOISY_PULUMI_STDERR config success\n' >&2
   exit 0
 fi
+printf 'NOISY_PULUMI_STDOUT generic success\n'
+printf 'NOISY_PULUMI_STDERR generic success\n' >&2
 exit 0
 EOF
   chmod +x "${fake_bin}/pulumi"
@@ -552,6 +631,15 @@ run_expect_exit_code 2 env \
 assert_file_contains "${temp_dir}/report-oidc/report.json" '"oidcDiscovery"'
 assert_file_contains "${temp_dir}/report-oidc/report.json" '"status": "needs_oidc_companion"'
 
+oidc_missing_output="$(env \
+  PATH="${temp_dir}/bin:$PATH" \
+  COMMAND_LOG="${temp_dir}/commands.log" \
+  SCENARIO="oidc_companion_missing" \
+  "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-oidc-quiet" 2>&1 || true)"
+
+assert_log_not_contains <(printf '%s' "${oidc_missing_output}") "NOISY_CURL_STDERR expected missing project"
+assert_log_not_contains <(printf '%s' "${oidc_missing_output}") "NOISY_CURL_STDERR expected missing domain"
+
 run_expect_exit_code 2 env \
   PATH="${temp_dir}/bin:$PATH" \
   COMMAND_LOG="${temp_dir}/commands.log" \
@@ -560,6 +648,33 @@ run_expect_exit_code 2 env \
 
 assert_file_contains "${temp_dir}/report-oidc-missing-dns/report.json" '"status": "needs_oidc_companion"'
 assert_file_contains "${temp_dir}/report-oidc-missing-dns/report.json" '"pagesDnsPresent": false'
+
+run_expect_exit_code 2 env \
+  PATH="${temp_dir}/bin:$PATH" \
+  COMMAND_LOG="${temp_dir}/commands.log" \
+  SCENARIO="oidc_project_success_false" \
+  "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-oidc-project-success-false"
+
+assert_file_contains "${temp_dir}/report-oidc-project-success-false/report.json" '"status": "needs_oidc_companion"'
+assert_file_contains "${temp_dir}/report-oidc-project-success-false/report.json" '"pagesProjectPresent": false'
+
+run_expect_exit_code 2 env \
+  PATH="${temp_dir}/bin:$PATH" \
+  COMMAND_LOG="${temp_dir}/commands.log" \
+  SCENARIO="oidc_domain_success_false" \
+  "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-oidc-domain-success-false"
+
+assert_file_contains "${temp_dir}/report-oidc-domain-success-false/report.json" '"status": "needs_oidc_companion"'
+assert_file_contains "${temp_dir}/report-oidc-domain-success-false/report.json" '"pagesDomainPresent": false'
+
+run_expect_exit_code 2 env \
+  PATH="${temp_dir}/bin:$PATH" \
+  COMMAND_LOG="${temp_dir}/commands.log" \
+  SCENARIO="oidc_dns_success_false" \
+  "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-oidc-dns-success-false"
+
+assert_file_contains "${temp_dir}/report-oidc-dns-success-false/report.json" '"status": "needs_oidc_companion"'
+assert_file_contains "${temp_dir}/report-oidc-dns-success-false/report.json" '"pagesDnsPresent": false'
 
 rm -rf "${temp_dir}/infra"
 mkdir -p "${temp_dir}/infra"
@@ -588,16 +703,26 @@ EOF
 done
 
 : >"${temp_dir}/commands.log"
-run_expect_exit_code 0 env \
+force_rollout_output="$(env \
   PATH="${temp_dir}/bin:$PATH" \
   COMMAND_LOG="${temp_dir}/commands.log" \
   SCENARIO="rollout_mix" \
-  "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-force-rollout" --force --release-id v2.0.0
+  "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-force-rollout" --force --release-id v2.0.0 2>&1)"
 
 # Should call reconcile for staging (needs_dsql_reconcile)
 assert_log_contains "${temp_dir}/report-force-rollout/actions.log" "reconcile-managed-dsql-endpoint.sh --env-file ${temp_dir}/.env --stack staging --infra-dir ${temp_dir}/infra"
 # Should dispatch rollout-hop.yml for devo (first needs_rollout stack), NOT rollout.yml
 assert_log_contains "${temp_dir}/report-force-rollout/actions.log" "gh workflow run rollout-hop.yml --repo customer-org/customer-ltbase -f release_id=v2.0.0 -f target_stack=devo -f continue_chain=true"
+assert_log_contains <(printf '%s' "${force_rollout_output}") "[info] Reconciling managed DSQL endpoint: staging"
+assert_log_contains <(printf '%s' "${force_rollout_output}") "[info] Dispatching rollout workflow: rollout-hop.yml"
+assert_log_not_contains <(printf '%s' "${force_rollout_output}") "NOISY_GH_STDOUT"
+assert_log_not_contains <(printf '%s' "${force_rollout_output}") "NOISY_GH_STDERR"
+assert_log_not_contains <(printf '%s' "${force_rollout_output}") "NOISY_AWS_STDOUT"
+assert_log_not_contains <(printf '%s' "${force_rollout_output}") "NOISY_AWS_STDERR"
+assert_log_not_contains <(printf '%s' "${force_rollout_output}") "NOISY_CURL_STDOUT"
+assert_log_not_contains <(printf '%s' "${force_rollout_output}") "NOISY_CURL_STDERR"
+assert_log_not_contains <(printf '%s' "${force_rollout_output}") "NOISY_PULUMI_STDOUT"
+assert_log_not_contains <(printf '%s' "${force_rollout_output}") "NOISY_PULUMI_STDERR"
 # Should NOT dispatch rollout.yml
 if grep -Fq "gh workflow run rollout.yml" "${temp_dir}/report-force-rollout/actions.log"; then
   fail "force mode with needs_rollout should dispatch rollout-hop.yml, not rollout.yml"
@@ -624,5 +749,22 @@ run_expect_exit_code 2 env \
   "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-envs-detect"
 
 assert_file_contains "${temp_dir}/report-envs-detect/report.json" '"status": "needs_repo_config"'
+
+force_output="$(env \
+  PATH="${temp_dir}/bin:$PATH" \
+  COMMAND_LOG="${temp_dir}/commands.log" \
+  SCENARIO="envs_missing" \
+  "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --infra-dir "${temp_dir}/infra" --report-dir "${temp_dir}/report-force-envs-quiet" --force --release-id v4.0.0 2>&1)"
+
+assert_log_contains <(printf '%s' "${force_output}") "[info] Ensuring protected deployment environment: staging"
+assert_log_contains <(printf '%s' "${force_output}") "[info] Dispatching rollout workflow: rollout.yml"
+assert_log_not_contains <(printf '%s' "${force_output}") "NOISY_GH_STDOUT"
+assert_log_not_contains <(printf '%s' "${force_output}") "NOISY_GH_STDERR"
+assert_log_not_contains <(printf '%s' "${force_output}") "NOISY_AWS_STDOUT"
+assert_log_not_contains <(printf '%s' "${force_output}") "NOISY_AWS_STDERR"
+assert_log_not_contains <(printf '%s' "${force_output}") "NOISY_CURL_STDOUT"
+assert_log_not_contains <(printf '%s' "${force_output}") "NOISY_CURL_STDERR"
+assert_log_not_contains <(printf '%s' "${force_output}") "NOISY_PULUMI_STDOUT"
+assert_log_not_contains <(printf '%s' "${force_output}") "NOISY_PULUMI_STDERR"
 
 printf 'PASS: evaluate-and-continue tests\n'

--- a/test/sync-template-upstream-test.sh
+++ b/test/sync-template-upstream-test.sh
@@ -10,6 +10,22 @@ fail() {
   exit 1
 }
 
+assert_text_contains() {
+  local text="$1"
+  local needle="$2"
+  if [[ "${text}" != *"${needle}"* ]]; then
+    fail "expected output to contain: ${needle}"
+  fi
+}
+
+assert_text_not_contains() {
+  local text="$1"
+  local needle="$2"
+  if [[ "${text}" == *"${needle}"* ]]; then
+    fail "expected output to not contain: ${needle}"
+  fi
+}
+
 assert_log_contains() {
   local path="$1"
   local needle="$2"
@@ -47,9 +63,11 @@ printf 'git %s\n' "$*" >>"${COMMAND_LOG}"
   case "$*" in
   "rev-parse --is-inside-work-tree")
     printf 'true\n'
+    printf 'INSIDE-WORKTREE-NOISE\n' >&2
     exit 0
     ;;
   "status --porcelain")
+    printf 'STATUS-NOISE\n' >&2
     if [[ "${SCENARIO:-success}" == "dirty" ]]; then
       printf ' M README.md\n'
     fi
@@ -57,26 +75,39 @@ printf 'git %s\n' "$*" >>"${COMMAND_LOG}"
     ;;
   "rev-parse --abbrev-ref HEAD")
     printf 'main\n'
+    printf 'BRANCH-NOISE\n' >&2
     exit 0
     ;;
   "remote get-url upstream")
     if [[ "${SCENARIO:-success}" == "url_mismatch" ]]; then
       printf 'https://github.com/example/wrong-template.git\n'
+      printf 'REMOTE-GET-NOISE\n' >&2
       exit 0
     fi
     exit 2
     ;;
   "remote add upstream https://github.com/Lychee-Technology/ltbase-private-deployment.git")
+    printf 'REMOTE-ADD-NOISE\n'
+    printf 'REMOTE-ADD-NOISE\n' >&2
     exit 0
     ;;
   "fetch upstream")
+    printf 'FETCH-NOISE\n'
+    printf 'FETCH-NOISE\n' >&2
     exit 0
     ;;
   "rev-parse upstream/main")
+    if [[ "${SCENARIO:-success}" == "upstream_commit_failure" ]]; then
+      printf 'upstream commit failed\n' >&2
+      exit 23
+    fi
     printf 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n'
+    printf 'UPSTREAM-COMMIT-NOISE\n' >&2
     exit 0
     ;;
   "archive --format=tar --output sync-template-upstream.tar upstream/main")
+    printf 'ARCHIVE-NOISE\n'
+    printf 'ARCHIVE-NOISE\n' >&2
     exit 0
     ;;
 esac
@@ -90,6 +121,14 @@ EOF
 set -euo pipefail
 printf 'find %s\n' "$*" >>"${COMMAND_LOG}"
 if [[ "$*" == "${TEMP_ROOT}/upstream-checkout/infra -type f" ]]; then
+  if [[ "${SCENARIO:-success}" == "find_failure" ]]; then
+    printf 'find failed\n' >&2
+    exit 31
+  fi
+  printf 'FIND-NOISE\n' >&2
+  if [[ "${SCENARIO:-success}" == "empty_find" ]]; then
+    exit 0
+  fi
   printf '%s\n' \
     "${TEMP_ROOT}/upstream-checkout/infra/go.mod" \
     "${TEMP_ROOT}/upstream-checkout/infra/go.sum"
@@ -103,6 +142,12 @@ EOF
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'shasum %s\n' "$*" >>"${COMMAND_LOG}"
+content="$(cat)"
+if [[ "${SCENARIO:-success}" == "empty_find" && "${content}" == *$'==  ==\n'* ]]; then
+  printf 'malformed fingerprint input\n' >&2
+  exit 41
+fi
+printf 'SHASUM-NOISE\n' >&2
 printf 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  -\n'
 EOF
   chmod +x "${fake_bin}/shasum"
@@ -114,6 +159,7 @@ printf 'jq %s\n' "$*" >>"${COMMAND_LOG}"
 if [[ "${1:-}" != "-n" ]]; then
   exit 1
 fi
+printf 'JQ-NOISE\n' >&2
 cat <<JSON
 {
   "template_repository": "Lychee-Technology/ltbase-private-deployment",
@@ -131,6 +177,8 @@ EOF
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'tar %s\n' "$*" >>"${COMMAND_LOG}"
+printf 'TAR-NOISE\n'
+printf 'TAR-NOISE\n' >&2
 if [[ "$*" == "-xf sync-template-upstream.tar -C ${TEMP_ROOT}/upstream-checkout" ]]; then
   mkdir -p \
     "${TEMP_ROOT}/upstream-checkout/.github/workflows" \
@@ -153,6 +201,8 @@ EOF
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'rsync %s\n' "$*" >>"${COMMAND_LOG}"
+printf 'RSYNC-NOISE\n'
+printf 'RSYNC-NOISE\n' >&2
 src="${@: -2:1}"
 dest="${@: -1}"
 mkdir -p "${dest}/__ref__"
@@ -179,6 +229,10 @@ if [[ "${1:-}" == "-d" ]]; then
   mkdir -p "${TEMP_ROOT}/upstream-checkout"
   exit 0
 fi
+path="${TEMP_ROOT}/mktemp-file.$$.$RANDOM"
+: >"${path}"
+printf '%s\n' "${path}"
+exit 0
 exit 1
 EOF
   chmod +x "${fake_bin}/mktemp"
@@ -192,6 +246,23 @@ run_success_case() {
   if ! output="$(PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" TEMP_ROOT="${temp_dir}" "${SCRIPT_PATH}" 2>&1)"; then
     fail "expected script to succeed, got: ${output}"
   fi
+
+  assert_text_contains "${output}" "[info] fetching upstream template from upstream/main"
+  assert_text_contains "${output}" "[info] refreshing provenance metadata"
+  assert_text_contains "${output}" "[info] syncing template-managed files"
+  assert_text_contains "${output}" "synced upstream/main into main"
+  assert_text_not_contains "${output}" "INSIDE-WORKTREE-NOISE"
+  assert_text_not_contains "${output}" "STATUS-NOISE"
+  assert_text_not_contains "${output}" "BRANCH-NOISE"
+  assert_text_not_contains "${output}" "REMOTE-ADD-NOISE"
+  assert_text_not_contains "${output}" "FETCH-NOISE"
+  assert_text_not_contains "${output}" "UPSTREAM-COMMIT-NOISE"
+  assert_text_not_contains "${output}" "ARCHIVE-NOISE"
+  assert_text_not_contains "${output}" "TAR-NOISE"
+  assert_text_not_contains "${output}" "FIND-NOISE"
+  assert_text_not_contains "${output}" "SHASUM-NOISE"
+  assert_text_not_contains "${output}" "JQ-NOISE"
+  assert_text_not_contains "${output}" "RSYNC-NOISE"
 
   assert_log_contains "${log_file}" "git rev-parse --is-inside-work-tree"
   assert_log_contains "${log_file}" "git status --porcelain"
@@ -243,6 +314,44 @@ run_url_mismatch_case() {
   fi
 }
 
+run_upstream_commit_failure_case() {
+  local fake_bin="$1"
+  setup_fake_git "${fake_bin}"
+
+  if PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" TEMP_ROOT="${temp_dir}" SCENARIO="upstream_commit_failure" "${SCRIPT_PATH}" >"${temp_dir}/upstream-commit-failure.out" 2>&1; then
+    fail "expected script to fail when upstream commit capture fails"
+  fi
+
+  if ! grep -Fq "upstream commit failed" "${temp_dir}/upstream-commit-failure.out"; then
+    fail "expected upstream commit capture failure output"
+  fi
+}
+
+run_find_failure_case() {
+  local fake_bin="$1"
+  setup_fake_git "${fake_bin}"
+
+  if PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" TEMP_ROOT="${temp_dir}" SCENARIO="find_failure" "${SCRIPT_PATH}" >"${temp_dir}/find-failure.out" 2>&1; then
+    fail "expected script to fail when fingerprint file discovery fails"
+  fi
+
+  if ! grep -Fq "find failed" "${temp_dir}/find-failure.out"; then
+    fail "expected fingerprint discovery failure output"
+  fi
+}
+
+run_empty_find_case() {
+  local fake_bin="$1"
+  setup_fake_git "${fake_bin}"
+
+  if ! output="$(PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" TEMP_ROOT="${temp_dir}" SCENARIO="empty_find" "${SCRIPT_PATH}" 2>&1)"; then
+    fail "expected script to succeed when fingerprint discovery is empty, got: ${output}"
+  fi
+
+  assert_text_contains "${output}" "synced upstream/main into main"
+  assert_text_not_contains "${output}" "find failed"
+}
+
 if [[ ! -x "${SCRIPT_PATH}" ]]; then
   fail "missing executable script: ${SCRIPT_PATH}"
 fi
@@ -250,9 +359,15 @@ fi
 success_bin="${temp_dir}/success-bin"
 dirty_bin="${temp_dir}/dirty-bin"
 url_mismatch_bin="${temp_dir}/url-mismatch-bin"
+upstream_commit_failure_bin="${temp_dir}/upstream-commit-failure-bin"
+find_failure_bin="${temp_dir}/find-failure-bin"
+empty_find_bin="${temp_dir}/empty-find-bin"
 
 run_success_case "${success_bin}" "${log_file}"
 run_dirty_tree_case "${dirty_bin}"
 run_url_mismatch_case "${url_mismatch_bin}"
+run_upstream_commit_failure_case "${upstream_commit_failure_bin}"
+run_find_failure_case "${find_failure_bin}"
+run_empty_find_case "${empty_find_bin}"
 
 printf 'PASS: sync-template-upstream tests\n'

--- a/test/update-sync-template-tooling-test.sh
+++ b/test/update-sync-template-tooling-test.sh
@@ -10,6 +10,22 @@ fail() {
   exit 1
 }
 
+assert_text_contains() {
+  local text="$1"
+  local needle="$2"
+  if [[ "${text}" != *"${needle}"* ]]; then
+    fail "expected output to contain: ${needle}"
+  fi
+}
+
+assert_text_not_contains() {
+  local text="$1"
+  local needle="$2"
+  if [[ "${text}" == *"${needle}"* ]]; then
+    fail "expected output to not contain: ${needle}"
+  fi
+}
+
 assert_log_contains() {
   local path="$1"
   local needle="$2"
@@ -44,26 +60,39 @@ printf 'git %s\n' "$*" >>"${COMMAND_LOG}"
 case "$*" in
   "rev-parse --is-inside-work-tree")
     printf 'true\n'
+    printf 'INSIDE-WORKTREE-NOISE\n' >&2
     exit 0
     ;;
   "status --porcelain")
+    printf 'STATUS-NOISE\n' >&2
+    if [[ "${SCENARIO:-success}" == "status_failure" ]]; then
+      printf 'status failed\n' >&2
+      exit 17
+    fi
     printf '\n'
     exit 0
     ;;
   "rev-parse --abbrev-ref HEAD")
     printf 'main\n'
+    printf 'BRANCH-NOISE\n' >&2
     exit 0
     ;;
   "remote get-url upstream")
     exit 2
     ;;
   "remote add upstream https://github.com/Lychee-Technology/ltbase-private-deployment.git")
+    printf 'REMOTE-ADD-NOISE\n'
+    printf 'REMOTE-ADD-NOISE\n' >&2
     exit 0
     ;;
   "fetch upstream")
+    printf 'FETCH-NOISE\n'
+    printf 'FETCH-NOISE\n' >&2
     exit 0
     ;;
   "archive --format=tar --output sync-template-upstream.tar upstream/main")
+    printf 'ARCHIVE-NOISE\n'
+    printf 'ARCHIVE-NOISE\n' >&2
     exit 0
     ;;
 esac
@@ -76,6 +105,8 @@ EOF
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'tar %s\n' "$*" >>"${COMMAND_LOG}"
+printf 'TAR-NOISE\n'
+printf 'TAR-NOISE\n' >&2
 if [[ "$*" == "-xf sync-template-upstream.tar -C ${TEMP_ROOT}/upstream-checkout" ]]; then
   mkdir -p "${TEMP_ROOT}/upstream-checkout/scripts" "${TEMP_ROOT}/upstream-checkout/test"
   : >"${TEMP_ROOT}/upstream-checkout/scripts/sync-template-upstream.sh"
@@ -89,6 +120,8 @@ EOF
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'cp %s\n' "$*" >>"${COMMAND_LOG}"
+printf 'CP-NOISE\n'
+printf 'CP-NOISE\n' >&2
 exit 0
 EOF
   chmod +x "${fake_bin}/cp"
@@ -101,6 +134,10 @@ if [[ "${1:-}" == "-d" ]]; then
   mkdir -p "${TEMP_ROOT}/upstream-checkout"
   exit 0
 fi
+path="${TEMP_ROOT}/mktemp-file.$$.$RANDOM"
+: >"${path}"
+printf '%s\n' "${path}"
+exit 0
 exit 1
 EOF
   chmod +x "${fake_bin}/mktemp"
@@ -125,6 +162,18 @@ if ! output="$(PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" TEMP_ROOT="${t
   fail "expected script to succeed, got: ${output}"
 fi
 
+assert_text_contains "${output}" "[info] fetching upstream template from upstream/main"
+assert_text_contains "${output}" "[info] updating local sync helper files"
+assert_text_contains "${output}" "updated sync tooling from upstream/main"
+assert_text_not_contains "${output}" "INSIDE-WORKTREE-NOISE"
+assert_text_not_contains "${output}" "STATUS-NOISE"
+assert_text_not_contains "${output}" "BRANCH-NOISE"
+assert_text_not_contains "${output}" "REMOTE-ADD-NOISE"
+assert_text_not_contains "${output}" "FETCH-NOISE"
+assert_text_not_contains "${output}" "ARCHIVE-NOISE"
+assert_text_not_contains "${output}" "TAR-NOISE"
+assert_text_not_contains "${output}" "CP-NOISE"
+
 assert_log_contains "${log_file}" "git rev-parse --is-inside-work-tree"
 assert_log_contains "${log_file}" "git status --porcelain"
 assert_log_contains "${log_file}" "git rev-parse --abbrev-ref HEAD"
@@ -136,5 +185,12 @@ assert_log_contains "${log_file}" "tar -xf sync-template-upstream.tar -C ${temp_
 assert_log_contains "${log_file}" "cp ${temp_dir}/upstream-checkout/scripts/sync-template-upstream.sh ${ROOT_DIR}/scripts/sync-template-upstream.sh"
 assert_log_contains "${log_file}" "cp ${temp_dir}/upstream-checkout/test/sync-template-upstream-test.sh ${ROOT_DIR}/test/sync-template-upstream-test.sh"
 assert_log_not_contains "${log_file}" "rsync "
+
+status_failure_out="${temp_dir}/status-failure.out"
+if PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" TEMP_ROOT="${temp_dir}" SCENARIO="status_failure" "${SCRIPT_PATH}" >"${status_failure_out}" 2>&1; then
+  fail "expected script to fail when git status capture fails"
+fi
+
+assert_log_contains "${status_failure_out}" "status failed"
 
 printf 'PASS: update-sync-template-tooling tests\n'


### PR DESCRIPTION
## Summary
- reduce customer-facing deployment shell scripts to concise info-level progress logs by default
- suppress success-path CLI chatter while preserving failure diagnostics for GitHub, AWS, Pulumi, Cloudflare, and sync flows
- add regression coverage for quiet success output, preserved failure output, and key edge cases

## Testing
- bash test/bootstrap-env-test.sh
- bash test/bootstrap-all-test.sh
- bash test/bootstrap-deployment-repo-test.sh
- bash test/create-deployment-repo-test.sh
- bash test/bootstrap-aws-foundation-test.sh
- bash test/bootstrap-oidc-discovery-companion-test.sh
- bash test/evaluate-and-continue-test.sh
- bash test/update-sync-template-tooling-test.sh
- bash test/sync-template-upstream-test.sh