### PR TITLE
feat: add Cloudflare mTLS audit checks

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -63,3 +63,50 @@ jobs:
       aws_role_arn: ${{ secrets[format('AWS_ROLE_ARN_{0}', needs.prepare.outputs.target_stack_upper)] }}
       ltbase_releases_token: ${{ secrets.LTBASE_RELEASES_TOKEN }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+  audit_mtls:
+    needs:
+      - prepare
+      - preview
+    if: ${{ needs.preview.result == 'success' }}
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets[format('AWS_ROLE_ARN_{0}', needs.prepare.outputs.target_stack_upper)] }}
+          aws-region: ${{ vars[format('AWS_REGION_{0}', needs.prepare.outputs.target_stack_upper)] }}
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Prepare mTLS audit env
+        env:
+          STACKS: ${{ vars.STACKS || 'devo,prod' }}
+          PROMOTION_PATH: ${{ vars.PROMOTION_PATH || vars.STACKS || 'devo,prod' }}
+          AWS_REGION: ${{ vars[format('AWS_REGION_{0}', needs.prepare.outputs.target_stack_upper)] }}
+          API_DOMAIN: ${{ vars[format('API_DOMAIN_{0}', needs.prepare.outputs.target_stack_upper)] }}
+          CONTROL_DOMAIN: ${{ vars[format('CONTROL_DOMAIN_{0}', needs.prepare.outputs.target_stack_upper)] }}
+          AUTH_DOMAIN: ${{ vars[format('AUTH_DOMAIN_{0}', needs.prepare.outputs.target_stack_upper)] }}
+          RUNTIME_BUCKET: ${{ vars[format('RUNTIME_BUCKET_{0}', needs.prepare.outputs.target_stack_upper)] }}
+          CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
+          MTLS_TRUSTSTORE_KEY: mtls/cloudflare-origin-pull-ca.pem
+        run: |
+          cat > .github/mTLS-audit.env <<EOF
+          STACKS=${STACKS}
+          PROMOTION_PATH=${PROMOTION_PATH}
+          AWS_REGION_${{ needs.prepare.outputs.target_stack_upper }}=${AWS_REGION}
+          API_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${API_DOMAIN}
+          CONTROL_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${CONTROL_DOMAIN}
+          AUTH_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${AUTH_DOMAIN}
+          RUNTIME_BUCKET_${{ needs.prepare.outputs.target_stack_upper }}=${RUNTIME_BUCKET}
+          CLOUDFLARE_ZONE_ID=${CLOUDFLARE_ZONE_ID}
+          MTLS_TRUSTSTORE_KEY=${MTLS_TRUSTSTORE_KEY}
+          EOF
+
+      - name: Audit Cloudflare mTLS
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: ./scripts/check-cloudflare-mtls.sh --env-file .github/mTLS-audit.env --stack ${{ needs.prepare.outputs.target_stack }}

