### PR TITLE
fix: fail early on Pulumi config drift

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -48,8 +48,19 @@ jobs:
             echo "target_stack_upper=$(printf '%s' "${target_stack}" | tr '[:lower:]-' '[:upper:]_')"
           } >> "${GITHUB_OUTPUT}"
 
-  preview:
+  validate_config:
     needs: prepare
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate Pulumi stack config
+        run: ./scripts/check-pulumi-stack-config.sh --stack ${{ needs.prepare.outputs.target_stack }}
+
+  preview:
+    needs:
+      - prepare
+      - validate_config
     uses: Lychee-Technology/ltbase-deploy-workflows/.github/workflows/preview-stack.yml@main
     with:
       pulumi_stack: ${{ needs.prepare.outputs.target_stack }}

--- a/.github/workflows/rollout-hop.yml
+++ b/.github/workflows/rollout-hop.yml
@@ -158,8 +158,19 @@ jobs:
             echo "run_canary=${run_canary}"
           } >> "${GITHUB_OUTPUT}"
 
-  approve:
+  validate_config:
     needs: prepare
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate Pulumi stack config
+        run: ./scripts/check-pulumi-stack-config.sh --stack ${{ needs.prepare.outputs.target_stack }}
+
+  approve:
+    needs:
+      - prepare
+      - validate_config
     if: ${{ needs.prepare.outputs.approval_required == 'true' }}
     runs-on: ubuntu-24.04-arm
     environment: ${{ needs.prepare.outputs.target_stack }}
@@ -169,6 +180,7 @@ jobs:
   rollout:
     needs:
       - prepare
+      - validate_config
       - approve
     if: ${{ always() && needs.prepare.result == 'success' && (needs.prepare.outputs.approval_required != 'true' || needs.approve.result == 'success') }}
     uses: Lychee-Technology/ltbase-deploy-workflows/.github/workflows/rollout-hop.yml@main

--- a/docs/onboarding/08-day-2-operations.md
+++ b/docs/onboarding/08-day-2-operations.md
@@ -41,6 +41,17 @@ The script checks:
 
 Use preview whenever you change stack configuration, release selection, or deployment-related values.
 
+### Recover from Pulumi config drift
+
+Preview and deployment workflows now validate that `infra/Pulumi.<stack>.yaml` contains the required `ltbase-infra:*` config keys before invoking the shared deployment workflows.
+
+If a workflow fails with a missing-key error, repair the generated deployment repository by either:
+
+- rerunning `./scripts/bootstrap-deployment-repo.sh --env-file .env --stack <stack>`
+- restoring the missing key in `infra/Pulumi.<stack>.yaml`
+
+This validation is presence-only. It does not modify customer config automatically during preview or deploy.
+
 ### Maintain local bootstrap inputs
 
 Keep `.env` private, current, and outside version control.

--- a/scripts/check-pulumi-stack-config.sh
+++ b/scripts/check-pulumi-stack-config.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+STACK=""
+INFRA_DIR="infra"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stack)
+      STACK="$2"
+      shift 2
+      ;;
+    --infra-dir)
+      INFRA_DIR="$2"
+      shift 2
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${STACK}" ]]; then
+  printf 'stack is required\n' >&2
+  exit 1
+fi
+
+stack_file="${INFRA_DIR}/Pulumi.${STACK}.yaml"
+display_path="infra/Pulumi.${STACK}.yaml"
+
+if [[ ! -f "${stack_file}" ]]; then
+  printf "Missing Pulumi stack file '%s'. Rerun bootstrap-deployment-repo.sh or restore the stack config file.\n" "${display_path}" >&2
+  exit 1
+fi
+
+required_keys=(
+  "ltbase-infra:deploymentAwsAccountId"
+  "ltbase-infra:runtimeBucket"
+  "ltbase-infra:tableName"
+  "ltbase-infra:mtlsTruststoreFile"
+  "ltbase-infra:mtlsTruststoreKey"
+  "ltbase-infra:apiDomain"
+  "ltbase-infra:controlPlaneDomain"
+  "ltbase-infra:authDomain"
+  "ltbase-infra:projectId"
+  "ltbase-infra:authProviderConfigFile"
+  "ltbase-infra:cloudflareZoneId"
+  "ltbase-infra:oidcIssuerUrl"
+  "ltbase-infra:jwksUrl"
+  "ltbase-infra:releaseId"
+  "ltbase-infra:githubOrg"
+  "ltbase-infra:githubRepo"
+  "ltbase-infra:githubOidcProviderArn"
+  "ltbase-infra:geminiApiKey"
+)
+
+for key in "${required_keys[@]}"; do
+  if ! grep -Fq "  ${key}:" "${stack_file}"; then
+    printf "Missing required Pulumi config key '%s' in %s. Rerun bootstrap-deployment-repo.sh or update the stack config file.\n" "${key}" "${display_path}" >&2
+    exit 1
+  fi
+done

