### PR TITLE
feat: backport schema bucket rollout contract

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -48,8 +48,24 @@ jobs:
             echo "target_stack_upper=$(printf '%s' "${target_stack}" | tr '[:lower:]-' '[:upper:]_')"
           } >> "${GITHUB_OUTPUT}"
 
-  preview:
+  validate_config:
     needs: prepare
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate Pulumi stack config
+        run: ./scripts/check-pulumi-stack-config.sh --stack ${{ needs.prepare.outputs.target_stack }}
+
+      - name: Validate customer schemas
+        env:
+          SCHEMA_BUCKET: ${{ vars[format('SCHEMA_BUCKET_{0}', needs.prepare.outputs.target_stack_upper)] }}
+        run: ./scripts/publish-schemas.sh --dry-run --schema-bucket ${{ vars[format('SCHEMA_BUCKET_{0}', needs.prepare.outputs.target_stack_upper)] }}
+
+  preview:
+    needs:
+      - prepare
+      - validate_config
     uses: Lychee-Technology/ltbase-deploy-workflows/.github/workflows/preview-stack.yml@main
     with:
       pulumi_stack: ${{ needs.prepare.outputs.target_stack }}

--- a/.github/workflows/rollout-hop.yml
+++ b/.github/workflows/rollout-hop.yml
@@ -158,8 +158,19 @@ jobs:
             echo "run_canary=${run_canary}"
           } >> "${GITHUB_OUTPUT}"
 
-  approve:
+  validate_config:
     needs: prepare
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate Pulumi stack config
+        run: ./scripts/check-pulumi-stack-config.sh --stack ${{ needs.prepare.outputs.target_stack }}
+
+  approve:
+    needs:
+      - prepare
+      - validate_config
     if: ${{ needs.prepare.outputs.approval_required == 'true' }}
     runs-on: ubuntu-24.04-arm
     environment: ${{ needs.prepare.outputs.target_stack }}
@@ -169,6 +180,7 @@ jobs:
   rollout:
     needs:
       - prepare
+      - validate_config
       - approve
     if: ${{ always() && needs.prepare.result == 'success' && (needs.prepare.outputs.approval_required != 'true' || needs.approve.result == 'success') }}
     uses: Lychee-Technology/ltbase-deploy-workflows/.github/workflows/rollout-hop.yml@main
@@ -188,11 +200,136 @@ jobs:
       ltbase_releases_token: ${{ secrets.LTBASE_RELEASES_TOKEN }}
       cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
-  audit_mtls:
+  publish_schemas:
     needs:
       - prepare
       - rollout
     if: ${{ needs.rollout.result == 'success' }}
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets[format('AWS_ROLE_ARN_{0}', needs.prepare.outputs.target_stack_upper)] }}
+          aws-region: ${{ vars[format('AWS_REGION_{0}', needs.prepare.outputs.target_stack_upper)] }}
+
+      - name: Publish customer schemas
+        env:
+          SCHEMA_BUCKET: ${{ vars[format('SCHEMA_BUCKET_{0}', needs.prepare.outputs.target_stack_upper)] }}
+        run: ./scripts/publish-schemas.sh --schema-bucket ${{ vars[format('SCHEMA_BUCKET_{0}', needs.prepare.outputs.target_stack_upper)] }}
+
+  ensure_project:
+    needs:
+      - prepare
+      - rollout
+      - publish_schemas
+    if: ${{ needs.rollout.result == 'success' && needs.publish_schemas.result == 'success' }}
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets[format('AWS_ROLE_ARN_{0}', needs.prepare.outputs.target_stack_upper)] }}
+          aws-region: ${{ vars[format('AWS_REGION_{0}', needs.prepare.outputs.target_stack_upper)] }}
+
+      - name: Validate schema bucket contract
+        env:
+          DEPLOYMENT_OUTPUTS_JSON: ${{ needs.rollout.outputs.deployment_outputs_json }}
+          SCHEMA_BUCKET: ${{ vars[format('SCHEMA_BUCKET_{0}', needs.prepare.outputs.target_stack_upper)] }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+
+          outputs = json.loads(os.environ['DEPLOYMENT_OUTPUTS_JSON'])
+          output_bucket = outputs.get('schemaBucket')
+          expected_bucket = os.environ['SCHEMA_BUCKET']
+          if not output_bucket:
+              raise SystemExit('deployment outputs missing schemaBucket')
+          if output_bucket != expected_bucket:
+              raise SystemExit(f'deployment outputs schemaBucket does not match workflow SCHEMA_BUCKET: {output_bucket} != {expected_bucket}')
+          PY
+
+      - name: Ensure project
+        env:
+          DEPLOYMENT_OUTPUTS_JSON: ${{ needs.rollout.outputs.deployment_outputs_json }}
+        run: |
+          python3 - <<'PY' > "${RUNNER_TEMP}/control-plane-target.json"
+          import json
+          import os
+
+          outputs = json.loads(os.environ['DEPLOYMENT_OUTPUTS_JSON'])
+          target = {
+              'function_name': outputs.get('controlPlaneFunctionName'),
+              'qualifier': outputs.get('controlPlaneAliasName'),
+          }
+          missing = [key for key, value in target.items() if not value]
+          if missing:
+              raise SystemExit(f"deployment outputs missing {', '.join(missing)}")
+          print(json.dumps(target))
+          PY
+
+          function_name="$(python3 - <<'PY' "${RUNNER_TEMP}/control-plane-target.json"
+          import json
+          import sys
+
+          with open(sys.argv[1], 'r', encoding='utf-8') as handle:
+              target = json.load(handle)
+
+          print(target['function_name'])
+          PY
+          )"
+          qualifier="$(python3 - <<'PY' "${RUNNER_TEMP}/control-plane-target.json"
+          import json
+          import sys
+
+          with open(sys.argv[1], 'r', encoding='utf-8') as handle:
+              target = json.load(handle)
+
+          print(target['qualifier'])
+          PY
+          )"
+
+          aws lambda invoke \
+            --function-name "${function_name}" \
+            --qualifier "${qualifier}" \
+            --cli-binary-format raw-in-base64-out \
+            --payload '{"action":"ensure-project"}' \
+            "${RUNNER_TEMP}/ensure-project-response.json" \
+            > "${RUNNER_TEMP}/ensure-project-invoke.json"
+
+          python3 - <<'PY' "${RUNNER_TEMP}/ensure-project-invoke.json" "${RUNNER_TEMP}/ensure-project-response.json"
+          import json
+          import sys
+
+          with open(sys.argv[1], 'r', encoding='utf-8') as handle:
+              invoke = json.load(handle)
+          with open(sys.argv[2], 'r', encoding='utf-8') as handle:
+              response = json.load(handle)
+
+          if invoke.get('FunctionError'):
+              raise SystemExit(f"ensure-project invocation failed: {invoke['FunctionError']}: {response}")
+          if response.get('status') != 'success':
+              raise SystemExit(f"ensure-project returned {response.get('status')}: {response.get('error', response)}")
+
+          print(json.dumps(response))
+          PY
+
+      - name: Advance applied schema pointer
+        env:
+          SCHEMA_BUCKET: ${{ vars[format('SCHEMA_BUCKET_{0}', needs.prepare.outputs.target_stack_upper)] }}
+        run: |
+          aws s3 cp \
+            "s3://${SCHEMA_BUCKET}/schemas/published/manifest.json" \
+            "s3://${SCHEMA_BUCKET}/schemas/applied/manifest.json"
+
+  audit_mtls:
+    needs:
+      - prepare
+      - ensure_project
+    if: ${{ needs.ensure_project.result == 'success' }}
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -238,9 +375,8 @@ jobs:
   dispatch_next:
     needs:
       - prepare
-      - rollout
       - audit_mtls
-    if: ${{ needs.rollout.result == 'success' && needs.prepare.outputs.continue_chain == 'true' && needs.prepare.outputs.next_stack != '' }}
+    if: ${{ needs.ensure_project.result == 'success' && needs.prepare.outputs.continue_chain == 'true' && needs.prepare.outputs.next_stack != '' }}
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Continue rollout chain

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It is not the LTBase application source repository.
 - a Pulumi program wrapper at `infra/scripts/pulumi-wrapper.sh` that uses a prebuilt binary when available and falls back to local source build when it is not
 - example deployment inputs such as `env.template`
 - customer onboarding and bootstrap documentation
+- customer-owned production schema files under `customer-owned/schemas/`
 
 ## Start Here
 
@@ -101,6 +102,8 @@ This template repository only tracks `infra/auth-providers.*.json.example`. A ge
 - only the upstream template repository publishes those prebuilt infra binaries; generated customer deployment repositories consume them only
 - customers own the GitHub repository, AWS account resources, and deployment approvals
 - bootstrap scripts prepare repository state and deployment configuration
+- deployment workflows validate schemas in preview, then publish versioned bundles to each stack's dedicated schema bucket during rollout
+- schema publication and schema application are separate: publishing updates immutable `schemas/releases/<version>/` objects plus the published pointer at `schemas/published/manifest.json`, then an explicit control-plane `ensure-project` call applies that published version into the runtime-consumed `schemas/applied/` pointer
 - the shared Pulumi backend bucket is created once and lives in the AWS account for the first stack in `PROMOTION_PATH`
 - manual preview only targets the first stack in `PROMOTION_PATH`
 - automated rollout continues one hop at a time across `PROMOTION_PATH`, with customer-controlled approvals on protected target environments
@@ -110,6 +113,7 @@ This template repository only tracks `infra/auth-providers.*.json.example`. A ge
 
 - keep local `.env` files private and out of version control
 - use the documentation in `docs/` as the source of truth for customer onboarding
+- keep customer-specific Forma schemas in `customer-owned/schemas/*.json`; deployment workflows publish them to the stack `SCHEMA_BUCKET`
 - keep `infra/.pulumi/bin/ltbase-infra` out of version control; the wrapper can recreate it locally and official workflows may preinstall it temporarily
 - `__ref__/template-provenance.json` records the upstream template commit and `build_fingerprint` that official workflows use when looking up prebuilt infra binaries
 - publishing into `ltbase-private-deployment-binaries` requires a repo secret named `LTBASE_PRIVATE_DEPLOYMENT_BINARIES_TOKEN` in the upstream template repository

--- a/docs/onboarding/04-prepare-env-file.md
+++ b/docs/onboarding/04-prepare-env-file.md
@@ -67,10 +67,14 @@ Use this guide to create the local `.env` file that drives the bootstrap scripts
     - `DSQL_PORT`, `DSQL_DB`, `DSQL_USER`, `DSQL_PROJECT_SCHEMA`
     - Source: LTBase application defaults and any approved customer-specific override
 11. Fill in secret values:
-    - `GEMINI_API_KEY`
-    - `CLOUDFLARE_API_TOKEN`
-    - `LTBASE_RELEASES_TOKEN`
-12. Save the file locally and confirm it is not committed.
+     - `GEMINI_API_KEY`
+     - `CLOUDFLARE_API_TOKEN`
+     - `LTBASE_RELEASES_TOKEN`
+12. Decide whether you will accept the default per-stack schema bucket names or set explicit overrides:
+    - `SCHEMA_BUCKET_<STACK>`
+    - Source: the stack-specific S3 bucket that preview and rollout use for schema validation/publication
+    - Important: preview and rollout now depend on the GitHub repository variable `SCHEMA_BUCKET_<STACK>` for every deployed stack. If you do not want the default `<DEPLOYMENT_REPO_NAME>-schema-<stack>` naming, set the override explicitly in `.env` before bootstrap.
+13. Save the file locally and confirm it is not committed.
 
 ## Values You Normally Fill Manually
 
@@ -82,6 +86,7 @@ These values are customer-controlled inputs and should usually be set explicitly
 - `AWS_REGION_<STACK>`, `AWS_ACCOUNT_ID_<STACK>`, `AWS_ROLE_NAME_<STACK>`
 - `AWS_PROFILE_<STACK>` when multiple stacks use different AWS credentials locally
 - `PULUMI_STATE_BUCKET`, `PULUMI_KMS_ALIAS`
+- `SCHEMA_BUCKET_<STACK>` when you do not want the default `<DEPLOYMENT_REPO_NAME>-schema-<stack>` bucket names used by preview and rollout
 - `LTBASE_RELEASES_REPO`, `LTBASE_RELEASE_ID`
 - `MTLS_TRUSTSTORE_FILE`, `MTLS_TRUSTSTORE_KEY` with the template defaults intact
 - `API_DOMAIN_<STACK>`, `CONTROL_DOMAIN_<STACK>`, `AUTH_DOMAIN_<STACK>`, `PROJECT_ID`, `AUTH_PROVIDER_CONFIG_FILE_<STACK>`, `CLOUDFLARE_ZONE_ID`
