### PR TITLE
fix: preserve customer auth provider configs during sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .env
 .env.*
+infra/auth-providers.*.json
+!infra/auth-providers.*.json.example
 .worktrees/
 dist/
 infra/.pulumi/

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ For day-2 maintenance, the generated deployment repository can sync later templa
 
 Use `./scripts/update-sync-template-tooling.sh` first when you want the latest sync helper and its regression test from the template. Then run `./scripts/sync-template-upstream.sh` to sync template-managed files. The template sync preserves local `.env` files, `infra/Pulumi.*.yaml`, customer-owned `infra/auth-providers.*.json`, and the sync helper's own script/test files.
 
+This template repository only tracks `infra/auth-providers.*.json.example`. A generated customer deployment repository should create and maintain the real `infra/auth-providers.<stack>.json` files itself, and may commit those customer-specific files in that generated repository.
+
 ## Deployment Principles
 
 - the deployment repository downloads official LTBase releases instead of building the application source code

--- a/README.zh.md
+++ b/README.zh.md
@@ -91,6 +91,8 @@ onboarding 文档支持通用多 stack 拓扑。文中出现 `devo`、`prod` 等
 
 当你希望先拿到模板中的最新同步工具和对应回归测试时，先运行 `./scripts/update-sync-template-tooling.sh`，再运行 `./scripts/sync-template-upstream.sh` 同步模板管理的文件。模板同步会保留本地 `.env`、`infra/Pulumi.*.yaml`、由 deployment repo 自行维护的 `infra/auth-providers.*.json`，以及同步工具自己的脚本与测试文件。
 
+此模板仓库只跟踪 `infra/auth-providers.*.json.example`。从模板生成出来的客户 deployment repo 需要自行创建并维护真实的 `infra/auth-providers.<stack>.json` 文件，并且可以在该客户仓库中提交这些客户专属文件。
+
 ## 部署原则
 
 - 部署仓库负责下载官方 LTBase release，而不是自行构建应用源码

--- a/docs/onboarding/04-prepare-env-file.md
+++ b/docs/onboarding/04-prepare-env-file.md
@@ -61,6 +61,7 @@ Use this guide to create the local `.env` file that drives the bootstrap scripts
     - `CLOUDFLARE_ZONE_ID`
     - Source: your final DNS plan in the target Cloudflare zone
     - For `AUTH_PROVIDER_CONFIG_FILE_<STACK>`, point to a checked-in JSON file that lists the external JWT providers enabled for that stack.
+    - Start by copying `infra/auth-providers.<stack>.json.example` to `infra/auth-providers.<stack>.json`, then edit the real file in the generated customer deployment repository.
 10. Fill in application defaults:
     - `GEMINI_MODEL`
     - `DSQL_PORT`, `DSQL_DB`, `DSQL_USER`, `DSQL_PROJECT_SCHEMA`
@@ -133,6 +134,7 @@ Only fill these when the defaults are wrong for your customer environment:
 
 - do not commit `.env`
 - do not put production secrets into tracked files
+- the template repository only ships `infra/auth-providers.*.json.example`; keep the real `infra/auth-providers.<stack>.json` files in the generated customer deployment repository
 - treat `PULUMI_BACKEND_URL` and `PULUMI_SECRETS_PROVIDER_*` as generated values if you rely on bootstrap to create backend resources
 - only fill values you actually control; generated values should come from bootstrap outputs
 - do not set `DSQL_ENDPOINT` manually for managed deployments; bootstrap and later reconciliation publish the authoritative value

--- a/docs/onboarding/04-prepare-env-file.zh.md
+++ b/docs/onboarding/04-prepare-env-file.zh.md
@@ -61,6 +61,7 @@
     - `CLOUDFLARE_ZONE_ID`
     - 来源：你在目标 Cloudflare zone 中规划好的最终域名
     - `AUTH_PROVIDER_CONFIG_FILE_<STACK>` 应该指向一个已提交的 JSON 文件，该文件列出该 stack 启用的外部 JWT provider。
+    - 先把 `infra/auth-providers.<stack>.json.example` 复制成 `infra/auth-providers.<stack>.json`，再在生成出来的客户 deployment repo 中编辑这个真实文件。
 10. 填写应用默认值：
     - `GEMINI_MODEL`
     - `DSQL_PORT`、`DSQL_DB`、`DSQL_USER`、`DSQL_PROJECT_SCHEMA`
