### PR TITLE
fix: preserve customer-owned data during template sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For day-2 maintenance, the generated deployment repository can sync later templa
 - `./scripts/update-sync-template-tooling.sh`
 - `./scripts/sync-template-upstream.sh`
 
-Use `./scripts/update-sync-template-tooling.sh` first when you want the latest sync helper and its regression test from the template. Then run `./scripts/sync-template-upstream.sh` to sync template-managed files. The template sync preserves local `.env` files, `infra/Pulumi.*.yaml`, customer-owned `infra/auth-providers.*.json`, and the sync helper's own script/test files.
+Use `./scripts/update-sync-template-tooling.sh` first when you want the latest sync helper and its regression test from the template. Then run `./scripts/sync-template-upstream.sh` to sync template-managed files. The template sync preserves local `.env` files, `infra/Pulumi.*.yaml`, the entire `customer-owned/` tree, customer-owned `infra/auth-providers.*.json`, and the sync helper's own script/test files.
 
 This template repository only tracks `infra/auth-providers.*.json.example`. A generated customer deployment repository should create and maintain the real `infra/auth-providers.<stack>.json` files itself, and may commit those customer-specific files in that generated repository.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -89,7 +89,7 @@ onboarding 文档支持通用多 stack 拓扑。文中出现 `devo`、`prod` 等
 - `./scripts/update-sync-template-tooling.sh`
 - `./scripts/sync-template-upstream.sh`
 
-当你希望先拿到模板中的最新同步工具和对应回归测试时，先运行 `./scripts/update-sync-template-tooling.sh`，再运行 `./scripts/sync-template-upstream.sh` 同步模板管理的文件。模板同步会保留本地 `.env`、`infra/Pulumi.*.yaml`、由 deployment repo 自行维护的 `infra/auth-providers.*.json`，以及同步工具自己的脚本与测试文件。
+当你希望先拿到模板中的最新同步工具和对应回归测试时，先运行 `./scripts/update-sync-template-tooling.sh`，再运行 `./scripts/sync-template-upstream.sh` 同步模板管理的文件。模板同步会保留本地 `.env`、`infra/Pulumi.*.yaml`、整个 `customer-owned/` 目录树、由 deployment repo 自行维护的 `infra/auth-providers.*.json`，以及同步工具自己的脚本与测试文件。
 
 此模板仓库只跟踪 `infra/auth-providers.*.json.example`。从模板生成出来的客户 deployment repo 需要自行创建并维护真实的 `infra/auth-providers.<stack>.json` 文件，并且可以在该客户仓库中提交这些客户专属文件。
 

--- a/docs/onboarding/08-day-2-operations.md
+++ b/docs/onboarding/08-day-2-operations.md
@@ -28,7 +28,7 @@ The script checks:
 
 1. If you want the latest template copy of the sync helper itself first, run `./scripts/update-sync-template-tooling.sh` from your deployment repository on a clean local `main` branch.
 2. If you want to bring in newer template-managed files, run `./scripts/sync-template-upstream.sh` from the same clean local `main` branch.
-3. Review the synced template changes. The sync preserves local `.env` files, `infra/Pulumi.*.yaml`, customer-owned `infra/auth-providers.*.json`, and the sync helper's own script/test files.
+3. Review the synced template changes. The sync preserves local `.env` files, `infra/Pulumi.*.yaml`, the entire `customer-owned/` tree, customer-owned `infra/auth-providers.*.json`, and the sync helper's own script/test files.
 4. If the generated deployment repository does not yet have a real auth provider config file for a stack, copy the matching `infra/auth-providers.<stack>.json.example` file to `infra/auth-providers.<stack>.json` in that generated repository before the next bootstrap or preview run.
 5. Update `LTBASE_RELEASE_ID` in GitHub variables, or pass a new `release_id` directly to the workflow.
 6. Run the preview workflow.

--- a/docs/onboarding/08-day-2-operations.zh.md
+++ b/docs/onboarding/08-day-2-operations.zh.md
@@ -14,7 +14,7 @@
 
 1. 如果你想先拿到模板中的最新同步工具本身，请在部署仓库干净的本地 `main` 分支上运行 `./scripts/update-sync-template-tooling.sh`。
 2. 如果你还想同步较新的模板管理文件，再在同一个干净的本地 `main` 分支上运行 `./scripts/sync-template-upstream.sh`。
-3. 审查同步进来的模板变更。模板同步会保留本地 `.env`、`infra/Pulumi.*.yaml`、由 deployment repo 自行维护的 `infra/auth-providers.*.json`，以及同步工具自己的脚本与测试文件。
+3. 审查同步进来的模板变更。模板同步会保留本地 `.env`、`infra/Pulumi.*.yaml`、整个 `customer-owned/` 目录树、由 deployment repo 自行维护的 `infra/auth-providers.*.json`，以及同步工具自己的脚本与测试文件。
 4. 如果生成出来的 deployment repo 某个 stack 还没有真实的 auth provider 配置文件，请先把对应的 `infra/auth-providers.<stack>.json.example` 复制成 `infra/auth-providers.<stack>.json`，再进行下一次 bootstrap 或 preview。
 5. 更新 GitHub variables 中的 `LTBASE_RELEASE_ID`，或在工作流中直接传入新的 `release_id`。
 6. 运行 preview 工作流。