--- a/test/check-pulumi-stack-config-test.sh
+++ b/test/check-pulumi-stack-config-test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/scripts/check-pulumi-stack-config.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    fail "expected output to contain: ${needle}"
+  fi
+}
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+mkdir -p "${temp_dir}/infra"
+
+cat >"${temp_dir}/infra/Pulumi.devo.yaml" <<'EOF'
+config:
+  ltbase-infra:deploymentAwsAccountId: "123456789012"
+  ltbase-infra:runtimeBucket: example-runtime
+  ltbase-infra:tableName: example-table
+  ltbase-infra:mtlsTruststoreFile: infra/certs/cloudflare-origin-pull-ca.pem
+  ltbase-infra:mtlsTruststoreKey: mtls/cloudflare-origin-pull-ca.pem
+  ltbase-infra:apiDomain: api.example.com
+  ltbase-infra:controlPlaneDomain: control.example.com
+  ltbase-infra:authDomain: auth.example.com
+  ltbase-infra:projectId: 11111111-1111-4111-8111-111111111111
+  ltbase-infra:authProviderConfigFile: infra/auth-providers.devo.json
+  ltbase-infra:cloudflareZoneId: zone-123
+  ltbase-infra:oidcIssuerUrl: https://issuer.example.com/devo
+  ltbase-infra:jwksUrl: https://issuer.example.com/devo/.well-known/jwks.json
+  ltbase-infra:releaseId: v1.0.0
+  ltbase-infra:githubOrg: Lychee-Technology
+  ltbase-infra:githubRepo: ltbase-private-deployment
+  ltbase-infra:githubOidcProviderArn: arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com
+  ltbase-infra:geminiApiKey:
+    secure: test-secret
+EOF
+
+if ! output="$(${SCRIPT_PATH} --stack devo --infra-dir "${temp_dir}/infra" 2>&1)"; then
+  fail "expected success for complete config, got: ${output}"
+fi
+
+python3 - <<'PY' "${temp_dir}/infra/Pulumi.devo.yaml"
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+path.write_text(path.read_text().replace('  ltbase-infra:deploymentAwsAccountId: "123456789012"\n', ''))
+PY
+
+if output="$(${SCRIPT_PATH} --stack devo --infra-dir "${temp_dir}/infra" 2>&1)"; then
+  fail "expected failure when deploymentAwsAccountId is missing"
+fi
+
+assert_contains "${output}" "Missing required Pulumi config key 'ltbase-infra:deploymentAwsAccountId'"
+assert_contains "${output}" "infra/Pulumi.devo.yaml"
+
+rm -f "${temp_dir}/infra/Pulumi.devo.yaml"
+
+if output="$(${SCRIPT_PATH} --stack devo --infra-dir "${temp_dir}/infra" 2>&1)"; then
+  fail "expected failure when stack file is missing"
+fi
+
+assert_contains "${output}" "Missing Pulumi stack file"
+assert_contains "${output}" "infra/Pulumi.devo.yaml"
+
+printf 'PASS: check Pulumi stack config tests\n'

--- a/test/rollout-workflows-test.sh
+++ b/test/rollout-workflows-test.sh
@@ -41,6 +41,8 @@ assert_file_contains "${preview_workflow}" "target_stack:"
 assert_file_contains "${preview_workflow}" "manual preview only supports the first promotion stack"
 assert_file_contains "${preview_workflow}" "runs-on: ubuntu-24.04-arm"
 assert_file_contains "${preview_workflow}" "Lychee-Technology/ltbase-deploy-workflows/.github/workflows/preview-stack.yml@main"
+assert_file_contains "${preview_workflow}" "name: Validate Pulumi stack config"
+assert_file_contains "${preview_workflow}" "./scripts/check-pulumi-stack-config.sh --stack \${{ needs.prepare.outputs.target_stack }}"
 assert_file_contains "${preview_workflow}" "name: Audit Cloudflare mTLS"
 assert_file_contains "${preview_workflow}" "./scripts/check-cloudflare-mtls.sh --env-file .github/mTLS-audit.env --stack"
 assert_file_contains "${preview_workflow}" 'CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}'
@@ -69,6 +71,8 @@ assert_file_contains "${rollout_hop_workflow}" 'environment: ${{ needs.prepare.o
 assert_file_contains "${rollout_hop_workflow}" 'gh api repos/${{ github.repository }}/actions/workflows/rollout-hop.yml/dispatches'
 assert_file_contains "${rollout_hop_workflow}" "name: Audit Cloudflare mTLS"
 assert_file_contains "${rollout_hop_workflow}" "./scripts/check-cloudflare-mtls.sh --env-file .github/mTLS-audit.env --stack"
+assert_file_contains "${rollout_hop_workflow}" "name: Validate Pulumi stack config"
+assert_file_contains "${rollout_hop_workflow}" "./scripts/check-pulumi-stack-config.sh --stack \${{ needs.prepare.outputs.target_stack }}"
 assert_file_contains "${rollout_hop_workflow}" 'CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}'
 assert_file_contains "${rollout_hop_workflow}" "MTLS_TRUSTSTORE_KEY: mtls/cloudflare-origin-pull-ca.pem"
 assert_file_contains "${rollout_hop_workflow}" "reconcile_managed_dsql_endpoint: true"


### PR DESCRIPTION
## Summary
- add a repo-local Pulumi stack config checker that fails when required `ltbase-infra:*` keys are missing
- gate preview and rollout-hop workflows on that validation before dispatching to shared deploy workflows
- document the recovery path for generated repos with stale or partially bootstrapped stack files

## Test Plan
- [x] bash test/check-pulumi-stack-config-test.sh
- [x] bash test/rollout-workflows-test.sh