@@ -108,7 +113,7 @@ Leave these unset unless you intentionally need an override:
   - default: derived from deployment repository name and target AWS account ID
 - `OIDC_ISSUER_URL_<STACK>`, `JWKS_URL_<STACK>`
   - default: derived from `OIDC_DISCOVERY_DOMAIN`
-- `RUNTIME_BUCKET_<STACK>`, `TABLE_NAME_<STACK>`
+- `RUNTIME_BUCKET_<STACK>`, `SCHEMA_BUCKET_<STACK>`, `TABLE_NAME_<STACK>`
   - default: derived from `DEPLOYMENT_REPO_NAME`
 - `PREVIEW_DEFAULT_STACK`
   - default: first stack in `PROMOTION_PATH`
@@ -127,6 +132,7 @@ Only fill these when the defaults are wrong for your customer environment:
 - `OIDC_ISSUER_URL_<STACK>`
 - `JWKS_URL_<STACK>`
 - `RUNTIME_BUCKET_<STACK>`
+- `SCHEMA_BUCKET_<STACK>`
 - `TABLE_NAME_<STACK>`
 - `OIDC_DISCOVERY_AWS_ROLE_NAME_<STACK>`
 
@@ -140,7 +146,8 @@ Only fill these when the defaults are wrong for your customer environment:
 - do not set `DSQL_ENDPOINT` manually for managed deployments; bootstrap and later reconciliation publish the authoritative value
 - keep `MTLS_TRUSTSTORE_FILE=infra/certs/cloudflare-origin-pull-ca.pem` and `MTLS_TRUSTSTORE_KEY=mtls/cloudflare-origin-pull-ca.pem` unless the LTBase template itself changes; bootstrap requires both values
 - expect `api`, `auth`, and `control-plane` to be reachable only through Cloudflare-proxied custom domains once the mTLS rollout tasks are applied
-- the following variables are auto-derived by `scripts/lib/bootstrap-env.sh` and normally do not need manual filling: `DEPLOYMENT_REPO`, `PULUMI_BACKEND_URL`, `PULUMI_SECRETS_PROVIDER_*`, `AWS_ROLE_ARN_*`, `OIDC_ISSUER_URL_*`, `JWKS_URL_*`, `RUNTIME_BUCKET_*`, `TABLE_NAME_*`, `GITHUB_ORG`, `GITHUB_REPO`, `OIDC_DISCOVERY_TEMPLATE_REPO`, `OIDC_DISCOVERY_REPO_NAME`, `OIDC_DISCOVERY_REPO`, `OIDC_DISCOVERY_PAGES_PROJECT`, `OIDC_DISCOVERY_AWS_ROLE_NAME_*`, `OIDC_DISCOVERY_AWS_ROLE_ARN_*`, `PREVIEW_DEFAULT_STACK`
+- preview and rollout require a valid `SCHEMA_BUCKET_<STACK>` repository variable for each stack; bootstrap writes it from `.env` or the derived default
+- the following variables are auto-derived by `scripts/lib/bootstrap-env.sh` and normally do not need manual filling: `DEPLOYMENT_REPO`, `PULUMI_BACKEND_URL`, `PULUMI_SECRETS_PROVIDER_*`, `AWS_ROLE_ARN_*`, `OIDC_ISSUER_URL_*`, `JWKS_URL_*`, `RUNTIME_BUCKET_*`, `SCHEMA_BUCKET_*`, `TABLE_NAME_*`, `GITHUB_ORG`, `GITHUB_REPO`, `OIDC_DISCOVERY_TEMPLATE_REPO`, `OIDC_DISCOVERY_REPO_NAME`, `OIDC_DISCOVERY_REPO`, `OIDC_DISCOVERY_PAGES_PROJECT`, `OIDC_DISCOVERY_AWS_ROLE_NAME_*`, `OIDC_DISCOVERY_AWS_ROLE_ARN_*`, `PREVIEW_DEFAULT_STACK`
 
 ## Expected Result
 

--- a/docs/onboarding/05-bootstrap-one-click.md
+++ b/docs/onboarding/05-bootstrap-one-click.md
@@ -49,6 +49,7 @@ gh auth status
 3. `.env` contains final customer-controlled values for:
    - repository identity
    - stack/account/region mapping
+   - schema bucket overrides when you do not want the default `SCHEMA_BUCKET_<STACK>=<DEPLOYMENT_REPO_NAME>-schema-<stack>` naming
    - domains
    - Cloudflare IDs and token
    - release ID and releases token
@@ -108,6 +109,7 @@ If you also want bootstrap to trigger the first rollout automatically, include t
 6. Wait for the script to complete.
 7. Review generated files in `dist/`, especially the recovery report and any rendered policy artifacts.
 8. Confirm GitHub variables and secrets were created in the deployment repository.
+   - for schema publication, confirm each stack has `SCHEMA_BUCKET_<STACK>` and that the value matches the bucket you intend preview/rollout to use
 9. Confirm every stack in `STACKS` was initialized.
 
 ## What This Command Does

--- a/docs/onboarding/06-bootstrap-manual.md
+++ b/docs/onboarding/06-bootstrap-manual.md
@@ -130,7 +130,8 @@ Example order:
 After each stack, confirm:
 
 - the matching `infra/Pulumi.<stack>.yaml` file exists, or the stack can be selected successfully while working from `infra/`
-- GitHub repository values for that stack were written: `AWS_REGION_<STACK>`, `PULUMI_SECRETS_PROVIDER_<STACK>`, and `AWS_ROLE_ARN_<STACK>`
+- GitHub repository values for that stack were written: `AWS_REGION_<STACK>`, `PULUMI_SECRETS_PROVIDER_<STACK>`, and `SCHEMA_BUCKET_<STACK>`
+- GitHub repository secret `AWS_ROLE_ARN_<STACK>` was written for that stack
 - shared repository configuration such as `PULUMI_BACKEND_URL`, `LTBASE_RELEASE_ID`, `LTBASE_RELEASES_TOKEN`, and `CLOUDFLARE_API_TOKEN` is present
 
 ### 6. Bootstrap OIDC discovery companion

--- a/docs/onboarding/07-first-deploy-and-managed-dsql.md
+++ b/docs/onboarding/07-first-deploy-and-managed-dsql.md
@@ -17,6 +17,7 @@ Use this guide to run the first preview and rollout workflows after bootstrap, a
 
 - confirm `PROMOTION_PATH` is the deployment order you actually want
 - confirm `LTBASE_RELEASE_ID` is final, or decide that you will override it in the workflow input
+- confirm your customer-owned Forma schemas in `customer-owned/schemas/*.json` are the exact bundle you want to publish
 - remember that manual preview only supports the first stack in `PROMOTION_PATH`
 - be ready to validate each deployed environment before approving the next one
 
@@ -36,6 +37,8 @@ Important:
 ### 2. Review the preview output
 
 Confirm that the Pulumi preview matches your expected infrastructure changes.
+
+The preview workflow also runs schema validation in dry-run mode against `customer-owned/schemas/*.json`. It does not upload anything to the stack schema bucket during preview.
 
 At minimum, confirm:
 
@@ -60,6 +63,20 @@ Additional guidance:
 
 Confirm the first deployed environment works before approving the next protected target stack.
 
+During rollout, the workflow publishes the validated schema bundle into the stack schema bucket with this layout:
+
+- `schemas/releases/<version>/manifest.json`
+- `schemas/releases/<version>/*.json`
+- `schemas/published/manifest.json`
+
+The published manifest points at immutable release objects under `schemas/releases/<version>/...`.
+
+The runtime-consumed pointer is separate:
+
+- `schemas/applied/manifest.json`
+
+After publication, the workflow directly invokes the control-plane Lambda with `{"action":"ensure-project"}`. Deployment stops if that explicit apply step fails.
+
 At minimum, check:
 
 - the workflow run completed successfully
@@ -67,8 +84,19 @@ At minimum, check:
 - your minimum health check, login path, or internal smoke test passes
 - the environment is running the same release ID used for the current rollout
 - the rollout workflow has already reconciled the authservice `project info` item in DynamoDB by using the deployed stack outputs and current AWS account id
+- the schema bucket shows the new release bundle under `schemas/releases/<version>/`
+- `schemas/published/manifest.json` points at the version that rollout just published
+- `schemas/applied/manifest.json` only advances after `ensure-project` succeeds
 
-### 5. Approve protected target environments
+### 5. Understand the publish/apply boundary
+
+Schema publication and schema application are intentionally separate.
+
+- if schema publication fails, `schemas/published/manifest.json` is not updated and `ensure-project` is not called
+- if schema publication succeeds but `ensure-project` fails, the new bundle remains visible in S3, but deployment stops and the previously applied schema version remains authoritative
+- only a successful explicit `ensure-project` call advances `schemas/applied/manifest.json` and the deployed project to the published schema version
+
+### 6. Approve protected target environments
 
 When GitHub requests approval for a protected target stack, approve it from the matching GitHub environment gate in your repository.
 
@@ -78,7 +106,7 @@ Recommended approval rhythm:
 - keep the same release ID across the entire promotion path
 - if one hop has a problem, stop approvals and investigate before continuing
 
-### 6. Optional manual single-hop promotion
+### 7. Optional manual single-hop promotion
 
 If you need to recover or replay only one hop, use `Promote LTBase Between Stacks` and provide `from_stack`, `to_stack`, and the same release tag. Invalid jumps fail fast.
 