--- a/.github/workflows/rollout-hop.yml
+++ b/.github/workflows/rollout-hop.yml
@@ -187,10 +187,58 @@ jobs:
       ltbase_releases_token: ${{ secrets.LTBASE_RELEASES_TOKEN }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
+  audit_mtls:
+    needs:
+      - prepare
+      - rollout
+    if: ${{ needs.rollout.result == 'success' }}
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets[format('AWS_ROLE_ARN_{0}', needs.prepare.outputs.target_stack_upper)] }}
+          aws-region: ${{ vars[format('AWS_REGION_{0}', needs.prepare.outputs.target_stack_upper)] }}
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Prepare mTLS audit env
+        env:
+          STACKS: ${{ vars.STACKS || 'devo,prod' }}
+          PROMOTION_PATH: ${{ vars.PROMOTION_PATH || vars.STACKS || 'devo,prod' }}
+          AWS_REGION: ${{ vars[format('AWS_REGION_{0}', needs.prepare.outputs.target_stack_upper)] }}
+          API_DOMAIN: ${{ vars[format('API_DOMAIN_{0}', needs.prepare.outputs.target_stack_upper)] }}
+          CONTROL_DOMAIN: ${{ vars[format('CONTROL_DOMAIN_{0}', needs.prepare.outputs.target_stack_upper)] }}
+          AUTH_DOMAIN: ${{ vars[format('AUTH_DOMAIN_{0}', needs.prepare.outputs.target_stack_upper)] }}
+          RUNTIME_BUCKET: ${{ vars[format('RUNTIME_BUCKET_{0}', needs.prepare.outputs.target_stack_upper)] }}
+          CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
+          MTLS_TRUSTSTORE_KEY: mtls/cloudflare-origin-pull-ca.pem
+        run: |
+          cat > .github/mTLS-audit.env <<EOF
+          STACKS=${STACKS}
+          PROMOTION_PATH=${PROMOTION_PATH}
+          AWS_REGION_${{ needs.prepare.outputs.target_stack_upper }}=${AWS_REGION}
+          API_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${API_DOMAIN}
+          CONTROL_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${CONTROL_DOMAIN}
+          AUTH_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${AUTH_DOMAIN}
+          RUNTIME_BUCKET_${{ needs.prepare.outputs.target_stack_upper }}=${RUNTIME_BUCKET}
+          CLOUDFLARE_ZONE_ID=${CLOUDFLARE_ZONE_ID}
+          MTLS_TRUSTSTORE_KEY=${MTLS_TRUSTSTORE_KEY}
+          EOF
+
+      - name: Audit Cloudflare mTLS
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: ./scripts/check-cloudflare-mtls.sh --env-file .github/mTLS-audit.env --stack ${{ needs.prepare.outputs.target_stack }}
+
   dispatch_next:
     needs:
       - prepare
       - rollout
+      - audit_mtls
     if: ${{ needs.rollout.result == 'success' && needs.prepare.outputs.continue_chain == 'true' && needs.prepare.outputs.next_stack != '' }}
     runs-on: ubuntu-24.04-arm
     steps:

--- a/docs/onboarding/08-day-2-operations.md
+++ b/docs/onboarding/08-day-2-operations.md
@@ -10,6 +10,20 @@ Use this guide for normal follow-up operations after the first successful deploy
 
 ## Typical Operations
 
+### Audit Cloudflare mTLS wiring
+
+Run `./scripts/check-cloudflare-mtls.sh --env-file .env --stack <stack>` from the deployment repository when you need a read-only audit of the Cloudflare to API Gateway mTLS path.
+
+The preview workflow and the rollout hop workflow both run this audit automatically after a successful job and fail if the Cloudflare or API Gateway mTLS posture drifts.
+
+The script checks:
+
+- Cloudflare proxying for `api`, `auth`, and `control-plane`
+- Cloudflare SSL mode is `Full (strict)`
+- Cloudflare Authenticated Origin Pulls is enabled
+- the truststore object exists in the stack runtime bucket
+- each API Gateway custom domain reports mutual TLS with the expected truststore URI and version
+
 ### Upgrade to a new LTBase release
 
 1. If you want the latest template copy of the sync helper itself first, run `./scripts/update-sync-template-tooling.sh` from your deployment repository on a clean local `main` branch.

