### PR TITLE
fix: keep sync-template-upstream self-contained

### DIFF
--- a/scripts/sync-template-upstream.sh
+++ b/scripts/sync-template-upstream.sh
@@ -2,9 +2,25 @@
 
 set -euo pipefail
 
-script_dir="$(cd "$(dirname "$0")" && pwd)"
-# shellcheck disable=SC1091
-source "${script_dir}/lib/bootstrap-env.sh"
+sync_template_info() {
+  printf '[info] %s\n' "$*"
+}
+
+sync_template_run_quiet() {
+  local output status
+
+  if output="$($@ 2>&1)"; then
+    return 0
+  else
+    status=$?
+  fi
+
+  if [[ -n "${output}" ]]; then
+    printf '%s\n' "${output}" >&2
+  fi
+
+  return "${status}"
+}
 
 capture_stdout_quiet() {
   local destination_var="$1"
@@ -125,19 +141,19 @@ if existing_url="$(git remote get-url "${UPSTREAM_NAME}" 2>/dev/null)"; then
     exit 1
   fi
 else
-  bootstrap_env_run_quiet git remote add "${UPSTREAM_NAME}" "${UPSTREAM_URL}"
+  sync_template_run_quiet git remote add "${UPSTREAM_NAME}" "${UPSTREAM_URL}"
 fi
 
-bootstrap_env_info "fetching upstream template from ${UPSTREAM_NAME}/${BRANCH}"
-bootstrap_env_run_quiet git fetch "${UPSTREAM_NAME}"
+sync_template_info "fetching upstream template from ${UPSTREAM_NAME}/${BRANCH}"
+sync_template_run_quiet git fetch "${UPSTREAM_NAME}"
 capture_stdout_quiet upstream_commit git rev-parse "${UPSTREAM_NAME}/${BRANCH}"
 
 temp_root="$(mktemp -d)"
 trap 'rm -rf "${temp_root}" "${ARCHIVE_PATH}"' EXIT
 
-bootstrap_env_run_quiet git archive --format=tar --output "${ARCHIVE_PATH}" "${UPSTREAM_NAME}/${BRANCH}"
+sync_template_run_quiet git archive --format=tar --output "${ARCHIVE_PATH}" "${UPSTREAM_NAME}/${BRANCH}"
 mkdir -p "${temp_root}"
-bootstrap_env_run_quiet tar -xf "${ARCHIVE_PATH}" -C "${temp_root}"
+sync_template_run_quiet tar -xf "${ARCHIVE_PATH}" -C "${temp_root}"
 
 for path in "${required_source_paths[@]}"; do
   if [[ ! -e "${temp_root}/${path}" ]]; then
@@ -149,7 +165,7 @@ done
 fingerprint="$(build_fingerprint "${temp_root}")"
 
 mkdir -p "${temp_root}/__ref__"
-bootstrap_env_info "refreshing provenance metadata"
+sync_template_info "refreshing provenance metadata"
 capture_stdout_quiet provenance_json jq -n \
   --arg template_repository "Lychee-Technology/ltbase-private-deployment" \
   --arg template_ref "${BRANCH}" \
@@ -160,8 +176,8 @@ capture_stdout_quiet provenance_json jq -n \
   '{template_repository:$template_repository,template_ref:$template_ref,template_commit:$template_commit,build_fingerprint:$build_fingerprint,generated_at:$generated_at,generator:$generator}'
 printf '%s\n' "${provenance_json}" > "${temp_root}/__ref__/template-provenance.json"
 
-bootstrap_env_info "syncing template-managed files"
-bootstrap_env_run_quiet rsync -a --delete \
+sync_template_info "syncing template-managed files"
+sync_template_run_quiet rsync -a --delete \
   --exclude '.git/' \
   --exclude 'dist/' \
   --exclude '.DS_Store' \

--- a/test/sync-template-upstream-test.sh
+++ b/test/sync-template-upstream-test.sh
@@ -352,6 +352,25 @@ run_empty_find_case() {
   assert_text_not_contains "${output}" "find failed"
 }
 
+run_without_bootstrap_env_case() {
+  local fake_bin="$1"
+  local backup_path="${ROOT_DIR}/scripts/lib/bootstrap-env.sh.test-backup"
+  setup_fake_git "${fake_bin}"
+
+  mv "${ROOT_DIR}/scripts/lib/bootstrap-env.sh" "${backup_path}"
+  trap 'mv "${backup_path}" "${ROOT_DIR}/scripts/lib/bootstrap-env.sh"; /bin/cp "${original_provenance}" "${provenance_path}"; rm -rf "${temp_dir}"' EXIT
+
+  if ! output="$(PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" TEMP_ROOT="${temp_dir}" "${SCRIPT_PATH}" 2>&1)"; then
+    fail "expected script to stay runnable without bootstrap-env.sh, got: ${output}"
+  fi
+
+  assert_text_contains "${output}" "[info] fetching upstream template from upstream/main"
+  assert_text_contains "${output}" "synced upstream/main into main"
+
+  mv "${backup_path}" "${ROOT_DIR}/scripts/lib/bootstrap-env.sh"
+  trap '/bin/cp "${original_provenance}" "${provenance_path}"; rm -rf "${temp_dir}"' EXIT
+}
+
 if [[ ! -x "${SCRIPT_PATH}" ]]; then
   fail "missing executable script: ${SCRIPT_PATH}"
 fi
@@ -362,6 +381,7 @@ url_mismatch_bin="${temp_dir}/url-mismatch-bin"
 upstream_commit_failure_bin="${temp_dir}/upstream-commit-failure-bin"
 find_failure_bin="${temp_dir}/find-failure-bin"
 empty_find_bin="${temp_dir}/empty-find-bin"
+self_contained_bin="${temp_dir}/self-contained-bin"
 
 run_success_case "${success_bin}" "${log_file}"
 run_dirty_tree_case "${dirty_bin}"
@@ -369,5 +389,6 @@ run_url_mismatch_case "${url_mismatch_bin}"
 run_upstream_commit_failure_case "${upstream_commit_failure_bin}"
 run_find_failure_case "${find_failure_bin}"
 run_empty_find_case "${empty_find_bin}"
+run_without_bootstrap_env_case "${self_contained_bin}"
 
 printf 'PASS: sync-template-upstream tests\n'


### PR DESCRIPTION
## Summary
- remove the runtime dependency on `scripts/lib/bootstrap-env.sh` from `scripts/sync-template-upstream.sh`
- keep the script self-contained so it still runs after `scripts/update-sync-template-tooling.sh` refreshes only the sync helpers
- add a regression test that verifies `sync-template-upstream.sh` stays runnable even when `bootstrap-env.sh` is unavailable

## Testing
- bash test/sync-template-upstream-test.sh
- bash test/update-sync-template-tooling-test.sh