@@ -133,6 +134,7 @@
 
 - 不要提交 `.env`
 - 不要把生产 secrets 写进被版本控制的文件
+- 模板仓库只提供 `infra/auth-providers.*.json.example`；真实的 `infra/auth-providers.<stack>.json` 文件应保留在生成出来的客户 deployment repo 中维护
 - 如果你依赖 bootstrap 创建 backend 资源，请把 `PULUMI_BACKEND_URL` 和 `PULUMI_SECRETS_PROVIDER_*` 当作生成值
 - 只填写你真正控制的输入项，生成值应来自 bootstrap 输出
 - 对于 managed 部署，不要手动设置 `DSQL_ENDPOINT`；bootstrap 和后续 reconcile 会发布权威值

--- a/docs/onboarding/08-day-2-operations.md
+++ b/docs/onboarding/08-day-2-operations.md
@@ -29,12 +29,13 @@ The script checks:
 1. If you want the latest template copy of the sync helper itself first, run `./scripts/update-sync-template-tooling.sh` from your deployment repository on a clean local `main` branch.
 2. If you want to bring in newer template-managed files, run `./scripts/sync-template-upstream.sh` from the same clean local `main` branch.
 3. Review the synced template changes. The sync preserves local `.env` files, `infra/Pulumi.*.yaml`, customer-owned `infra/auth-providers.*.json`, and the sync helper's own script/test files.
-4. Update `LTBASE_RELEASE_ID` in GitHub variables, or pass a new `release_id` directly to the workflow.
-5. Run the preview workflow.
-6. Review the Pulumi preview output.
-7. Trigger `rollout.yml` once for the new release.
-8. Validate each deployed stack before approving the next protected target environment.
-9. Approve each protected hop in order until the promotion path completes.
+4. If the generated deployment repository does not yet have a real auth provider config file for a stack, copy the matching `infra/auth-providers.<stack>.json.example` file to `infra/auth-providers.<stack>.json` in that generated repository before the next bootstrap or preview run.
+5. Update `LTBASE_RELEASE_ID` in GitHub variables, or pass a new `release_id` directly to the workflow.
+6. Run the preview workflow.
+7. Review the Pulumi preview output.
+8. Trigger `rollout.yml` once for the new release.
+9. Validate each deployed stack before approving the next protected target environment.
+10. Approve each protected hop in order until the promotion path completes.
 
 ### Re-run preview before changes
 

--- a/docs/onboarding/08-day-2-operations.zh.md
+++ b/docs/onboarding/08-day-2-operations.zh.md
@@ -15,12 +15,13 @@
 1. 如果你想先拿到模板中的最新同步工具本身，请在部署仓库干净的本地 `main` 分支上运行 `./scripts/update-sync-template-tooling.sh`。
 2. 如果你还想同步较新的模板管理文件，再在同一个干净的本地 `main` 分支上运行 `./scripts/sync-template-upstream.sh`。
 3. 审查同步进来的模板变更。模板同步会保留本地 `.env`、`infra/Pulumi.*.yaml`、由 deployment repo 自行维护的 `infra/auth-providers.*.json`，以及同步工具自己的脚本与测试文件。
-4. 更新 GitHub variables 中的 `LTBASE_RELEASE_ID`，或在工作流中直接传入新的 `release_id`。
-5. 运行 preview 工作流。
-6. 审查 Pulumi preview 输出。
-7. 针对新 release 触发一次 `rollout.yml`。
-8. 在审批下一个受保护目标环境前，验证当前已部署 stack。
-9. 按顺序审批每一跳，直到 promotion path 完成。
+4. 如果生成出来的 deployment repo 某个 stack 还没有真实的 auth provider 配置文件，请先把对应的 `infra/auth-providers.<stack>.json.example` 复制成 `infra/auth-providers.<stack>.json`，再进行下一次 bootstrap 或 preview。
+5. 更新 GitHub variables 中的 `LTBASE_RELEASE_ID`，或在工作流中直接传入新的 `release_id`。
+6. 运行 preview 工作流。
+7. 审查 Pulumi preview 输出。
+8. 针对新 release 触发一次 `rollout.yml`。
+9. 在审批下一个受保护目标环境前，验证当前已部署 stack。
+10. 按顺序审批每一跳，直到 promotion path 完成。
 
 ### 在变更前重新执行 preview
 