--- a/scripts/check-cloudflare-mtls.sh
+++ b/scripts/check-cloudflare-mtls.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ENV_FILE=""
+STACK="devo"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env-file)
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --stack)
+      STACK="$2"
+      shift 2
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${ENV_FILE}" ]]; then
+  printf '--env-file is required\n' >&2
+  exit 1
+fi
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+source "${script_dir}/lib/bootstrap-env.sh"
+bootstrap_env_load "${ENV_FILE}"
+
+if [[ -n "${CLOUDFLARE_API_TOKEN:-}" ]]; then
+  export CLOUDFLARE_API_TOKEN
+fi
+
+if ! bootstrap_env_has_stack "${STACK}"; then
+  printf 'unknown stack: %s\n' "${STACK}" >&2
+  exit 1
+fi
+
+bootstrap_env_require_vars CLOUDFLARE_ZONE_ID CLOUDFLARE_API_TOKEN MTLS_TRUSTSTORE_KEY || exit 1
+bootstrap_env_require_stack_values "${STACK}" AWS_REGION API_DOMAIN CONTROL_DOMAIN AUTH_DOMAIN RUNTIME_BUCKET || exit 1
+
+selected_api_domain="$(bootstrap_env_resolve_stack_value API_DOMAIN "${STACK}")"
+selected_control_domain="$(bootstrap_env_resolve_stack_value CONTROL_DOMAIN "${STACK}")"
+selected_auth_domain="$(bootstrap_env_resolve_stack_value AUTH_DOMAIN "${STACK}")"
+selected_runtime_bucket="$(bootstrap_env_resolve_stack_value RUNTIME_BUCKET "${STACK}")"
+expected_truststore_uri="s3://${selected_runtime_bucket}/${MTLS_TRUSTSTORE_KEY}"
+
+cloudflare_headers=(
+  -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}"
+  -H "Content-Type: application/json"
+)
+
+overall_status=0
+
+pass() {
+  printf 'PASS %s\n' "$1"
+}
+
+info() {
+  printf 'INFO %s\n' "$1"
+}
+
+fail_check() {
+  printf 'FAIL %s\n' "$1"
+  overall_status=1
+}
+
+cloudflare_get_json() {
+  local url="$1"
+  local action="$2"
+  local response_file status response success
+
+  response_file="$(mktemp)"
+  if ! status="$(curl -sS -o "${response_file}" -w '%{http_code}' "${cloudflare_headers[@]}" "${url}")"; then
+    rm -f "${response_file}"
+    printf 'Cloudflare API request failed: %s\n' "${action}" >&2
+    return 1
+  fi
+
+  response="$(<"${response_file}")"
+  rm -f "${response_file}"
+
+  if [[ "${status}" != "200" ]]; then
+    printf 'Cloudflare API request failed: %s (HTTP %s)\n' "${action}" "${status}" >&2
+    printf '%s\n' "${response}" >&2
+    return 1
+  fi
+
+  success="$(printf '%s' "${response}" | jq -r '.success // false')"
+  if [[ "${success}" != "true" ]]; then
+    printf 'Cloudflare API request failed: %s\n' "${action}" >&2
+    printf '%s\n' "${response}" >&2
+    return 1
+  fi
+
+  printf '%s' "${response}"
+}
+
+check_cloudflare_record() {
+  local domain="$1"
+  local response proxied content
+
+  response="$(cloudflare_get_json "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/dns_records?type=CNAME&name=${domain}" "get DNS record ${domain}")" || {
+    fail_check "Cloudflare DNS ${domain} lookup"
+    return
+  }
+
+  proxied="$(printf '%s' "${response}" | jq -r '.result[0].proxied // "missing"')"
+  content="$(printf '%s' "${response}" | jq -r '.result[0].content // "missing"')"
+
+  if [[ "${proxied}" == "true" ]]; then
+    pass "Cloudflare DNS ${domain} is proxied"
+  else
+    fail_check "Cloudflare DNS ${domain} is proxied"
+  fi
+
+  info "Cloudflare DNS ${domain} target: ${content}"
+}
+
+check_cloudflare_ssl_mode() {
+  local response value
+
+  response="$(cloudflare_get_json "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/settings/ssl" "get SSL mode")" || {
+    fail_check "Cloudflare SSL mode is Full (strict): lookup failed"
+    return
+  }
+  value="$(printf '%s' "${response}" | jq -r '.result.value // "missing"')"
+
+  if [[ "${value}" == "strict" ]]; then
+    pass "Cloudflare SSL mode is Full (strict)"
+  else
+    fail_check "Cloudflare SSL mode is Full (strict): got ${value}"
+  fi
+}
+
+check_cloudflare_aop() {
+  local response value cert_response enabled_count
+
+  response="$(cloudflare_get_json "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/settings/tls_client_auth" "get Authenticated Origin Pulls setting")" || {
+    fail_check "Cloudflare Authenticated Origin Pulls is enabled: lookup failed"
+    return
+  }
+  value="$(printf '%s' "${response}" | jq -r '.result.value // "missing"')"
+
+  if [[ "${value}" == "on" ]]; then
+    pass "Cloudflare Authenticated Origin Pulls is enabled"
+  else
+    fail_check "Cloudflare Authenticated Origin Pulls is enabled: got ${value}"
+  fi
+
+  cert_response="$(cloudflare_get_json "https://api.cloudflare.com/client/v4/zones/${CLOUDFLARE_ZONE_ID}/origin_tls_client_auth" "get zone-level AOP certificates")" || {
+    fail_check "Cloudflare zone-level AOP certificates lookup"
+    return
+  }
+  enabled_count="$(printf '%s' "${cert_response}" | jq '[.result[] | select(.enabled == true)] | length')"
+  info "Cloudflare zone-level AOP certificates: ${enabled_count} active uploaded certificates"
+}
+
+check_s3_truststore() {
+  if bootstrap_env_aws_command_for_stack "${STACK}" s3api head-object --bucket "${selected_runtime_bucket}" --key "${MTLS_TRUSTSTORE_KEY}" >/dev/null 2>&1; then
+    pass "AWS truststore object exists: ${expected_truststore_uri}"
+  else
+    fail_check "AWS truststore object exists: ${expected_truststore_uri}"
+  fi
+}
+
+check_apigw_domain() {
+  local domain="$1"
+  local response truststore_uri truststore_version status
+
+  if ! response="$(bootstrap_env_aws_command_for_stack "${STACK}" apigatewayv2 get-domain-name --domain-name "${domain}" --output json)"; then
+    fail_check "API Gateway domain ${domain} lookup"
+    return
+  fi
+
+  truststore_uri="$(printf '%s' "${response}" | jq -r '.MutualTlsAuthentication.TruststoreUri // "missing"')"
+  truststore_version="$(printf '%s' "${response}" | jq -r '.MutualTlsAuthentication.TruststoreVersion // "missing"')"
+  status="$(printf '%s' "${response}" | jq -r '.DomainNameConfigurations[0].DomainNameStatus // "missing"')"
+
+  if [[ "${truststore_uri}" == "${expected_truststore_uri}" ]]; then
+    pass "API Gateway domain ${domain} mutual TLS truststore matches: ${truststore_uri}"
+  else
+    fail_check "API Gateway domain ${domain} mutual TLS truststore matches: got ${truststore_uri}"
+  fi
+
+  if [[ "${truststore_version}" == "missing" || -z "${truststore_version}" ]]; then
+    fail_check "API Gateway domain ${domain} truststore version is present"
+  else
+    pass "API Gateway domain ${domain} truststore version is present: ${truststore_version}"
+  fi
+
+  info "API Gateway domain ${domain} status: ${status}"
+}
+
+check_cloudflare_record "${selected_api_domain}"
+check_cloudflare_record "${selected_auth_domain}"
+check_cloudflare_record "${selected_control_domain}"
+check_cloudflare_ssl_mode
+check_cloudflare_aop
+check_s3_truststore
+check_apigw_domain "${selected_api_domain}"
+check_apigw_domain "${selected_auth_domain}"
+check_apigw_domain "${selected_control_domain}"
+
+exit "${overall_status}"

