### PR TITLE
fix: restore customer-owned files without nesting

### DIFF
--- a/scripts/sync-template-upstream.sh
+++ b/scripts/sync-template-upstream.sh
@@ -78,7 +78,7 @@ restore_customer_owned_files() {
   for path in "${preserved_customer_owned_paths[@]}"; do
     if [[ -d "${backup_root}/${path}" ]]; then
       mkdir -p "./$(dirname "${path}")"
-      cp -R "${backup_root}/${path}" "./${path}"
+      cp -R "${backup_root}/${path}" "./$(dirname "${path}")"
     elif [[ -f "${backup_root}/${path}" ]]; then
       mkdir -p "./$(dirname "${path}")"
       cp "${backup_root}/${path}" "./${path}"

--- a/test/sync-template-upstream-test.sh
+++ b/test/sync-template-upstream-test.sh
@@ -207,6 +207,9 @@ src="${@: -2:1}"
 dest="${@: -1}"
 if [[ "${SCENARIO:-success}" == "preserve_customer_owned_directory" ]]; then
   rm -rf "${dest}/customer-owned"
+elif [[ "${SCENARIO:-success}" == "preserve_customer_owned_directory_contents_only" ]]; then
+  rm -rf "${dest}/customer-owned"
+  mkdir -p "${dest}/customer-owned"
 fi
 mkdir -p "${dest}/__ref__"
 if [[ -f "${src}/__ref__/template-provenance.json" ]]; then
@@ -417,6 +420,35 @@ run_preserves_customer_owned_directory_case() {
   rm -f "${schema_path}"
 }
 
+run_preserves_customer_owned_directory_contents_case() {
+  local fake_bin="$1"
+  local schema_dir="${ROOT_DIR}/customer-owned/schemas"
+  local schema_path="${schema_dir}/customer-owned-contents.json"
+  local nested_schema_path="${ROOT_DIR}/customer-owned/customer-owned/schemas/customer-owned-contents.json"
+  local original_content='{"schema":"customer-owned-contents"}'
+
+  setup_fake_git "${fake_bin}"
+  rm -rf "${ROOT_DIR}/customer-owned/customer-owned"
+  mkdir -p "${schema_dir}"
+  printf '%s\n' "${original_content}" >"${schema_path}"
+
+  if ! output="$(PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" TEMP_ROOT="${temp_dir}" SCENARIO="preserve_customer_owned_directory_contents_only" "${SCRIPT_PATH}" 2>&1)"; then
+    rm -f "${schema_path}"
+    fail "expected script to preserve customer-owned directory contents, got: ${output}"
+  fi
+
+  assert_text_contains "${output}" "synced upstream/main into main"
+  if [[ ! -f "${schema_path}" ]]; then
+    fail "expected sync to restore customer-owned schema file in place"
+  fi
+  if [[ -e "${nested_schema_path}" ]]; then
+    rm -f "${schema_path}"
+    fail "expected sync to avoid nesting restored customer-owned data"
+  fi
+  assert_log_contains "${schema_path}" "${original_content}"
+  rm -f "${schema_path}"
+}
+
 run_without_bootstrap_env_case() {
   local fake_bin="$1"
   local backup_path="${ROOT_DIR}/scripts/lib/bootstrap-env.sh.test-backup"
@@ -450,6 +482,7 @@ self_contained_bin="${temp_dir}/self-contained-bin"
 preserve_auth_provider_bin="${temp_dir}/preserve-auth-provider-bin"
 missing_auth_provider_bin="${temp_dir}/missing-auth-provider-bin"
 preserve_customer_owned_directory_bin="${temp_dir}/preserve-customer-owned-directory-bin"
+preserve_customer_owned_directory_contents_bin="${temp_dir}/preserve-customer-owned-directory-contents-bin"
 
 run_success_case "${success_bin}" "${log_file}"
 run_dirty_tree_case "${dirty_bin}"
@@ -461,5 +494,6 @@ run_without_bootstrap_env_case "${self_contained_bin}"
 run_preserves_customer_auth_provider_case "${preserve_auth_provider_bin}"
 run_missing_customer_auth_provider_case "${missing_auth_provider_bin}"
 run_preserves_customer_owned_directory_case "${preserve_customer_owned_directory_bin}"
+run_preserves_customer_owned_directory_contents_case "${preserve_customer_owned_directory_contents_bin}"
 
 printf 'PASS: sync-template-upstream tests\n'


### PR DESCRIPTION
## Summary
- fix `scripts/sync-template-upstream.sh` so restoring a preserved directory copies it back to the parent path instead of nesting it under `customer-owned/customer-owned/`
- add a regression test that simulates `rsync --delete` leaving an empty `customer-owned/` directory behind
- verify preserved customer-owned schema files are restored in place without creating nested directories

## Test Plan
- [x] `bash ./test/sync-template-upstream-test.sh`