--- a/scripts/sync-template-upstream.sh
+++ b/scripts/sync-template-upstream.sh
@@ -50,6 +50,35 @@ UPSTREAM_URL="https://github.com/Lychee-Technology/ltbase-private-deployment.git
 BRANCH="main"
 ARCHIVE_PATH="sync-template-upstream.tar"
 
+customer_owned_paths=(
+  "infra/auth-providers.devo.json"
+  "infra/auth-providers.prod.json"
+)
+
+preserve_customer_owned_files() {
+  local backup_root="$1"
+  local path
+
+  for path in "${customer_owned_paths[@]}"; do
+    if [[ -f "./${path}" ]]; then
+      mkdir -p "${backup_root}/$(dirname "${path}")"
+      cp "./${path}" "${backup_root}/${path}"
+    fi
+  done
+}
+
+restore_customer_owned_files() {
+  local backup_root="$1"
+  local path
+
+  for path in "${customer_owned_paths[@]}"; do
+    if [[ -f "${backup_root}/${path}" ]]; then
+      mkdir -p "./$(dirname "${path}")"
+      cp "${backup_root}/${path}" "./${path}"
+    fi
+  done
+}
+
 build_fingerprint() {
   local root="$1"
   local paths paths_file hash_output status
@@ -150,6 +179,7 @@ capture_stdout_quiet upstream_commit git rev-parse "${UPSTREAM_NAME}/${BRANCH}"
 
 temp_root="$(mktemp -d)"
 trap 'rm -rf "${temp_root}" "${ARCHIVE_PATH}"' EXIT
+customer_owned_backup_root="${temp_root}/customer-owned"
 
 sync_template_run_quiet git archive --format=tar --output "${ARCHIVE_PATH}" "${UPSTREAM_NAME}/${BRANCH}"
 mkdir -p "${temp_root}"
@@ -176,6 +206,8 @@ capture_stdout_quiet provenance_json jq -n \
   '{template_repository:$template_repository,template_ref:$template_ref,template_commit:$template_commit,build_fingerprint:$build_fingerprint,generated_at:$generated_at,generator:$generator}'
 printf '%s\n' "${provenance_json}" > "${temp_root}/__ref__/template-provenance.json"
 
+preserve_customer_owned_files "${customer_owned_backup_root}"
+
 sync_template_info "syncing template-managed files"
 sync_template_run_quiet rsync -a --delete \
   --exclude '.git/' \
@@ -184,9 +216,9 @@ sync_template_run_quiet rsync -a --delete \
   --exclude '.env' \
   --exclude '.env.*' \
   --exclude 'infra/Pulumi.*.yaml' \
-  --exclude 'infra/auth-providers.*.json' \
   --exclude 'scripts/sync-template-upstream.sh' \
   --exclude 'test/sync-template-upstream-test.sh' \
   "${temp_root}/" "./"
+restore_customer_owned_files "${customer_owned_backup_root}"
 
 printf 'synced %s/%s into %s\n' "${UPSTREAM_NAME}" "${BRANCH}" "${BRANCH}"

--- a/test/sync-template-upstream-test.sh
+++ b/test/sync-template-upstream-test.sh
@@ -217,7 +217,7 @@ EOF
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'cp %s\n' "$*" >>"${COMMAND_LOG}"
-exit 0
+/bin/cp "$@"
 EOF
   chmod +x "${fake_bin}/cp"
 
@@ -276,7 +276,7 @@ run_success_case() {
   assert_log_contains "${log_file}" "find ${temp_dir}/upstream-checkout/infra -type f"
   assert_log_contains "${log_file}" "shasum -a 256"
   assert_log_contains "${log_file}" "jq -n"
-  assert_log_contains "${log_file}" "rsync -a --delete --exclude .git/ --exclude dist/ --exclude .DS_Store --exclude .env --exclude .env.* --exclude infra/Pulumi.*.yaml --exclude infra/auth-providers.*.json --exclude scripts/sync-template-upstream.sh --exclude test/sync-template-upstream-test.sh ${temp_dir}/upstream-checkout/ ./"
+  assert_log_contains "${log_file}" "rsync -a --delete --exclude .git/ --exclude dist/ --exclude .DS_Store --exclude .env --exclude .env.* --exclude infra/Pulumi.*.yaml --exclude scripts/sync-template-upstream.sh --exclude test/sync-template-upstream-test.sh ${temp_dir}/upstream-checkout/ ./"
   assert_log_not_contains "${log_file}" "git merge --no-edit upstream/main"
 
   if [[ ! -f "${ROOT_DIR}/__ref__/template-provenance.json" ]]; then
@@ -352,6 +352,45 @@ run_empty_find_case() {
   assert_text_not_contains "${output}" "find failed"
 }
 
+run_preserves_customer_auth_provider_case() {
+  local fake_bin="$1"
+  local auth_provider_path="${ROOT_DIR}/infra/auth-providers.prod.json"
+  local original_content='{"providers":[{"name":"customer"}]}'
+
+  setup_fake_git "${fake_bin}"
+  mkdir -p "${ROOT_DIR}/infra"
+  printf '%s\n' "${original_content}" >"${auth_provider_path}"
+
+  if ! output="$(PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" TEMP_ROOT="${temp_dir}" "${SCRIPT_PATH}" 2>&1)"; then
+    rm -f "${auth_provider_path}"
+    fail "expected script to preserve customer auth provider file, got: ${output}"
+  fi
+
+  assert_text_contains "${output}" "synced upstream/main into main"
+  assert_log_contains "${auth_provider_path}" "${original_content}"
+  assert_log_contains "${log_file}" "cp ./infra/auth-providers.prod.json ${temp_dir}/upstream-checkout/customer-owned/infra/auth-providers.prod.json"
+  assert_log_contains "${log_file}" "cp ${temp_dir}/upstream-checkout/customer-owned/infra/auth-providers.prod.json ./infra/auth-providers.prod.json"
+  rm -f "${auth_provider_path}"
+}
+
+run_missing_customer_auth_provider_case() {
+  local fake_bin="$1"
+  local auth_provider_path="${ROOT_DIR}/infra/auth-providers.prod.json"
+
+  setup_fake_git "${fake_bin}"
+  rm -f "${auth_provider_path}"
+
+  if ! output="$(PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" TEMP_ROOT="${temp_dir}" "${SCRIPT_PATH}" 2>&1)"; then
+    fail "expected script to succeed when customer auth provider file is absent, got: ${output}"
+  fi
+
+  assert_text_contains "${output}" "synced upstream/main into main"
+  if [[ -e "${auth_provider_path}" ]]; then
+    rm -f "${auth_provider_path}"
+    fail "expected sync to leave missing customer auth provider file absent"
+  fi
+}
+
 run_without_bootstrap_env_case() {
   local fake_bin="$1"
   local backup_path="${ROOT_DIR}/scripts/lib/bootstrap-env.sh.test-backup"
@@ -382,6 +421,8 @@ upstream_commit_failure_bin="${temp_dir}/upstream-commit-failure-bin"
 find_failure_bin="${temp_dir}/find-failure-bin"
 empty_find_bin="${temp_dir}/empty-find-bin"
 self_contained_bin="${temp_dir}/self-contained-bin"
+preserve_auth_provider_bin="${temp_dir}/preserve-auth-provider-bin"
+missing_auth_provider_bin="${temp_dir}/missing-auth-provider-bin"
 
 run_success_case "${success_bin}" "${log_file}"
 run_dirty_tree_case "${dirty_bin}"
@@ -390,5 +431,7 @@ run_upstream_commit_failure_case "${upstream_commit_failure_bin}"
 run_find_failure_case "${find_failure_bin}"
 run_empty_find_case "${empty_find_bin}"
 run_without_bootstrap_env_case "${self_contained_bin}"
+run_preserves_customer_auth_provider_case "${preserve_auth_provider_bin}"
+run_missing_customer_auth_provider_case "${missing_auth_provider_bin}"
 
 printf 'PASS: sync-template-upstream tests\n'


### PR DESCRIPTION
## Summary
- preserve customer-owned `infra/auth-providers.*.json` files by backing them up before template sync and restoring them afterward instead of relying on rsync exclude behavior
- add regression coverage for both present and missing customer auth provider config files during `sync-template-upstream.sh`
- document that the template only ships `*.example` auth provider config files while generated customer deployment repos own the real JSON files

## Testing
- bash test/sync-template-upstream-test.sh