--- a/test/check-cloudflare-mtls-test.sh
+++ b/test/check-cloudflare-mtls-test.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/scripts/check-cloudflare-mtls.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_log_contains() {
+  local path="$1"
+  local needle="$2"
+  if ! grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+assert_log_not_contains() {
+  local path="$1"
+  local needle="$2"
+  if grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to not contain: ${needle}"
+  fi
+}
+
+write_env() {
+  local path="$1"
+  cat >"${path}" <<'EOF'
+STACKS=devo,prod
+PROMOTION_PATH=devo,prod
+GITHUB_OWNER=customer-org
+DEPLOYMENT_REPO_NAME=customer-ltbase
+AWS_REGION_DEVO=ap-northeast-1
+AWS_REGION_PROD=us-west-2
+AWS_PROFILE_DEVO=devo-profile
+AWS_PROFILE_PROD=prod-profile
+PULUMI_STATE_BUCKET=test-pulumi-state
+PULUMI_KMS_ALIAS=alias/test-pulumi-secrets
+MTLS_TRUSTSTORE_FILE=infra/certs/cloudflare-origin-pull-ca.pem
+MTLS_TRUSTSTORE_KEY=mtls/cloudflare-origin-pull-ca.pem
+API_DOMAIN_DEVO=api.devo.example.com
+API_DOMAIN_PROD=api.example.com
+CONTROL_DOMAIN_DEVO=control.devo.example.com
+CONTROL_DOMAIN_PROD=control.example.com
+AUTH_DOMAIN_DEVO=auth.devo.example.com
+AUTH_DOMAIN_PROD=auth.example.com
+CLOUDFLARE_ZONE_ID=zone-123
+CLOUDFLARE_API_TOKEN=test-cloudflare-token
+RUNTIME_BUCKET_DEVO=customer-ltbase-runtime-devo
+RUNTIME_BUCKET_PROD=customer-ltbase-runtime-prod
+EOF
+}
+
+setup_fake_bin() {
+  local fake_bin="$1"
+  local log_file="$2"
+
+  mkdir -p "${fake_bin}"
+
+  cat >"${fake_bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+response_file=""
+write_format=""
+url=""
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    -o)
+      response_file="${args[$((i + 1))]}"
+      i=$((i + 1))
+      ;;
+    -w)
+      write_format="${args[$((i + 1))]}"
+      i=$((i + 1))
+      ;;
+    http*)
+      url="${args[$i]}"
+      ;;
+  esac
+done
+
+printf 'curl %s\n' "$*" >>"${COMMAND_LOG}"
+
+status="200"
+body='{"success":true,"result":{}}'
+
+case "${url}" in
+  *"/zones/zone-123/settings/ssl")
+    ssl_value="strict"
+    if [[ "${SCENARIO}" == "failure" ]]; then
+      ssl_value="full"
+    fi
+    body="{\"success\":true,\"result\":{\"id\":\"ssl\",\"value\":\"${ssl_value}\"}}"
+    ;;
+  *"/zones/zone-123/settings/tls_client_auth")
+    aop_value="on"
+    if [[ "${SCENARIO}" == "failure" ]]; then
+      aop_value="off"
+    fi
+    body="{\"success\":true,\"result\":{\"id\":\"tls_client_auth\",\"value\":\"${aop_value}\"}}"
+    ;;
+  *"/zones/zone-123/origin_tls_client_auth")
+    result='[]'
+    if [[ "${SCENARIO}" == "custom-cert" ]]; then
+      result='[{"id":"cert-1","enabled":true}]'
+    fi
+    body="{\"success\":true,\"result\":${result}}"
+    ;;
+  *"name=api.example.com"*)
+    body='{"success":true,"result":[{"name":"api.example.com","proxied":true,"content":"d-api.execute-api.us-west-2.amazonaws.com"}]}'
+    ;;
+  *"name=auth.example.com"*)
+    proxied='true'
+    if [[ "${SCENARIO}" == "failure" ]]; then
+      proxied='false'
+    fi
+    body="{\"success\":true,\"result\":[{\"name\":\"auth.example.com\",\"proxied\":${proxied},\"content\":\"d-auth.execute-api.us-west-2.amazonaws.com\"}]}"
+    ;;
+  *"name=control.example.com"*)
+    body='{"success":true,"result":[{"name":"control.example.com","proxied":true,"content":"d-control.execute-api.us-west-2.amazonaws.com"}]}'
+    ;;
+  *)
+    status="404"
+    body='{"success":false,"errors":[{"message":"not found"}]}'
+    ;;
+esac
+
+printf '%s' "${body}" >"${response_file}"
+if [[ -n "${write_format}" ]]; then
+  printf '%s' "${status}"
+fi
+exit 0
+EOF
+  chmod +x "${fake_bin}/curl"
+
+  cat >"${fake_bin}/aws" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'aws %s\n' "$*" >>"${COMMAND_LOG}"
+
+filtered=()
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  case "${args[$i]}" in
+    --profile|--region|--output|--query|--color|--cli-binary-format)
+      i=$((i + 1))
+      ;;
+    --no-cli-pager)
+      ;;
+    *)
+      filtered+=("${args[$i]}")
+      ;;
+  esac
+done
+
+if [[ "${filtered[0]:-}" == "s3api" && "${filtered[1]:-}" == "head-object" ]]; then
+  if [[ "${SCENARIO}" == "failure" ]]; then
+    printf 'An error occurred (404) when calling the HeadObject operation: Not Found\n' >&2
+    exit 254
+  fi
+  printf '{"VersionId":"truststore-version-123"}\n'
+  exit 0
+fi
+
+if [[ "${filtered[0]:-}" == "apigatewayv2" && "${filtered[1]:-}" == "get-domain-name" ]]; then
+  domain=""
+  for ((i = 0; i < ${#filtered[@]}; i++)); do
+    if [[ "${filtered[$i]}" == "--domain-name" ]]; then
+      domain="${filtered[$((i + 1))]}"
+      break
+    fi
+  done
+  truststore_uri='s3://customer-ltbase-runtime-prod/mtls/cloudflare-origin-pull-ca.pem'
+  if [[ "${SCENARIO}" == "failure" && "${domain}" == "control.example.com" ]]; then
+    truststore_uri='s3://customer-ltbase-runtime-prod/mtls/unexpected.pem'
+  fi
+  cat <<JSON
+{"DomainName":"${domain}","DomainNameConfigurations":[{"ApiGatewayDomainName":"regional-${domain}","DomainNameStatus":"AVAILABLE"}],"MutualTlsAuthentication":{"TruststoreUri":"${truststore_uri}","TruststoreVersion":"truststore-version-123"}}
+JSON
+  exit 0
+fi
+
+printf 'unexpected aws invocation: %s\n' "$*" >&2
+exit 1
+EOF
+  chmod +x "${fake_bin}/aws"
+}
+
+temp_dir="$(mktemp -d)"
+fake_bin="${temp_dir}/bin"
+log_file="${temp_dir}/commands.log"
+env_file="${temp_dir}/.env"
+touch "${log_file}"
+write_env "${env_file}"
+setup_fake_bin "${fake_bin}" "${log_file}"
+
+if output="$(PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" SCENARIO=success "${SCRIPT_PATH}" --env-file "${env_file}" --stack prod 2>&1)"; then
+  :
+else
+  rm -rf "${temp_dir}"
+  fail "expected success scenario to pass, got: ${output}"
+fi
+
+assert_log_contains <(printf '%s' "${output}") "PASS Cloudflare DNS api.example.com is proxied"
+assert_log_contains <(printf '%s' "${output}") "PASS Cloudflare SSL mode is Full (strict)"
+assert_log_contains <(printf '%s' "${output}") "PASS Cloudflare Authenticated Origin Pulls is enabled"
+assert_log_contains <(printf '%s' "${output}") "INFO Cloudflare zone-level AOP certificates: 0 active uploaded certificates"
+assert_log_contains <(printf '%s' "${output}") "PASS AWS truststore object exists: s3://customer-ltbase-runtime-prod/mtls/cloudflare-origin-pull-ca.pem"
+assert_log_contains <(printf '%s' "${output}") "PASS API Gateway domain api.example.com mutual TLS truststore matches: s3://customer-ltbase-runtime-prod/mtls/cloudflare-origin-pull-ca.pem"
+assert_log_not_contains <(printf '%s' "${output}") "FAIL"
+
+if output="$(PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" SCENARIO=failure "${SCRIPT_PATH}" --env-file "${env_file}" --stack prod 2>&1)"; then
+  rm -rf "${temp_dir}"
+  fail "expected failure scenario to exit non-zero"
+fi
+
+assert_log_contains <(printf '%s' "${output}") "FAIL Cloudflare DNS auth.example.com is proxied"
+assert_log_contains <(printf '%s' "${output}") "FAIL Cloudflare SSL mode is Full (strict): got full"
+assert_log_contains <(printf '%s' "${output}") "FAIL Cloudflare Authenticated Origin Pulls is enabled: got off"
+assert_log_contains <(printf '%s' "${output}") "FAIL AWS truststore object exists: s3://customer-ltbase-runtime-prod/mtls/cloudflare-origin-pull-ca.pem"
+assert_log_contains <(printf '%s' "${output}") "FAIL API Gateway domain control.example.com mutual TLS truststore matches: got s3://customer-ltbase-runtime-prod/mtls/unexpected.pem"
+
+rm -rf "${temp_dir}"
+printf 'PASS: check-cloudflare-mtls tests\n'