--- a/docs/superpowers/plans/2026-04-17-schema-bucket-backport.md
+++ b/docs/superpowers/plans/2026-04-17-schema-bucket-backport.md
@@ -1,0 +1,82 @@
+# Schema Bucket Backport Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Backport the schema-bucket publication and explicit `ensure-project` rollout contract from `ltbase-private-deployment-demo01` into `ltbase-private-deployment`.
+
+**Architecture:** Extend the template's stack config and runtime resources with a dedicated schema bucket, switch Lambda schema wiring from packaged files to S3-backed prefixes, and update preview/rollout workflows so schema publication and schema application are separate steps. Keep bootstrap scripts, docs, and tests aligned with the new `SCHEMA_BUCKET_<STACK>` contract.
+
+**Tech Stack:** Go, Pulumi, GitHub Actions, Bash
+
+---
+
+### Task 1: Backport infra schema bucket support
+
+**Files:**
+- Modify: `infra/internal/config/config.go`
+- Modify: `infra/internal/config/config_test.go`
+- Modify: `infra/internal/services/lambda.go`
+- Modify: `infra/internal/services/lambda_test.go`
+- Create: `infra/internal/services/schema_bucket.go`
+- Create: `infra/internal/services/schema_bucket_test.go`
+- Modify: `infra/cmd/ltbase-infra/main.go`
+
+- [ ] Add `SchemaBucket` config support and validation.
+- [ ] Provision schema bucket resources and export `schemaBucket` from the Pulumi program.
+- [ ] Wire data-plane and control-plane Lambdas to schema-bucket env vars and read-only schema S3 access.
+- [ ] Add/adjust unit tests for config defaults, validation, env wiring, and schema bucket helpers.
+
+### Task 2: Backport workflow and script contract
+
+**Files:**
+- Modify: `.github/workflows/preview.yml`
+- Modify: `.github/workflows/rollout-hop.yml`
+- Modify: `scripts/bootstrap-deployment-repo.sh`
+- Modify: `scripts/check-pulumi-stack-config.sh`
+- Modify: `scripts/lib/bootstrap-env.sh`
+- Create: `scripts/publish-schemas.sh`
+
+- [ ] Add preview-time schema validation.
+- [ ] Add rollout-time schema publication, schema bucket contract validation, explicit `ensure-project`, and applied-pointer advancement.
+- [ ] Add bootstrap handling for `SCHEMA_BUCKET_<STACK>` repository variables and Pulumi config.
+- [ ] Require `schemaBucket` in Pulumi stack config checks.
+
+### Task 3: Backport tests and fixtures
+
+**Files:**
+- Modify: `test/bootstrap-deployment-repo-test.sh`
+- Create: `test/check-pulumi-stack-config-test.sh`
+- Create: `test/publish-schemas-test.sh`
+- Modify: `test/rollout-workflows-test.sh`
+
+- [ ] Extend bootstrap regression coverage for schema bucket variables and Pulumi config.
+- [ ] Add schema publish script coverage.
+- [ ] Add Pulumi stack config coverage for `schemaBucket`.
+- [ ] Update rollout workflow assertions for the publish/apply split.
+
+### Task 4: Backport docs and customer schema directory support
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/onboarding/04-prepare-env-file.md`
+- Modify: `docs/onboarding/05-bootstrap-one-click.md`
+- Modify: `docs/onboarding/06-bootstrap-manual.md`
+- Modify: `docs/onboarding/07-first-deploy-and-managed-dsql.md`
+- Modify: `env.template`
+- Create: `customer-owned/schemas/.gitkeep`
+
+- [ ] Document the customer-owned schema location and publish/apply contract.
+- [ ] Document `SCHEMA_BUCKET_<STACK>` defaults and overrides in onboarding docs and `env.template`.
+- [ ] Ensure the template includes the customer-owned schema directory.
+
+### Task 5: Verify the backport
+
+**Files:**
+- No source changes expected
+
+- [ ] Run `go test ./internal/config ./internal/services` in `infra/`.
+- [ ] Run `bash ./test/publish-schemas-test.sh`.
+- [ ] Run `bash ./test/rollout-workflows-test.sh`.
+- [ ] Run `bash ./test/bootstrap-deployment-repo-test.sh`.
+- [ ] Run `bash ./test/check-pulumi-stack-config-test.sh`.
+- [ ] Run `./test/managed-dsql-consistency-test.sh`.

--- a/docs/superpowers/specs/2026-04-17-schema-bucket-backport-design.md
+++ b/docs/superpowers/specs/2026-04-17-schema-bucket-backport-design.md
@@ -1,0 +1,54 @@
+# Schema Bucket Backport Design
+
+## Goal
+
+Backport the schema publication and explicit schema apply rollout contract from `ltbase-private-deployment-demo01` into `ltbase-private-deployment` so the template can provision per-stack schema buckets, publish customer-owned schema bundles, and only advance runtime-consumed schema pointers after a successful control-plane `ensure-project` apply.
+
+## Scope
+
+- Add customer-owned schema support under `customer-owned/schemas/`.
+- Provision and export a dedicated schema bucket per stack.
+- Wire runtime Lambdas to read schema from S3 instead of packaged schema files.
+- Validate customer schemas during preview.
+- Publish immutable schema releases plus `schemas/published/manifest.json` during rollout.
+- Call control-plane `ensure-project` explicitly after publication.
+- Advance `schemas/applied/manifest.json` only after successful apply.
+- Update bootstrap/config validation, tests, and docs to reflect `SCHEMA_BUCKET_<STACK>`.
+
+## Non-Goals
+
+- No product code changes in `ltbase.api`.
+- No changes to unrelated bootstrap, OIDC, mTLS, or release flows beyond what the schema contract requires.
+- No attempt to reconcile unrelated untracked files already present in the target repo.
+
+## Design
+
+### Infra and Config
+
+Add `SchemaBucket` to stack configuration with a derived default of `<githubRepo>-schema-<stack>`. Validate that the schema bucket never matches the runtime bucket. Provision the schema bucket alongside the runtime bucket and export it from the Pulumi program so workflows can verify they are publishing to the same bucket that the deployed runtime expects.
+
+### Lambda Contract
+
+Remove reliance on packaged `FORMA_SCHEMA_DIR`. Data-plane and control-plane Lambdas will both receive schema source environment variables pointing at the schema bucket, but with different prefixes:
+
+- data plane reads `schemas/applied`
+- control plane reads `schemas/published`
+
+Both Lambdas receive read-only access to the schema bucket.
+
+### Workflow Contract
+
+Preview validates Pulumi stack config and validates customer schemas in dry-run mode without uploading anything. Rollout publishes schemas after infrastructure rollout, then validates that the deployment outputs' `schemaBucket` matches the configured `SCHEMA_BUCKET_<STACK>` value, calls control-plane `ensure-project`, and only then copies the published manifest to the applied manifest.
+
+### Bootstrap and Operator Contract
+
+Bootstrap derives and writes `SCHEMA_BUCKET_<STACK>` repository variables and Pulumi config. Operator docs explain the split between published and applied pointers, the explicit apply gate, and the new customer-owned schema location.
+
+## Verification
+
+- `go test ./internal/config ./internal/services` in `infra/`
+- `bash ./test/publish-schemas-test.sh`
+- `bash ./test/rollout-workflows-test.sh`
+- `bash ./test/bootstrap-deployment-repo-test.sh`
+- `bash ./test/check-pulumi-stack-config-test.sh`
+- `./test/managed-dsql-consistency-test.sh`

--- a/env.template
+++ b/env.template
@@ -64,9 +64,12 @@ CLOUDFLARE_ZONE_ID=replace-with-zone-id
 # JWKS_URL_DEVO=https://oidc.customer.example.com/devo/.well-known/jwks.json
 # JWKS_URL_PROD=https://oidc.customer.example.com/prod/.well-known/jwks.json
 
-# Optional overrides. Defaults are <DEPLOYMENT_REPO_NAME>-runtime-<stack> and <DEPLOYMENT_REPO_NAME>-<stack>.
+# Optional overrides. Defaults are <DEPLOYMENT_REPO_NAME>-runtime-<stack>,
+# <DEPLOYMENT_REPO_NAME>-schema-<stack>, and <DEPLOYMENT_REPO_NAME>-<stack>.
 # RUNTIME_BUCKET_DEVO=customer-ltbase-runtime-devo
 # RUNTIME_BUCKET_PROD=customer-ltbase-runtime-prod
+# SCHEMA_BUCKET_DEVO=customer-ltbase-schema-devo
+# SCHEMA_BUCKET_PROD=customer-ltbase-schema-prod
 # TABLE_NAME_DEVO=customer-ltbase-devo
 # TABLE_NAME_PROD=customer-ltbase-prod
 

--- a/infra/cmd/ltbase-infra/main.go
+++ b/infra/cmd/ltbase-infra/main.go
@@ -57,6 +57,7 @@ func main() {
 		}
 		ctx.Log.Info("ltbase-infra: declared forma schedule", nil)
 		ctx.Export("runtimeBucket", runtime.RuntimeBucket.Bucket)
+		ctx.Export("schemaBucket", runtime.SchemaBucket.Bucket)
 		ctx.Export("tableName", runtime.Table.Name)
 		ctx.Export("projectId", pulumi.String(cfg.ProjectID))
 		ctx.Export("apiId", apis.API.ID())

--- a/infra/internal/config/config.go
+++ b/infra/internal/config/config.go
@@ -18,6 +18,7 @@ type StackConfig struct {
 	DeploymentAWSAccountID   string
 	ReleaseAssetDir          string
 	RuntimeBucket            string
+	SchemaBucket             string
 	TableName                string
 	MTLSTruststoreFile       string
 	MTLSTruststoreKey        string
@@ -51,6 +52,7 @@ type StackConfig struct {
 func Load(ctx *pulumi.Context) (StackConfig, error) {
 	cfg := pcfg.New(ctx, "")
 	stack := ctx.Stack()
+	githubRepo := cfg.Require("githubRepo")
 	out := StackConfig{
 		Project:                  ctx.Project(),
 		Stack:                    stack,
@@ -58,6 +60,7 @@ func Load(ctx *pulumi.Context) (StackConfig, error) {
 		DeploymentAWSAccountID:   cfg.Require("deploymentAwsAccountId"),
 		ReleaseAssetDir:          valueOrDefault(cfg.Get("releaseAssetDir"), defaultReleaseAssetDir),
 		RuntimeBucket:            cfg.Require("runtimeBucket"),
+		SchemaBucket:             valueOrDefault(cfg.Get("schemaBucket"), defaultSchemaBucket(githubRepo, stack)),
 		TableName:                cfg.Require("tableName"),
 		MTLSTruststoreFile:       cfg.Require("mtlsTruststoreFile"),
 		MTLSTruststoreKey:        cfg.Require("mtlsTruststoreKey"),
@@ -81,7 +84,7 @@ func Load(ctx *pulumi.Context) (StackConfig, error) {
 		GeminiAPIKey:             cfg.RequireSecret("geminiApiKey"),
 		GeminiModel:              valueOrDefault(cfg.Get("geminiModel"), "gemini-3-flash-preview"),
 		GitHubOrg:                cfg.Require("githubOrg"),
-		GitHubRepo:               cfg.Require("githubRepo"),
+		GitHubRepo:               githubRepo,
 		ManageGitHubOIDCProvider: cfg.GetBool("manageGithubOidcProvider"),
 		GitHubOIDCProviderArn:    strings.TrimSpace(cfg.Get("githubOidcProviderArn")),
 		GitHubThumbprints:        []string{githubThumbprint},
@@ -100,7 +103,14 @@ func (c StackConfig) Validate() error {
 	if !c.ManageGitHubOIDCProvider && c.GitHubOIDCProviderArn == "" {
 		return fmt.Errorf("githubOidcProviderArn is required when manageGithubOidcProvider is false")
 	}
+	if c.RuntimeBucket != "" && c.SchemaBucket != "" && c.RuntimeBucket == c.SchemaBucket {
+		return fmt.Errorf("schemaBucket must differ from runtimeBucket")
+	}
 	return nil
+}
+
+func defaultSchemaBucket(repoName, stack string) string {
+	return strings.ToLower(strings.TrimSpace(repoName)) + "-schema-" + strings.ToLower(strings.TrimSpace(stack))
 }
 
 func valueOrDefault(value, fallback string) string {

--- a/infra/internal/config/config_test.go
+++ b/infra/internal/config/config_test.go
@@ -82,3 +82,30 @@ func TestValidateAllowsProjectIDAndAuthProviderConfigFile(t *testing.T) {
 		t.Fatal("MTLSTruststoreKey should be preserved")
 	}
 }
+
+func TestDefaultSchemaBucketUsesCanonicalRepoBasedName(t *testing.T) {
+	devo := defaultSchemaBucket("customer-ltbase", "devo")
+	prod := defaultSchemaBucket("customer-ltbase", "prod")
+
+	if devo != "customer-ltbase-schema-devo" {
+		t.Fatalf("defaultSchemaBucket() devo = %q", devo)
+	}
+	if prod != "customer-ltbase-schema-prod" {
+		t.Fatalf("defaultSchemaBucket() prod = %q", prod)
+	}
+	if devo == prod {
+		t.Fatal("defaultSchemaBucket() should vary per stack")
+	}
+}
+
+func TestValidateRejectsSchemaBucketMatchingRuntimeBucket(t *testing.T) {
+	cfg := StackConfig{
+		ManageGitHubOIDCProvider: true,
+		RuntimeBucket:            "customer-ltbase-runtime-devo",
+		SchemaBucket:             "customer-ltbase-runtime-devo",
+	}
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate() expected error when schemaBucket matches runtimeBucket")
+	}
+}

--- a/infra/internal/services/lambda.go
+++ b/infra/internal/services/lambda.go
@@ -21,6 +21,8 @@ import (
 type RuntimeResources struct {
 	RuntimeBucket           *s3.BucketV2
 	RuntimeBucketVersioning *s3.BucketVersioningV2
+	SchemaBucket            *s3.BucketV2
+	SchemaBucketVersioning  *s3.BucketVersioningV2
 	Table                   *dynamodb.Table
 	DSQL                    *DSQLResources
 	AuthKey                 *kms.Key
@@ -60,6 +62,10 @@ func NewRuntimeResources(ctx *pulumi.Context, cfg config.StackConfig, providers 
 	if err != nil {
 		return nil, err
 	}
+	schemaBucket, schemaBucketVersioning, err := newSchemaBucket(ctx, cfg, providers)
+	if err != nil {
+		return nil, err
+	}
 	table, err := dynamodb.NewTable(ctx, naming.ResourceName(cfg.Project, cfg.Stack, "table"), &dynamodb.TableArgs{
 		Name:                pulumi.String(cfg.TableName),
 		BillingMode:         pulumi.String("PAY_PER_REQUEST"),
@@ -91,6 +97,8 @@ func NewRuntimeResources(ctx *pulumi.Context, cfg config.StackConfig, providers 
 	return &RuntimeResources{
 		RuntimeBucket:           runtimeBucket,
 		RuntimeBucketVersioning: bucketVersioning,
+		SchemaBucket:            schemaBucket,
+		SchemaBucketVersioning:  schemaBucketVersioning,
 		Table:                   table,
 		DSQL:                    dsqlResources,
 		AuthKey:                 authKey,
@@ -110,29 +118,27 @@ func NewLambdaServices(ctx *pulumi.Context, cfg config.StackConfig, runtime *Run
 	}
 	providerNames := authProviderNames(providerCfg)
 	dataPlane, err := newLambdaService(ctx, cfg, providers, lambdaSpec{
-		Name:         "data-plane",
-		ArtifactPath: release.DataPlaneZip,
-		Memory:       1024,
-		Timeout:      30,
-		AliasName:    naming.AliasName(cfg.Stack),
-		Env: mergeEnv(commonEnv, pulumi.StringMap{
-			"LTBASE_API_BASE_URL": pulumi.String("https://" + cfg.APIDomain),
-			"GEMINI_API_KEY":      cfg.GeminiAPIKey,
-			"GEMINI_MODEL":        pulumi.String(cfg.GeminiModel),
-		}),
-		AllowKMS: false,
+		Name:            "data-plane",
+		ArtifactPath:    release.DataPlaneZip,
+		Memory:          1024,
+		Timeout:         30,
+		AliasName:       naming.AliasName(cfg.Stack),
+		Env:             dataPlaneLambdaEnv(cfg, runtime.Table.Name, runtime.RuntimeBucket.Bucket, runtime.SchemaBucket.Bucket, cfg.GeminiAPIKey),
+		AllowKMS:        false,
+		AllowSchemaRead: true,
 	}, runtime)
 	if err != nil {
 		return nil, err
 	}
 	controlPlane, err := newLambdaService(ctx, cfg, providers, lambdaSpec{
-		Name:         "control-plane",
-		ArtifactPath: release.ControlPlaneZip,
-		Memory:       512,
-		Timeout:      30,
-		AliasName:    naming.AliasName(cfg.Stack),
-		Env:          controlPlaneLambdaEnv(cfg, runtime.Table.Name, runtime.RuntimeBucket.Bucket),
-		AllowKMS:     false,
+		Name:            "control-plane",
+		ArtifactPath:    release.ControlPlaneZip,
+		Memory:          512,
+		Timeout:         30,
+		AliasName:       naming.AliasName(cfg.Stack),
+		Env:             controlPlaneLambdaEnv(cfg, runtime.Table.Name, runtime.RuntimeBucket.Bucket, runtime.SchemaBucket.Bucket),
+		AllowKMS:        false,
+		AllowSchemaRead: true,
 	}, runtime)
 	if err != nil {
 		return nil, err
@@ -179,8 +185,16 @@ func authLambdaEnv(cfg config.StackConfig, providerNames []string, authKeyID pul
 	})
 }
 
-func controlPlaneLambdaEnv(cfg config.StackConfig, tableName pulumi.StringInput, bucketName pulumi.StringInput) pulumi.StringMap {
-	return mergeEnv(commonLambdaEnv(cfg, tableName, bucketName), pulumi.StringMap{
+func dataPlaneLambdaEnv(cfg config.StackConfig, tableName pulumi.StringInput, bucketName pulumi.StringInput, schemaBucket pulumi.StringInput, geminiAPIKey pulumi.StringInput) pulumi.StringMap {
+	return mergeEnv(commonLambdaEnv(cfg, tableName, bucketName), schemaLambdaEnv(schemaBucket, pulumi.String(schemaAppliedPrefix)), pulumi.StringMap{
+		"LTBASE_API_BASE_URL": pulumi.String("https://" + cfg.APIDomain),
+		"GEMINI_API_KEY":      geminiAPIKey,
+		"GEMINI_MODEL":        pulumi.String(cfg.GeminiModel),
+	})
+}
+
+func controlPlaneLambdaEnv(cfg config.StackConfig, tableName pulumi.StringInput, bucketName pulumi.StringInput, schemaBucket pulumi.StringInput) pulumi.StringMap {
+	return mergeEnv(commonLambdaEnv(cfg, tableName, bucketName), schemaLambdaEnv(schemaBucket, pulumi.String(schemaPublishedPrefix)), pulumi.StringMap{
 		"PROJECT_ID":   pulumi.String(cfg.ProjectID),
 		"PROJECT_NAME": pulumi.String(cfg.DeploymentProjectName),
 		"ACCOUNT_ID":   pulumi.String(cfg.DeploymentAWSAccountID),
@@ -189,13 +203,14 @@ func controlPlaneLambdaEnv(cfg config.StackConfig, tableName pulumi.StringInput,
 }
 
 type lambdaSpec struct {
-	Name         string
-	ArtifactPath string
-	Memory       int
-	Timeout      int
-	AliasName    string
-	Env          pulumi.StringMap
-	AllowKMS     bool
+	Name            string
+	ArtifactPath    string
+	Memory          int
+	Timeout         int
+	AliasName       string
+	Env             pulumi.StringMap
+	AllowKMS        bool
+	AllowSchemaRead bool
 }
 
 func newLambdaService(ctx *pulumi.Context, cfg config.StackConfig, providers Providers, spec lambdaSpec, runtime *RuntimeResources) (*LambdaService, error) {
@@ -274,7 +289,7 @@ func newLambdaRole(ctx *pulumi.Context, cfg config.StackConfig, providers Provid
 	if err != nil {
 		return nil, err
 	}
-	policyJSON := lambdaPolicyDocument(runtime, spec.AllowKMS)
+	policyJSON := lambdaPolicyDocument(runtime, spec.AllowKMS, spec.AllowSchemaRead)
 	_, err = iam.NewRolePolicy(ctx, naming.ResourceName(cfg.Project, cfg.Stack, spec.Name+"-inline"), &iam.RolePolicyArgs{
 		Role:   role.ID(),
 		Policy: policyJSON,
@@ -285,7 +300,7 @@ func newLambdaRole(ctx *pulumi.Context, cfg config.StackConfig, providers Provid
 	return role, nil
 }
 
-func lambdaPolicyDocument(runtime *RuntimeResources, allowKMS bool) pulumi.StringOutput {
+func lambdaPolicyDocument(runtime *RuntimeResources, allowKMS bool, allowSchemaRead bool) pulumi.StringOutput {
 	statements := pulumi.Array{
 		pulumi.Map{
 			"Effect": pulumi.String("Allow"),
@@ -334,6 +349,24 @@ func lambdaPolicyDocument(runtime *RuntimeResources, allowKMS bool) pulumi.Strin
 				pulumi.String("*"),
 			},
 		},
+	}
+	if allowSchemaRead {
+		statements = append(statements,
+			pulumi.Map{
+				"Effect": pulumi.String("Allow"),
+				"Action": pulumi.StringArray{pulumi.String("s3:GetObject")},
+				"Resource": pulumi.Array{
+					pulumi.Sprintf("arn:aws:s3:::%s/*", runtime.SchemaBucket.Bucket),
+				},
+			},
+			pulumi.Map{
+				"Effect": pulumi.String("Allow"),
+				"Action": pulumi.StringArray{pulumi.String("s3:ListBucket")},
+				"Resource": pulumi.Array{
+					pulumi.Sprintf("arn:aws:s3:::%s", runtime.SchemaBucket.Bucket),
+				},
+			},
+		)
 	}
 	if allowKMS {
 		statements = append(statements, pulumi.Map{
@@ -407,7 +440,6 @@ func commonLambdaEnv(cfg config.StackConfig, tableName pulumi.StringInput, bucke
 		"DSQL_DB":             pulumi.String(cfg.DSQLDB),
 		"DSQL_USER":           pulumi.String(cfg.DSQLUser),
 		"DSQL_PROJECT_SCHEMA": pulumi.String(cfg.DSQLProjectSchema),
-		"FORMA_SCHEMA_DIR":    pulumi.String("/var/task/schemas"),
 		"S3_BUCKET_NAME":      bucketName,
 	}
 	for key, value := range optionalDSQLEnv(cfg) {

--- a/infra/internal/services/lambda_test.go
+++ b/infra/internal/services/lambda_test.go
@@ -43,10 +43,33 @@ func TestCommonLambdaEnvOmitsReservedAWSRegion(t *testing.T) {
 	if _, ok := env["AWS_REGION"]; ok {
 		t.Fatal("commonLambdaEnv() unexpectedly sets reserved AWS_REGION")
 	}
+	if _, ok := env["FORMA_SCHEMA_DIR"]; ok {
+		t.Fatal("commonLambdaEnv() unexpectedly sets packaged FORMA_SCHEMA_DIR")
+	}
+	if _, ok := env["FORMA_SCHEMA_SOURCE"]; ok {
+		t.Fatal("commonLambdaEnv() unexpectedly sets schema source contract")
+	}
 
-	for _, key := range []string{"DSQL_PORT", "DSQL_DB", "DSQL_USER", "DSQL_PROJECT_SCHEMA", "FORMA_SCHEMA_DIR"} {
+	for _, key := range []string{"DSQL_PORT", "DSQL_DB", "DSQL_USER", "DSQL_PROJECT_SCHEMA"} {
 		if _, ok := env[key]; !ok {
 			t.Fatalf("commonLambdaEnv() missing %s", key)
+		}
+	}
+}
+
+func TestDataPlaneLambdaEnvIncludesSchemaSourceContract(t *testing.T) {
+	env := dataPlaneLambdaEnv(config.StackConfig{
+		APIDomain:         "api.devo.example.com",
+		GeminiModel:       "gemini-3-flash-preview",
+		DSQLPort:          "5432",
+		DSQLDB:            "postgres",
+		DSQLUser:          "admin",
+		DSQLProjectSchema: "ltbase",
+	}, pulumi.String("table-name"), pulumi.String("runtime-bucket"), pulumi.String("schema-bucket"), pulumi.String("gemini-key"))
+
+	for _, key := range []string{"FORMA_SCHEMA_SOURCE", "FORMA_SCHEMA_BUCKET", "FORMA_SCHEMA_PREFIX", "FORMA_SCHEMA_PUBLISHED_PREFIX", "FORMA_SCHEMA_CACHE_DIR"} {
+		if _, ok := env[key]; !ok {
+			t.Fatalf("dataPlaneLambdaEnv() missing %s", key)
 		}
 	}
 }
@@ -81,9 +104,9 @@ func TestControlPlaneLambdaEnvIncludesBootstrapProjectConfig(t *testing.T) {
 		DSQLDB:                 "postgres",
 		DSQLUser:               "admin",
 		DSQLProjectSchema:      "ltbase",
-	}, pulumi.String("table-name"), pulumi.String("bucket-name"))
+	}, pulumi.String("table-name"), pulumi.String("bucket-name"), pulumi.String("schema-bucket"))
 
-	for _, key := range []string{"PROJECT_ID", "PROJECT_NAME", "ACCOUNT_ID", "API_BASE_URL"} {
+	for _, key := range []string{"PROJECT_ID", "PROJECT_NAME", "ACCOUNT_ID", "API_BASE_URL", "FORMA_SCHEMA_SOURCE", "FORMA_SCHEMA_BUCKET", "FORMA_SCHEMA_PREFIX", "FORMA_SCHEMA_PUBLISHED_PREFIX", "FORMA_SCHEMA_CACHE_DIR"} {
 		if _, ok := env[key]; !ok {
 			t.Fatalf("controlPlaneLambdaEnv() missing %s", key)
 		}

--- a/infra/internal/services/schema_bucket.go
+++ b/infra/internal/services/schema_bucket.go
@@ -1,0 +1,37 @@
+package services
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"lychee.technology/ltbase/infra/internal/config"
+	"lychee.technology/ltbase/infra/internal/naming"
+)
+
+const schemaAppliedPrefix = "schemas/applied"
+const schemaPublishedPrefix = "schemas/published"
+const schemaCacheDir = "/tmp/ltbase-schemas"
+
+func newSchemaBucket(ctx *pulumi.Context, cfg config.StackConfig, providers Providers) (*s3.BucketV2, *s3.BucketVersioningV2, error) {
+	bucket, err := s3.NewBucketV2(ctx, naming.ResourceName(cfg.Project, cfg.Stack, "schema"), &s3.BucketV2Args{
+		Bucket: pulumi.String(cfg.SchemaBucket),
+	}, pulumi.Provider(providers.AWS))
+	if err != nil {
+		return nil, nil, err
+	}
+	versioning, err := secureBucket(ctx, naming.ResourceName(cfg.Project, cfg.Stack, "schema"), bucket, providers)
+	if err != nil {
+		return nil, nil, err
+	}
+	return bucket, versioning, nil
+}
+
+func schemaLambdaEnv(schemaBucket pulumi.StringInput, runtimePrefix pulumi.StringInput) pulumi.StringMap {
+	return pulumi.StringMap{
+		"FORMA_SCHEMA_SOURCE":           pulumi.String("s3"),
+		"FORMA_SCHEMA_BUCKET":           schemaBucket,
+		"FORMA_SCHEMA_PREFIX":           runtimePrefix,
+		"FORMA_SCHEMA_PUBLISHED_PREFIX": pulumi.String(schemaPublishedPrefix),
+		"FORMA_SCHEMA_CACHE_DIR":        pulumi.String(schemaCacheDir),
+	}
+}

--- a/infra/internal/services/schema_bucket_test.go
+++ b/infra/internal/services/schema_bucket_test.go
@@ -1,0 +1,416 @@
+package services
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws"
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/dynamodb"
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/kms"
+	"github.com/pulumi/pulumi-aws/sdk/v7/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"lychee.technology/ltbase/infra/internal/config"
+)
+
+func TestNewRuntimeResourcesProvisionsAndSecuresDedicatedSchemaBucket(t *testing.T) {
+	mocks := &runtimeResourceMocks{}
+	cfg := testStackConfig()
+
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		providers, err := newMockProviders(ctx)
+		if err != nil {
+			return err
+		}
+		_, err = NewRuntimeResources(ctx, cfg, providers)
+		return err
+	}, pulumi.WithMocks("ltbase-infra", "devo", mocks))
+	if err != nil {
+		t.Fatalf("NewRuntimeResources() error = %v", err)
+	}
+
+	bucket := mocks.resourceByName("aws:s3/bucketV2:BucketV2", "ltbase-infra-devo-schema")
+	if bucket == nil {
+		t.Fatal("expected dedicated schema bucket resource")
+	}
+	if got := stringInput(bucket.Inputs, "bucket"); got != cfg.SchemaBucket {
+		t.Fatalf("schema bucket name = %q", got)
+	}
+
+	versioning := mocks.resourceByName("aws:s3/bucketVersioningV2:BucketVersioningV2", "ltbase-infra-devo-schema-versioning")
+	if versioning == nil {
+		t.Fatal("expected schema bucket versioning resource")
+	}
+	if got := nestedStringInput(versioning.Inputs, "versioningConfiguration", "status"); got != "Enabled" {
+		t.Fatalf("schema bucket versioning status = %q", got)
+	}
+
+	sse := mocks.resourceByName("aws:s3/bucketServerSideEncryptionConfigurationV2:BucketServerSideEncryptionConfigurationV2", "ltbase-infra-devo-schema-sse")
+	if sse == nil {
+		t.Fatal("expected schema bucket SSE resource")
+	}
+	if got := nestedArrayStringInput(sse.Inputs, 0, "rules", "applyServerSideEncryptionByDefault", "sseAlgorithm"); got != "AES256" {
+		t.Fatalf("schema bucket sse algorithm = %q", got)
+	}
+
+	publicAccess := mocks.resourceByName("aws:s3/bucketPublicAccessBlock:BucketPublicAccessBlock", "ltbase-infra-devo-schema-public-access")
+	if publicAccess == nil {
+		t.Fatal("expected schema bucket public access block resource")
+	}
+	for _, key := range []string{"blockPublicAcls", "blockPublicPolicy", "ignorePublicAcls", "restrictPublicBuckets"} {
+		if !boolInput(publicAccess.Inputs, key) {
+			t.Fatalf("schema bucket %s = false", key)
+		}
+	}
+}
+
+func TestNewLambdaRolePolicyGrantsReadOnlySchemaBucketAccess(t *testing.T) {
+	mocks := &runtimeResourceMocks{}
+	runtime := testRuntimeResources()
+	cfg := testStackConfig()
+
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		providers, err := newMockProviders(ctx)
+		if err != nil {
+			return err
+		}
+		for _, spec := range []lambdaSpec{
+			{
+				Name:            "data-plane",
+				AllowSchemaRead: true,
+			},
+			{
+				Name:            "control-plane",
+				AllowSchemaRead: true,
+			},
+		} {
+			if _, err := newLambdaRole(ctx, cfg, providers, spec, runtime); err != nil {
+				return err
+			}
+		}
+		return nil
+	}, pulumi.WithMocks("ltbase-infra", "devo", mocks))
+	if err != nil {
+		t.Fatalf("newLambdaRole() error = %v", err)
+	}
+
+	for _, name := range []string{"ltbase-infra-devo-data-plane-inline", "ltbase-infra-devo-control-plane-inline"} {
+		policy := mocks.resourceByName("aws:iam/rolePolicy:RolePolicy", name)
+		if policy == nil {
+			t.Fatalf("expected inline policy %s", name)
+		}
+		assertSchemaReadOnlyStatement(t, stringInput(policy.Inputs, "policy"), "customer-ltbase-schema-devo")
+	}
+}
+
+func TestNewLambdaServicesWireSchemaEnvAndReadOnlyPolicy(t *testing.T) {
+	mocks := &runtimeResourceMocks{}
+	runtime := testRuntimeResources()
+	cfg := testStackConfig()
+	rootDir := t.TempDir()
+	writeAuthProviderConfig(t, rootDir)
+
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		providers, err := newMockProviders(ctx)
+		if err != nil {
+			return err
+		}
+		cfg.ReleaseAssetDir = "."
+		cfg.ReleaseID = "test-release"
+		cfg.AuthProviderConfigFile = "auth-providers.test.json"
+		_, err = NewLambdaServices(ctx, cfg, runtime, providers)
+		return err
+	}, pulumi.WithMocks("ltbase-infra", "devo", mocks), withRootDirectory(rootDir))
+	if err != nil {
+		t.Fatalf("NewLambdaServices() error = %v", err)
+	}
+
+	for _, name := range []string{"ltbase-infra-devo-data-plane", "ltbase-infra-devo-control-plane"} {
+		fn := mocks.resourceByName("aws:lambda/function:Function", name)
+		if fn == nil {
+			t.Fatalf("expected lambda function %s", name)
+		}
+		assertSchemaEnvContract(t, fn.Inputs, "customer-ltbase-schema-devo")
+	}
+	assertSchemaEnvPrefix(t, mocks.resourceByName("aws:lambda/function:Function", "ltbase-infra-devo-data-plane").Inputs, schemaAppliedPrefix)
+	assertSchemaEnvPrefix(t, mocks.resourceByName("aws:lambda/function:Function", "ltbase-infra-devo-control-plane").Inputs, schemaPublishedPrefix)
+	assertSchemaPublishedPrefix(t, mocks.resourceByName("aws:lambda/function:Function", "ltbase-infra-devo-data-plane").Inputs, schemaPublishedPrefix)
+	assertSchemaPublishedPrefix(t, mocks.resourceByName("aws:lambda/function:Function", "ltbase-infra-devo-control-plane").Inputs, schemaPublishedPrefix)
+
+	for _, name := range []string{"ltbase-infra-devo-data-plane-inline", "ltbase-infra-devo-control-plane-inline"} {
+		policy := mocks.resourceByName("aws:iam/rolePolicy:RolePolicy", name)
+		if policy == nil {
+			t.Fatalf("expected inline policy %s", name)
+		}
+		assertSchemaReadOnlyStatement(t, stringInput(policy.Inputs, "policy"), "customer-ltbase-schema-devo")
+	}
+}
+
+type runtimeResourceMocks struct {
+	resources []mockResource
+}
+
+type mockResource struct {
+	Token  string
+	Name   string
+	Inputs resource.PropertyMap
+}
+
+func (m *runtimeResourceMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return resource.PropertyMap{}, nil
+}
+
+func (m *runtimeResourceMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	inputs := args.Inputs.Copy()
+	m.resources = append(m.resources, mockResource{Token: args.TypeToken, Name: args.Name, Inputs: inputs})
+	state := inputs.Copy()
+	state[resource.PropertyKey("name")] = resource.NewStringProperty(args.Name)
+	state[resource.PropertyKey("arn")] = resource.NewStringProperty("arn:mock:" + args.Name)
+	state[resource.PropertyKey("bucket")] = firstDefinedString(inputs, "bucket", args.Name)
+	return args.Name + "-id", state, nil
+}
+
+func (m *runtimeResourceMocks) resourceByName(token, name string) *mockResource {
+	for i := range m.resources {
+		resource := &m.resources[i]
+		if resource.Token == token && resource.Name == name {
+			return resource
+		}
+	}
+	return nil
+}
+
+func newMockProviders(ctx *pulumi.Context) (Providers, error) {
+	provider, err := aws.NewProvider(ctx, "aws-provider", &aws.ProviderArgs{
+		Region: pulumi.String("ap-northeast-1"),
+	})
+	if err != nil {
+		return Providers{}, err
+	}
+	return Providers{AWS: provider}, nil
+}
+
+func withRootDirectory(root string) pulumi.RunOption {
+	return func(info *pulumi.RunInfo) {
+		info.RootDirectory = root
+	}
+}
+
+func writeAuthProviderConfig(t *testing.T, rootDir string) {
+	t.Helper()
+	content := []byte(`{"providers":[{"name":"firebase","issuer":"https://issuer.example.com","audiences":["ltbase"],"enable_login":true}]}`)
+	if err := os.WriteFile(filepath.Join(rootDir, "auth-providers.test.json"), content, 0o600); err != nil {
+		t.Fatalf("os.WriteFile(auth provider config) error = %v", err)
+	}
+}
+
+func testStackConfig() config.StackConfig {
+	return config.StackConfig{
+		Project:                  "ltbase-infra",
+		Stack:                    "devo",
+		RuntimeBucket:            "customer-ltbase-runtime-devo",
+		SchemaBucket:             "customer-ltbase-schema-devo",
+		TableName:                "customer-ltbase-devo",
+		DeploymentAWSAccountID:   "123456789012",
+		ProjectID:                "33333333-3333-4333-8333-333333333333",
+		DeploymentProjectName:    "Customer Ltbase",
+		APIDomain:                "api.devo.example.com",
+		DSQLPort:                 "5432",
+		DSQLDB:                   "postgres",
+		DSQLUser:                 "admin",
+		DSQLProjectSchema:        "ltbase",
+		ManageGitHubOIDCProvider: true,
+	}
+}
+
+func testRuntimeResources() *RuntimeResources {
+	return &RuntimeResources{
+		RuntimeBucket: &s3.BucketV2{Bucket: pulumi.String("customer-ltbase-runtime-devo").ToStringOutput(), Arn: pulumi.String("arn:aws:s3:::customer-ltbase-runtime-devo").ToStringOutput()},
+		SchemaBucket:  &s3.BucketV2{Bucket: pulumi.String("customer-ltbase-schema-devo").ToStringOutput(), Arn: pulumi.String("arn:aws:s3:::customer-ltbase-schema-devo").ToStringOutput()},
+		Table:         &dynamodb.Table{Arn: pulumi.String("arn:aws:dynamodb:ap-northeast-1:123456789012:table/customer-ltbase-devo").ToStringOutput()},
+		AuthKey:       &kms.Key{Arn: pulumi.String("arn:aws:kms:ap-northeast-1:123456789012:key/test").ToStringOutput()},
+	}
+}
+
+func assertSchemaReadOnlyStatement(t *testing.T, policyJSON string, bucket string) {
+	t.Helper()
+	var policy struct {
+		Statement []struct {
+			Action   []string `json:"Action"`
+			Resource []string `json:"Resource"`
+		} `json:"Statement"`
+	}
+	if err := json.Unmarshal([]byte(policyJSON), &policy); err != nil {
+		t.Fatalf("json.Unmarshal(policy) error = %v", err)
+	}
+
+	objectArn := "arn:aws:s3:::" + bucket + "/*"
+	bucketArn := "arn:aws:s3:::" + bucket
+	var foundObject bool
+	var foundList bool
+	for _, statement := range policy.Statement {
+		if containsString(statement.Resource, objectArn) {
+			foundObject = true
+			if !containsString(statement.Action, "s3:GetObject") {
+				t.Fatalf("schema object actions = %v", statement.Action)
+			}
+			if containsString(statement.Action, "s3:PutObject") || containsString(statement.Action, "s3:DeleteObject") {
+				t.Fatalf("schema object actions should be read-only: %v", statement.Action)
+			}
+		}
+		if containsString(statement.Resource, bucketArn) {
+			foundList = true
+			if !containsString(statement.Action, "s3:ListBucket") {
+				t.Fatalf("schema bucket actions = %v", statement.Action)
+			}
+			if containsString(statement.Action, "s3:PutObject") || containsString(statement.Action, "s3:DeleteObject") {
+				t.Fatalf("schema bucket actions should be read-only: %v", statement.Action)
+			}
+		}
+	}
+	if !foundObject {
+		t.Fatalf("missing schema object statement in %s", policyJSON)
+	}
+	if !foundList {
+		t.Fatalf("missing schema list statement in %s", policyJSON)
+	}
+}
+
+func assertSchemaEnvContract(t *testing.T, inputs resource.PropertyMap, bucket string) {
+	t.Helper()
+	variables := nestedObjectInput(inputs, "environment", "variables")
+	if got := propertyString(variables[resource.PropertyKey("FORMA_SCHEMA_SOURCE")]); got != "s3" {
+		t.Fatalf("FORMA_SCHEMA_SOURCE = %q", got)
+	}
+	if got := propertyString(variables[resource.PropertyKey("FORMA_SCHEMA_BUCKET")]); got != bucket {
+		t.Fatalf("FORMA_SCHEMA_BUCKET = %q", got)
+	}
+	if got := propertyString(variables[resource.PropertyKey("FORMA_SCHEMA_PUBLISHED_PREFIX")]); got != schemaPublishedPrefix {
+		t.Fatalf("FORMA_SCHEMA_PUBLISHED_PREFIX = %q", got)
+	}
+	if got := propertyString(variables[resource.PropertyKey("FORMA_SCHEMA_CACHE_DIR")]); got != schemaCacheDir {
+		t.Fatalf("FORMA_SCHEMA_CACHE_DIR = %q", got)
+	}
+}
+
+func assertSchemaEnvPrefix(t *testing.T, inputs resource.PropertyMap, want string) {
+	t.Helper()
+	variables := nestedObjectInput(inputs, "environment", "variables")
+	if got := propertyString(variables[resource.PropertyKey("FORMA_SCHEMA_PREFIX")]); got != want {
+		t.Fatalf("FORMA_SCHEMA_PREFIX = %q, want %q", got, want)
+	}
+}
+
+func assertSchemaPublishedPrefix(t *testing.T, inputs resource.PropertyMap, want string) {
+	t.Helper()
+	variables := nestedObjectInput(inputs, "environment", "variables")
+	if got := propertyString(variables[resource.PropertyKey("FORMA_SCHEMA_PUBLISHED_PREFIX")]); got != want {
+		t.Fatalf("FORMA_SCHEMA_PUBLISHED_PREFIX = %q, want %q", got, want)
+	}
+}
+
+func stringInput(inputs resource.PropertyMap, key string) string {
+	value, ok := inputs[resource.PropertyKey(key)]
+	if !ok {
+		return ""
+	}
+	return propertyString(value)
+}
+
+func nestedStringInput(inputs resource.PropertyMap, key string, nestedKeys ...string) string {
+	value, ok := inputs[resource.PropertyKey(key)]
+	if !ok || !value.IsObject() {
+		return ""
+	}
+	current := value.ObjectValue()
+	for i, nestedKey := range nestedKeys {
+		nestedValue, ok := current[resource.PropertyKey(nestedKey)]
+		if !ok {
+			return ""
+		}
+		if i == len(nestedKeys)-1 {
+			return propertyString(nestedValue)
+		}
+		if !nestedValue.IsObject() {
+			return ""
+		}
+		current = nestedValue.ObjectValue()
+	}
+	return ""
+}
+
+func nestedArrayStringInput(inputs resource.PropertyMap, index int, key string, nestedKeys ...string) string {
+	value, ok := inputs[resource.PropertyKey(key)]
+	if !ok || !value.IsArray() {
+		return ""
+	}
+	items := value.ArrayValue()
+	if index >= len(items) || !items[index].IsObject() {
+		return ""
+	}
+	current := items[index].ObjectValue()
+	for i, nestedKey := range nestedKeys {
+		nestedValue, ok := current[resource.PropertyKey(nestedKey)]
+		if !ok {
+			return ""
+		}
+		if i == len(nestedKeys)-1 {
+			return propertyString(nestedValue)
+		}
+		if !nestedValue.IsObject() {
+			return ""
+		}
+		current = nestedValue.ObjectValue()
+	}
+	return ""
+}
+
+func nestedObjectInput(inputs resource.PropertyMap, key string, nestedKeys ...string) resource.PropertyMap {
+	value, ok := inputs[resource.PropertyKey(key)]
+	if !ok || !value.IsObject() {
+		return resource.PropertyMap{}
+	}
+	current := value.ObjectValue()
+	for _, nestedKey := range nestedKeys {
+		nestedValue, ok := current[resource.PropertyKey(nestedKey)]
+		if !ok || !nestedValue.IsObject() {
+			return resource.PropertyMap{}
+		}
+		current = nestedValue.ObjectValue()
+	}
+	return current
+}
+
+func boolInput(inputs resource.PropertyMap, key string) bool {
+	value, ok := inputs[resource.PropertyKey(key)]
+	return ok && value.IsBool() && value.BoolValue()
+}
+
+func propertyString(value resource.PropertyValue) string {
+	if value.IsString() {
+		return value.StringValue()
+	}
+	if value.IsOutput() {
+		return propertyString(value.OutputValue().Element)
+	}
+	return ""
+}
+
+func firstDefinedString(inputs resource.PropertyMap, key string, fallback string) resource.PropertyValue {
+	if value, ok := inputs[resource.PropertyKey(key)]; ok {
+		return value
+	}
+	return resource.NewStringProperty(fallback)
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/scripts/bootstrap-deployment-repo.sh
+++ b/scripts/bootstrap-deployment-repo.sh
@@ -50,7 +50,7 @@ for name in "${required_vars[@]}"; do
   fi
 done
 
-if ! bootstrap_env_require_stack_values "${STACK}" AWS_REGION AWS_ROLE_ARN PULUMI_SECRETS_PROVIDER API_DOMAIN CONTROL_DOMAIN AUTH_DOMAIN PROJECT_ID AUTH_PROVIDER_CONFIG_FILE OIDC_ISSUER_URL JWKS_URL RUNTIME_BUCKET TABLE_NAME; then
+if ! bootstrap_env_require_stack_values "${STACK}" AWS_REGION AWS_ROLE_ARN PULUMI_SECRETS_PROVIDER API_DOMAIN CONTROL_DOMAIN AUTH_DOMAIN PROJECT_ID AUTH_PROVIDER_CONFIG_FILE OIDC_ISSUER_URL JWKS_URL RUNTIME_BUCKET SCHEMA_BUCKET TABLE_NAME; then
   exit 1
 fi
 
@@ -59,10 +59,12 @@ while IFS= read -r target_stack; do
   target_upper="$(bootstrap_env_stack_upper "${target_stack}")"
   target_region="$(bootstrap_env_resolve_stack_value AWS_REGION "${target_stack}")"
   target_secrets_provider="$(bootstrap_env_resolve_stack_value PULUMI_SECRETS_PROVIDER "${target_stack}")"
+  target_schema_bucket="$(bootstrap_env_resolve_stack_value SCHEMA_BUCKET "${target_stack}")"
   target_role_arn="$(bootstrap_env_resolve_stack_value AWS_ROLE_ARN "${target_stack}")"
 
   bootstrap_env_run_quiet gh variable set "AWS_REGION_${target_upper}" --repo "${DEPLOYMENT_REPO}" --body "${target_region}"
   bootstrap_env_run_quiet gh variable set "PULUMI_SECRETS_PROVIDER_${target_upper}" --repo "${DEPLOYMENT_REPO}" --body "${target_secrets_provider}"
+  bootstrap_env_run_quiet gh variable set "SCHEMA_BUCKET_${target_upper}" --repo "${DEPLOYMENT_REPO}" --body "${target_schema_bucket}"
   bootstrap_env_run_quiet gh secret set "AWS_ROLE_ARN_${target_upper}" --repo "${DEPLOYMENT_REPO}" --body "${target_role_arn}"
 done < <(bootstrap_env_each_stack)
 
@@ -81,6 +83,7 @@ backend_stack="$(bootstrap_env_csv_first "${PROMOTION_PATH:-${STACKS}}")"
 backend_region="$(bootstrap_env_resolve_stack_value AWS_REGION "${backend_stack}")"
 selected_secrets_provider="$(bootstrap_env_resolve_stack_value PULUMI_SECRETS_PROVIDER "${STACK}")"
 selected_runtime_bucket="$(bootstrap_env_resolve_stack_value RUNTIME_BUCKET "${STACK}")"
+selected_schema_bucket="$(bootstrap_env_resolve_stack_value SCHEMA_BUCKET "${STACK}")"
 selected_table_name="$(bootstrap_env_resolve_stack_value TABLE_NAME "${STACK}")"
 selected_api_domain="$(bootstrap_env_resolve_stack_value API_DOMAIN "${STACK}")"
 selected_control_domain="$(bootstrap_env_resolve_stack_value CONTROL_DOMAIN "${STACK}")"
@@ -121,6 +124,7 @@ else
 fi
 bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set awsRegion "${selected_region}" --stack "${STACK}"
 bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set runtimeBucket "${selected_runtime_bucket}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set schemaBucket "${selected_schema_bucket}" --stack "${STACK}"
 bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set tableName "${selected_table_name}" --stack "${STACK}"
 bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set mtlsTruststoreFile "${MTLS_TRUSTSTORE_FILE}" --stack "${STACK}"
 bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set mtlsTruststoreKey "${MTLS_TRUSTSTORE_KEY}" --stack "${STACK}"

--- a/scripts/check-pulumi-stack-config.sh
+++ b/scripts/check-pulumi-stack-config.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+STACK=""
+INFRA_DIR="infra"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --stack)
+      STACK="$2"
+      shift 2
+      ;;
+    --infra-dir)
+      INFRA_DIR="$2"
+      shift 2
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${STACK}" ]]; then
+  printf 'stack is required\n' >&2
+  exit 1
+fi
+
+stack_file="${INFRA_DIR}/Pulumi.${STACK}.yaml"
+display_path="infra/Pulumi.${STACK}.yaml"
+
+if [[ ! -f "${stack_file}" ]]; then
+  printf "Missing Pulumi stack file '%s'. Rerun bootstrap-deployment-repo.sh or restore the stack config file.\n" "${display_path}" >&2
+  exit 1
+fi
+
+required_keys=(
+  "ltbase-infra:deploymentAwsAccountId"
+  "ltbase-infra:runtimeBucket"
+  "ltbase-infra:schemaBucket"
+  "ltbase-infra:tableName"
+  "ltbase-infra:mtlsTruststoreFile"
+  "ltbase-infra:mtlsTruststoreKey"
+  "ltbase-infra:apiDomain"
+  "ltbase-infra:controlPlaneDomain"
+  "ltbase-infra:authDomain"
+  "ltbase-infra:projectId"
+  "ltbase-infra:authProviderConfigFile"
+  "ltbase-infra:cloudflareZoneId"
+  "ltbase-infra:oidcIssuerUrl"
+  "ltbase-infra:jwksUrl"
+  "ltbase-infra:releaseId"
+  "ltbase-infra:githubOrg"
+  "ltbase-infra:githubRepo"
+  "ltbase-infra:githubOidcProviderArn"
+  "ltbase-infra:geminiApiKey"
+)
+
+for key in "${required_keys[@]}"; do
+  if ! grep -Fq "  ${key}:" "${stack_file}"; then
+    printf "Missing required Pulumi config key '%s' in %s. Rerun bootstrap-deployment-repo.sh or update the stack config file.\n" "${key}" "${display_path}" >&2
+    exit 1
+  fi
+done

--- a/scripts/lib/bootstrap-env.sh
+++ b/scripts/lib/bootstrap-env.sh
@@ -198,7 +198,7 @@ bootstrap_env_require_stack_values() {
 
 bootstrap_env_apply_derivations() {
   local stack upper_name region account_id role_name
-  local role_arn_var provider_var runtime_bucket_var table_name_var
+  local role_arn_var provider_var runtime_bucket_var schema_bucket_var table_name_var
   local discovery_role_name_var discovery_role_arn_var issuer_var jwks_var
 
   if [[ -z "${DEPLOYMENT_REPO:-}" && -n "${GITHUB_OWNER:-}" && -n "${DEPLOYMENT_REPO_NAME:-}" ]]; then
@@ -256,6 +256,12 @@ bootstrap_env_apply_derivations() {
     if [[ -z "${!runtime_bucket_var:-}" && -z "${RUNTIME_BUCKET:-}" && -n "${DEPLOYMENT_REPO_NAME:-}" ]]; then
       printf -v "${runtime_bucket_var}" '%s-runtime-%s' "${DEPLOYMENT_REPO_NAME}" "${stack}"
       export "${runtime_bucket_var}"
+    fi
+
+    schema_bucket_var="SCHEMA_BUCKET_${upper_name}"
+    if [[ -z "${!schema_bucket_var:-}" && -z "${SCHEMA_BUCKET:-}" && -n "${DEPLOYMENT_REPO_NAME:-}" ]]; then
+      printf -v "${schema_bucket_var}" '%s-schema-%s' "${DEPLOYMENT_REPO_NAME}" "${stack}"
+      export "${schema_bucket_var}"
     fi
 
     table_name_var="TABLE_NAME_${upper_name}"

--- a/scripts/publish-schemas.sh
+++ b/scripts/publish-schemas.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCHEMA_DIR=""
+SCHEMA_BUCKET="${SCHEMA_BUCKET:-}"
+DRY_RUN="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --schema-dir)
+      SCHEMA_DIR="$2"
+      shift 2
+      ;;
+    --schema-bucket)
+      SCHEMA_BUCKET="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_dir="$(cd "${script_dir}/.." && pwd)"
+
+if [[ -z "${SCHEMA_DIR}" ]]; then
+  SCHEMA_DIR="${repo_dir}/customer-owned/schemas"
+fi
+
+if [[ -z "${SCHEMA_BUCKET}" ]]; then
+  printf 'schema bucket is required\n' >&2
+  exit 1
+fi
+
+if [[ ! -d "${SCHEMA_DIR}" ]]; then
+  printf 'schema directory does not exist: %s\n' "${SCHEMA_DIR}" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+published_manifest_path="${tmp_dir}/published-manifest.json"
+
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+
+trap cleanup EXIT
+
+generated_at="${PUBLISH_SCHEMAS_GENERATED_AT:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}" 
+manifest_path="${tmp_dir}/manifest.json"
+
+python3 - <<'PY' "${SCHEMA_DIR}" "${manifest_path}" "${generated_at}"
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+schema_dir = Path(sys.argv[1])
+manifest_path = Path(sys.argv[2])
+generated_at = sys.argv[3]
+
+schema_files = sorted(path for path in schema_dir.glob('*.json') if path.is_file())
+if not schema_files:
+    raise SystemExit(f'no schema files found in {schema_dir}')
+
+files = []
+version_hash = hashlib.sha256()
+for path in schema_files:
+    raw = path.read_bytes()
+    try:
+        json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f'invalid schema JSON: {path.name}: {exc}')
+
+    digest = hashlib.sha256(raw).hexdigest()
+    version_hash.update(path.name.encode('utf-8'))
+    version_hash.update(b'\0')
+    version_hash.update(digest.encode('ascii'))
+    version_hash.update(b'\0')
+    files.append({
+        'name': path.name,
+        'sha256': digest,
+    })
+
+manifest = {
+    'version': version_hash.hexdigest(),
+    'generated_at': generated_at,
+    'files': files,
+}
+manifest_path.write_text(json.dumps(manifest, indent=2) + '\n', encoding='utf-8')
+print(manifest['version'])
+PY
+
+version="$(python3 - <<'PY' "${manifest_path}"
+import json
+import sys
+
+with open(sys.argv[1], 'r', encoding='utf-8') as handle:
+    manifest = json.load(handle)
+
+print(manifest['version'])
+PY
+)"
+
+if [[ "${DRY_RUN}" == "true" ]]; then
+  printf 'validated schema bundle %s for %s\n' "${version}" "${SCHEMA_BUCKET}"
+  exit 0
+fi
+
+release_prefix="schemas/releases/${version}"
+published_prefix="schemas/published"
+
+for schema_path in "${SCHEMA_DIR}"/*.json; do
+  file_name="$(basename "${schema_path}")"
+  aws s3 cp "${schema_path}" "s3://${SCHEMA_BUCKET}/${release_prefix}/${file_name}"
+done
+aws s3 cp "${manifest_path}" "s3://${SCHEMA_BUCKET}/${release_prefix}/manifest.json"
+
+python3 - <<'PY' "${manifest_path}" "${published_manifest_path}" "${release_prefix}"
+import json
+import sys
+
+with open(sys.argv[1], 'r', encoding='utf-8') as handle:
+    manifest = json.load(handle)
+
+for item in manifest.get('files', []):
+    item['name'] = f"{sys.argv[3]}/{item['name'].strip()}"
+
+with open(sys.argv[2], 'w', encoding='utf-8') as handle:
+    json.dump(manifest, handle, indent=2)
+    handle.write('\n')
+PY
+
+aws s3 cp "${published_manifest_path}" "s3://${SCHEMA_BUCKET}/${published_prefix}/manifest.json"
+
+printf 'published schema bundle %s to %s\n' "${version}" "${SCHEMA_BUCKET}"

--- a/test/bootstrap-deployment-repo-test.sh
+++ b/test/bootstrap-deployment-repo-test.sh
@@ -149,6 +149,9 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
   assert_log_contains "${log_file}" "gh variable set AWS_REGION_DEVO --repo Lychee-Technology/ltbase-private-deployment --body ap-northeast-1"
   assert_log_contains "${log_file}" "gh variable set AWS_REGION_STAGING --repo Lychee-Technology/ltbase-private-deployment --body us-east-1"
   assert_log_contains "${log_file}" "gh variable set AWS_REGION_PROD --repo Lychee-Technology/ltbase-private-deployment --body us-west-2"
+  assert_log_contains "${log_file}" "gh variable set SCHEMA_BUCKET_DEVO --repo Lychee-Technology/ltbase-private-deployment --body ltbase-private-deployment-schema-devo"
+  assert_log_contains "${log_file}" "gh variable set SCHEMA_BUCKET_STAGING --repo Lychee-Technology/ltbase-private-deployment --body ltbase-private-deployment-schema-staging"
+  assert_log_contains "${log_file}" "gh variable set SCHEMA_BUCKET_PROD --repo Lychee-Technology/ltbase-private-deployment --body ltbase-private-deployment-schema-prod"
   assert_log_contains "${log_file}" "gh variable set STACKS --repo Lychee-Technology/ltbase-private-deployment --body devo,staging,prod"
   assert_log_contains "${log_file}" "gh variable set PROMOTION_PATH --repo Lychee-Technology/ltbase-private-deployment --body devo,staging,prod"
   assert_log_contains "${log_file}" "gh variable set PREVIEW_DEFAULT_STACK --repo Lychee-Technology/ltbase-private-deployment --body devo"
@@ -158,6 +161,7 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
   assert_log_contains "${log_file}" "AWS_REGION=ap-northeast-1 AWS_DEFAULT_REGION=ap-northeast-1 AWS_PROFILE=devo-profile pulumi login s3://test-pulumi-state"
   assert_log_contains "${log_file}" "PWD=${temp_dir}/infra AWS_REGION=us-west-2 AWS_DEFAULT_REGION=us-west-2 AWS_PROFILE=prod-profile pulumi stack init prod --secrets-provider awskms://alias/test-pulumi-secrets?region=us-west-2"
   assert_log_contains "${log_file}" "pulumi config set runtimeBucket ltbase-private-deployment-runtime-prod --stack prod"
+  assert_log_contains "${log_file}" "pulumi config set schemaBucket ltbase-private-deployment-schema-prod --stack prod"
   assert_log_contains "${log_file}" "pulumi config set apiDomain api.example.com --stack prod"
   assert_log_contains "${log_file}" "pulumi config set projectId 33333333-3333-4333-8333-333333333333 --stack prod"
   assert_log_contains "${log_file}" "pulumi config set authProviderConfigFile infra/auth-providers.prod.json --stack prod"
@@ -185,14 +189,14 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
   assert_log_contains <(printf '%s' "${output}") "NOISY GH STDOUT variable set AWS_REGION_DEVO --repo Lychee-Technology/ltbase-private-deployment --body ap-northeast-1"
   assert_log_contains <(printf '%s' "${output}") "NOISY GH STDERR variable set AWS_REGION_DEVO --repo Lychee-Technology/ltbase-private-deployment --body ap-northeast-1"
 
-  if output="$(PULUMI_FAIL_COMMAND="config set runtimeBucket ltbase-private-deployment-runtime-prod --stack prod" PATH="${fake_bin}:$PATH" "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --stack prod --infra-dir "${temp_dir}/infra" 2>&1)"; then
+  if output="$(PULUMI_FAIL_COMMAND="config set schemaBucket ltbase-private-deployment-schema-prod --stack prod" PATH="${fake_bin}:$PATH" "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --stack prod --infra-dir "${temp_dir}/infra" 2>&1)"; then
     rm -rf "${temp_dir}"
     fail "expected script to fail when pulumi fails"
   fi
 
   assert_log_contains <(printf '%s' "${output}") "[info] configuring Pulumi stack prod"
-  assert_log_contains <(printf '%s' "${output}") "NOISY PULUMI STDOUT config set runtimeBucket ltbase-private-deployment-runtime-prod --stack prod"
-  assert_log_contains <(printf '%s' "${output}") "NOISY PULUMI STDERR config set runtimeBucket ltbase-private-deployment-runtime-prod --stack prod"
+  assert_log_contains <(printf '%s' "${output}") "NOISY PULUMI STDOUT config set schemaBucket ltbase-private-deployment-schema-prod --stack prod"
+  assert_log_contains <(printf '%s' "${output}") "NOISY PULUMI STDERR config set schemaBucket ltbase-private-deployment-schema-prod --stack prod"
 
   : >"${log_file}"
   if ! output="$(PULUMI_STACK_SELECT_MODE=existing PATH="${fake_bin}:$PATH" "${SCRIPT_PATH}" --env-file "${temp_dir}/.env" --stack prod --infra-dir "${temp_dir}/infra" 2>&1)"; then

--- a/test/check-pulumi-stack-config-test.sh
+++ b/test/check-pulumi-stack-config-test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/scripts/check-pulumi-stack-config.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  if [[ "${haystack}" != *"${needle}"* ]]; then
+    fail "expected output to contain: ${needle}"
+  fi
+}
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+mkdir -p "${temp_dir}/infra"
+
+cat >"${temp_dir}/infra/Pulumi.devo.yaml" <<'EOF'
+config:
+  ltbase-infra:deploymentAwsAccountId: "123456789012"
+  ltbase-infra:runtimeBucket: example-runtime
+  ltbase-infra:schemaBucket: example-schema
+  ltbase-infra:tableName: example-table
+  ltbase-infra:mtlsTruststoreFile: infra/certs/cloudflare-origin-pull-ca.pem
+  ltbase-infra:mtlsTruststoreKey: mtls/cloudflare-origin-pull-ca.pem
+  ltbase-infra:apiDomain: api.example.com
+  ltbase-infra:controlPlaneDomain: control.example.com
+  ltbase-infra:authDomain: auth.example.com
+  ltbase-infra:projectId: 11111111-1111-4111-8111-111111111111
+  ltbase-infra:authProviderConfigFile: infra/auth-providers.devo.json
+  ltbase-infra:cloudflareZoneId: zone-123
+  ltbase-infra:oidcIssuerUrl: https://issuer.example.com/devo
+  ltbase-infra:jwksUrl: https://issuer.example.com/devo/.well-known/jwks.json
+  ltbase-infra:releaseId: v1.0.0
+  ltbase-infra:githubOrg: Lychee-Technology
+  ltbase-infra:githubRepo: ltbase-private-deployment
+  ltbase-infra:githubOidcProviderArn: arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com
+  ltbase-infra:geminiApiKey:
+    secure: test-secret
+EOF
+
+if ! output="$(${SCRIPT_PATH} --stack devo --infra-dir "${temp_dir}/infra" 2>&1)"; then
+  fail "expected success for complete config, got: ${output}"
+fi
+
+python3 - <<'PY' "${temp_dir}/infra/Pulumi.devo.yaml"
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+path.write_text(path.read_text().replace('  ltbase-infra:schemaBucket: example-schema\n', ''))
+PY
+
+if output="$(${SCRIPT_PATH} --stack devo --infra-dir "${temp_dir}/infra" 2>&1)"; then
+  fail "expected failure when schemaBucket is missing"
+fi
+
+assert_contains "${output}" "Missing required Pulumi config key 'ltbase-infra:schemaBucket'"
+assert_contains "${output}" "infra/Pulumi.devo.yaml"
+
+python3 - <<'PY' "${temp_dir}/infra/Pulumi.devo.yaml"
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+marker = '  ltbase-infra:runtimeBucket: example-runtime\n'
+path.write_text(text.replace(marker, marker + '  ltbase-infra:schemaBucket: example-schema\n'))
+PY
+
+python3 - <<'PY' "${temp_dir}/infra/Pulumi.devo.yaml"
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+path.write_text(path.read_text().replace('  ltbase-infra:deploymentAwsAccountId: "123456789012"\n', ''))
+PY
+
+if output="$(${SCRIPT_PATH} --stack devo --infra-dir "${temp_dir}/infra" 2>&1)"; then
+  fail "expected failure when deploymentAwsAccountId is missing"
+fi
+
+assert_contains "${output}" "Missing required Pulumi config key 'ltbase-infra:deploymentAwsAccountId'"
+assert_contains "${output}" "infra/Pulumi.devo.yaml"
+
+rm -f "${temp_dir}/infra/Pulumi.devo.yaml"
+
+if output="$(${SCRIPT_PATH} --stack devo --infra-dir "${temp_dir}/infra" 2>&1)"; then
+  fail "expected failure when stack file is missing"
+fi
+
+assert_contains "${output}" "Missing Pulumi stack file"
+assert_contains "${output}" "infra/Pulumi.devo.yaml"
+
+printf 'PASS: check Pulumi stack config tests\n'

--- a/test/publish-schemas-test.sh
+++ b/test/publish-schemas-test.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_PATH="${ROOT_DIR}/scripts/publish-schemas.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_file_exists() {
+  local path="$1"
+  if [[ ! -f "${path}" ]]; then
+    fail "missing file: ${path}"
+  fi
+}
+
+assert_file_contains() {
+  local path="$1"
+  local needle="$2"
+  if ! grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  if [[ "${expected}" != "${actual}" ]]; then
+    fail "expected '${expected}', got '${actual}'"
+  fi
+}
+
+assert_file_missing() {
+  local path="$1"
+  if [[ -e "${path}" ]]; then
+    fail "expected missing path: ${path}"
+  fi
+}
+
+temp_dir="$(mktemp -d)"
+fake_bin="${temp_dir}/bin"
+bucket_dir="${temp_dir}/bucket"
+schema_dir="${temp_dir}/schemas"
+log_file="${temp_dir}/aws.log"
+lead_schema="${schema_dir}/lead.json"
+visit_schema="${schema_dir}/visit.json"
+invalid_schema="${schema_dir}/broken.json"
+
+cleanup() {
+  rm -rf "${temp_dir}"
+}
+trap cleanup EXIT
+
+mkdir -p "${fake_bin}" "${bucket_dir}" "${schema_dir}"
+touch "${log_file}"
+
+cat >"${fake_bin}/aws" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+bucket_root="${FAKE_S3_ROOT:?}"
+log_file="${COMMAND_LOG:?}"
+
+printf 'aws %s\n' "$*" >>"${log_file}"
+
+if [[ "$1" != "s3" ]]; then
+  printf 'unsupported aws invocation: %s\n' "$*" >&2
+  exit 1
+fi
+
+command="$2"
+
+resolve_s3_path() {
+  local uri="$1"
+  local target bucket key
+  target="${uri#s3://}"
+  bucket="${target%%/*}"
+  key="${target#*/}"
+  if [[ "${bucket}" == "${target}" ]]; then
+    key=""
+  fi
+  printf '%s\n' "${bucket_root}/${bucket}/${key}"
+}
+
+case "${command}" in
+  cp)
+    src="$3"
+    dest="$4"
+
+    if [[ "${src}" == s3://* && "${dest}" != s3://* ]]; then
+      source_path="$(resolve_s3_path "${src}")"
+      cp "${source_path}" "${dest}"
+      exit 0
+    fi
+
+    if [[ "${dest}" != s3://* ]]; then
+      printf 'unsupported destination: %s\n' "${dest}" >&2
+      exit 1
+    fi
+
+    target_path="$(resolve_s3_path "${dest}")"
+    mkdir -p "$(dirname "${target_path}")"
+
+    if [[ -n "${FAIL_CURRENT_AFTER:-}" && "${dest}" == *"/schemas/current/"* && "${src}" != *"/current-backup/"* && "${src}" != *"/previous-current-manifest.json" ]]; then
+      count_file="${bucket_root}/.current-copy-count"
+      count=0
+      if [[ -f "${count_file}" ]]; then
+        count="$(<"${count_file}")"
+      fi
+      count=$((count + 1))
+      printf '%s' "${count}" >"${count_file}"
+      if [[ "${count}" -gt "${FAIL_CURRENT_AFTER}" ]]; then
+        printf 'simulated current publish failure for %s\n' "${dest}" >&2
+        exit 1
+      fi
+    fi
+
+    cp "${src}" "${target_path}"
+    ;;
+  rm)
+    target_path="$(resolve_s3_path "$3")"
+    rm -f "${target_path}"
+    ;;
+  *)
+    printf 'unsupported aws invocation: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${fake_bin}/aws"
+
+cat >"${lead_schema}" <<'EOF'
+{
+  "name": "lead",
+  "fields": [
+    {
+      "name": "full_name",
+      "type": "string"
+    }
+  ]
+}
+EOF
+
+cat >"${visit_schema}" <<'EOF'
+{
+  "name": "visit",
+  "fields": [
+    {
+      "name": "scheduled_at",
+      "type": "datetime"
+    }
+  ]
+}
+EOF
+
+if [[ ! -x "${SCRIPT_PATH}" ]]; then
+  fail "missing executable script: ${SCRIPT_PATH}"
+fi
+
+if ! output="$(PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" FAKE_S3_ROOT="${bucket_dir}" PUBLISH_SCHEMAS_GENERATED_AT="2026-04-18T00:00:00Z" "${SCRIPT_PATH}" --schema-dir "${schema_dir}" --schema-bucket test-schema-bucket 2>&1)"; then
+  fail "expected publish-schemas.sh to succeed, got: ${output}"
+fi
+
+manifest_path="${bucket_dir}/test-schema-bucket/schemas/published/manifest.json"
+assert_file_exists "${manifest_path}"
+
+version="$(python3 - <<'PY' "${manifest_path}"
+import json
+import sys
+
+with open(sys.argv[1], 'r', encoding='utf-8') as handle:
+    manifest = json.load(handle)
+
+print(manifest['version'])
+PY
+)"
+
+assert_file_exists "${bucket_dir}/test-schema-bucket/schemas/releases/${version}/manifest.json"
+assert_file_exists "${bucket_dir}/test-schema-bucket/schemas/releases/${version}/lead.json"
+assert_file_exists "${bucket_dir}/test-schema-bucket/schemas/releases/${version}/visit.json"
+assert_file_contains "${manifest_path}" '"generated_at": "2026-04-18T00:00:00Z"'
+assert_file_contains "${manifest_path}" '"name": "schemas/releases/'
+assert_file_contains "${manifest_path}" '/lead.json"'
+assert_file_contains "${manifest_path}" '/visit.json"'
+assert_file_contains "${log_file}" "aws s3 cp"
+assert_file_contains "${log_file}" "s3://test-schema-bucket/schemas/releases/${version}/manifest.json"
+assert_file_contains "${log_file}" "s3://test-schema-bucket/schemas/published/manifest.json"
+
+release_manifest="${bucket_dir}/test-schema-bucket/schemas/releases/${version}/manifest.json"
+release_version="$(python3 - <<'PY' "${release_manifest}"
+import json
+import sys
+
+with open(sys.argv[1], 'r', encoding='utf-8') as handle:
+    manifest = json.load(handle)
+
+print(manifest['version'])
+PY
+)"
+assert_equals "${version}" "${release_version}"
+
+cat >"${invalid_schema}" <<'EOF'
+{
+  "name": "broken",
+EOF
+
+if output="$(PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" FAKE_S3_ROOT="${bucket_dir}" "${SCRIPT_PATH}" --schema-dir "${schema_dir}" --schema-bucket test-schema-bucket 2>&1)"; then
+  fail "expected publish-schemas.sh to fail for invalid JSON"
+fi
+
+assert_file_contains <(printf '%s' "${output}") "invalid schema JSON"
+assert_file_contains <(printf '%s' "${output}") "broken.json"
+
+printf 'PASS: publish schema tests\n'

--- a/test/rollout-workflows-test.sh
+++ b/test/rollout-workflows-test.sh
@@ -41,6 +41,10 @@ assert_file_contains "${preview_workflow}" "target_stack:"
 assert_file_contains "${preview_workflow}" "manual preview only supports the first promotion stack"
 assert_file_contains "${preview_workflow}" "runs-on: ubuntu-24.04-arm"
 assert_file_contains "${preview_workflow}" "Lychee-Technology/ltbase-deploy-workflows/.github/workflows/preview-stack.yml@main"
+assert_file_contains "${preview_workflow}" "name: Validate Pulumi stack config"
+assert_file_contains "${preview_workflow}" "./scripts/check-pulumi-stack-config.sh --stack \${{ needs.prepare.outputs.target_stack }}"
+assert_file_contains "${preview_workflow}" "name: Validate customer schemas"
+assert_file_contains "${preview_workflow}" "./scripts/publish-schemas.sh --dry-run --schema-bucket"
 assert_file_contains "${preview_workflow}" "name: Audit Cloudflare mTLS"
 assert_file_contains "${preview_workflow}" "./scripts/check-cloudflare-mtls.sh --env-file .github/mTLS-audit.env --stack"
 assert_file_contains "${preview_workflow}" 'CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}'
@@ -69,9 +73,23 @@ assert_file_contains "${rollout_hop_workflow}" 'environment: ${{ needs.prepare.o
 assert_file_contains "${rollout_hop_workflow}" 'gh api repos/${{ github.repository }}/actions/workflows/rollout-hop.yml/dispatches'
 assert_file_contains "${rollout_hop_workflow}" "name: Audit Cloudflare mTLS"
 assert_file_contains "${rollout_hop_workflow}" "./scripts/check-cloudflare-mtls.sh --env-file .github/mTLS-audit.env --stack"
-assert_file_contains "${rollout_hop_workflow}" 'CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}'
-assert_file_contains "${rollout_hop_workflow}" "MTLS_TRUSTSTORE_KEY: mtls/cloudflare-origin-pull-ca.pem"
-assert_file_contains "${rollout_hop_workflow}" "reconcile_managed_dsql_endpoint: true"
+assert_file_contains "${rollout_hop_workflow}" "name: Validate Pulumi stack config"
+assert_file_contains "${rollout_hop_workflow}" "./scripts/check-pulumi-stack-config.sh --stack \${{ needs.prepare.outputs.target_stack }}"
+assert_file_contains "${rollout_hop_workflow}" "name: Publish customer schemas"
+assert_file_contains "${rollout_hop_workflow}" "./scripts/publish-schemas.sh --schema-bucket"
+assert_file_contains "${rollout_hop_workflow}" "name: Validate schema bucket contract"
+assert_file_contains "${rollout_hop_workflow}" "deployment outputs schemaBucket does not match"
+assert_file_contains "${rollout_hop_workflow}" 'SCHEMA_BUCKET: ${{ vars[format('\''SCHEMA_BUCKET_{0}'\'', needs.prepare.outputs.target_stack_upper)] }}'
+assert_file_contains "${rollout_hop_workflow}" "deployment outputs missing schemaBucket"
+assert_file_contains "${rollout_hop_workflow}" "name: Ensure project"
+assert_file_contains "${rollout_hop_workflow}" "aws lambda invoke"
+assert_file_contains "${rollout_hop_workflow}" "name: Advance applied schema pointer"
+assert_file_contains "${rollout_hop_workflow}" "s3://\${SCHEMA_BUCKET}/schemas/published/manifest.json"
+assert_file_contains "${rollout_hop_workflow}" "s3://\${SCHEMA_BUCKET}/schemas/applied/manifest.json"
+assert_file_contains "${rollout_hop_workflow}" "needs.publish_schemas.result == 'success'"
+  assert_file_contains "${rollout_hop_workflow}" 'CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}'
+  assert_file_contains "${rollout_hop_workflow}" "MTLS_TRUSTSTORE_KEY: mtls/cloudflare-origin-pull-ca.pem"
+  assert_file_contains "${rollout_hop_workflow}" "reconcile_managed_dsql_endpoint: true"
 assert_file_not_contains "${rollout_hop_workflow}" "pulumi_stack: devo"
 assert_file_not_contains "${rollout_hop_workflow}" "pulumi_stack: prod"
 


### PR DESCRIPTION
## Summary
- backport per-stack schema bucket provisioning and Lambda schema source wiring from the verified demo deployment repo into the template
- add preview validation, schema publish/apply rollout steps, and bootstrap support for `SCHEMA_BUCKET_<STACK>` plus Pulumi config contract checks
- extend docs, scripts, and regression coverage for the explicit published-vs-applied schema rollout contract

## Test Plan
- go test ./internal/config ./internal/services
- bash ./test/publish-schemas-test.sh
- bash ./test/rollout-workflows-test.sh
- bash ./test/bootstrap-deployment-repo-test.sh
- bash ./test/check-pulumi-stack-config-test.sh
- ./test/managed-dsql-consistency-test.sh