--- a/scripts/sync-template-upstream.sh
+++ b/scripts/sync-template-upstream.sh
@@ -50,7 +50,8 @@ UPSTREAM_URL="https://github.com/Lychee-Technology/ltbase-private-deployment.git
 BRANCH="main"
 ARCHIVE_PATH="sync-template-upstream.tar"
 
-customer_owned_paths=(
+preserved_customer_owned_paths=(
+  "customer-owned"
   "infra/auth-providers.devo.json"
   "infra/auth-providers.prod.json"
 )
@@ -59,8 +60,11 @@ preserve_customer_owned_files() {
   local backup_root="$1"
   local path
 
-  for path in "${customer_owned_paths[@]}"; do
-    if [[ -f "./${path}" ]]; then
+  for path in "${preserved_customer_owned_paths[@]}"; do
+    if [[ -d "./${path}" ]]; then
+      mkdir -p "${backup_root}/$(dirname "${path}")"
+      cp -R "./${path}" "${backup_root}/${path}"
+    elif [[ -f "./${path}" ]]; then
       mkdir -p "${backup_root}/$(dirname "${path}")"
       cp "./${path}" "${backup_root}/${path}"
     fi
@@ -71,8 +75,11 @@ restore_customer_owned_files() {
   local backup_root="$1"
   local path
 
-  for path in "${customer_owned_paths[@]}"; do
-    if [[ -f "${backup_root}/${path}" ]]; then
+  for path in "${preserved_customer_owned_paths[@]}"; do
+    if [[ -d "${backup_root}/${path}" ]]; then
+      mkdir -p "./$(dirname "${path}")"
+      cp -R "${backup_root}/${path}" "./${path}"
+    elif [[ -f "${backup_root}/${path}" ]]; then
       mkdir -p "./$(dirname "${path}")"
       cp "${backup_root}/${path}" "./${path}"
     fi

--- a/test/sync-template-upstream-test.sh
+++ b/test/sync-template-upstream-test.sh
@@ -205,6 +205,9 @@ printf 'RSYNC-NOISE\n'
 printf 'RSYNC-NOISE\n' >&2
 src="${@: -2:1}"
 dest="${@: -1}"
+if [[ "${SCENARIO:-success}" == "preserve_customer_owned_directory" ]]; then
+  rm -rf "${dest}/customer-owned"
+fi
 mkdir -p "${dest}/__ref__"
 if [[ -f "${src}/__ref__/template-provenance.json" ]]; then
   /bin/cp "${src}/__ref__/template-provenance.json" "${dest}/__ref__/template-provenance.json"
@@ -391,6 +394,29 @@ run_missing_customer_auth_provider_case() {
   fi
 }
 
+run_preserves_customer_owned_directory_case() {
+  local fake_bin="$1"
+  local schema_dir="${ROOT_DIR}/customer-owned/schemas"
+  local schema_path="${schema_dir}/customer-owned.json"
+  local original_content='{"schema":"customer-owned"}'
+
+  setup_fake_git "${fake_bin}"
+  mkdir -p "${schema_dir}"
+  printf '%s\n' "${original_content}" >"${schema_path}"
+
+  if ! output="$(PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" TEMP_ROOT="${temp_dir}" SCENARIO="preserve_customer_owned_directory" "${SCRIPT_PATH}" 2>&1)"; then
+    rm -f "${schema_path}"
+    fail "expected script to preserve customer-owned directory, got: ${output}"
+  fi
+
+  assert_text_contains "${output}" "synced upstream/main into main"
+  if [[ ! -f "${schema_path}" ]]; then
+    fail "expected sync to restore customer-owned schema file"
+  fi
+  assert_log_contains "${schema_path}" "${original_content}"
+  rm -f "${schema_path}"
+}
+
 run_without_bootstrap_env_case() {
   local fake_bin="$1"
   local backup_path="${ROOT_DIR}/scripts/lib/bootstrap-env.sh.test-backup"
@@ -423,6 +449,7 @@ empty_find_bin="${temp_dir}/empty-find-bin"
 self_contained_bin="${temp_dir}/self-contained-bin"
 preserve_auth_provider_bin="${temp_dir}/preserve-auth-provider-bin"
 missing_auth_provider_bin="${temp_dir}/missing-auth-provider-bin"
+preserve_customer_owned_directory_bin="${temp_dir}/preserve-customer-owned-directory-bin"
 
 run_success_case "${success_bin}" "${log_file}"
 run_dirty_tree_case "${dirty_bin}"
@@ -433,5 +460,6 @@ run_empty_find_case "${empty_find_bin}"
 run_without_bootstrap_env_case "${self_contained_bin}"
 run_preserves_customer_auth_provider_case "${preserve_auth_provider_bin}"
 run_missing_customer_auth_provider_case "${missing_auth_provider_bin}"
+run_preserves_customer_owned_directory_case "${preserve_customer_owned_directory_bin}"
 
 printf 'PASS: sync-template-upstream tests\n'


### PR DESCRIPTION
## Summary
- preserve the entire `customer-owned/` tree when `scripts/sync-template-upstream.sh` syncs template-managed files with `rsync --delete`
- keep the existing customer auth provider file preservation in the same explicit preserved path list
- add a regression test and update English/Chinese docs to match the new preservation behavior

## Test Plan
- [x] `bash ./test/sync-template-upstream-test.sh`