--- a/test/rollout-workflows-test.sh
+++ b/test/rollout-workflows-test.sh
@@ -41,6 +41,9 @@ assert_file_contains "${preview_workflow}" "target_stack:"
 assert_file_contains "${preview_workflow}" "manual preview only supports the first promotion stack"
 assert_file_contains "${preview_workflow}" "runs-on: ubuntu-24.04-arm"
 assert_file_contains "${preview_workflow}" "Lychee-Technology/ltbase-deploy-workflows/.github/workflows/preview-stack.yml@main"
+assert_file_contains "${preview_workflow}" "name: Audit Cloudflare mTLS"
+assert_file_contains "${preview_workflow}" "./scripts/check-cloudflare-mtls.sh --env-file .github/mTLS-audit.env --stack"
+assert_file_contains "${preview_workflow}" 'CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}'
 assert_file_contains "${rollout_hop_workflow}" "Lychee-Technology/ltbase-deploy-workflows/.github/workflows/rollout-hop.yml@main"
 
 assert_file_contains "${deploy_workflow}" "uses: ./.github/workflows/rollout-hop.yml"
@@ -64,6 +67,10 @@ assert_file_contains "${rollout_hop_workflow}" "runs-on: ubuntu-24.04-arm"
 assert_file_contains "${rollout_hop_workflow}" "invalid promotion hop"
 assert_file_contains "${rollout_hop_workflow}" 'environment: ${{ needs.prepare.outputs.target_stack }}'
 assert_file_contains "${rollout_hop_workflow}" 'gh api repos/${{ github.repository }}/actions/workflows/rollout-hop.yml/dispatches'
+assert_file_contains "${rollout_hop_workflow}" "name: Audit Cloudflare mTLS"
+assert_file_contains "${rollout_hop_workflow}" "./scripts/check-cloudflare-mtls.sh --env-file .github/mTLS-audit.env --stack"
+assert_file_contains "${rollout_hop_workflow}" 'CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}'
+assert_file_contains "${rollout_hop_workflow}" "MTLS_TRUSTSTORE_KEY: mtls/cloudflare-origin-pull-ca.pem"
 assert_file_not_contains "${rollout_hop_workflow}" "pulumi_stack: devo"
 assert_file_not_contains "${rollout_hop_workflow}" "pulumi_stack: prod"
 


### PR DESCRIPTION
## Summary
- add a reusable `scripts/check-cloudflare-mtls.sh` audit with shell regression coverage for Cloudflare proxy, SSL mode, Authenticated Origin Pulls, S3 truststore, and API Gateway custom domain mTLS wiring
- run the mTLS audit automatically after successful preview and rollout-hop workflow runs so drift blocks promotion before the next hop
- document the manual audit command and the new workflow guardrail in day-2 operations docs

## Testing
- bash test/check-cloudflare-mtls-test.sh
- bash test/rollout-workflows-test.sh
- bash test/bootstrap-deployment-repo-test.sh