### PR TITLE
fix rollout follow-up job gating

### DIFF
--- a/.github/workflows/rollout-hop.yml
+++ b/.github/workflows/rollout-hop.yml
@@ -204,7 +204,7 @@ jobs:
     needs:
       - prepare
       - rollout
-    if: ${{ needs.rollout.result == 'success' }}
+    if: ${{ always() && needs.rollout.result == 'success' }}
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -225,7 +225,7 @@ jobs:
       - prepare
       - rollout
       - publish_schemas
-    if: ${{ needs.rollout.result == 'success' && needs.publish_schemas.result == 'success' }}
+    if: ${{ always() && needs.rollout.result == 'success' && needs.publish_schemas.result == 'success' }}
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Configure AWS credentials
@@ -329,7 +329,7 @@ jobs:
     needs:
       - prepare
       - ensure_project
-    if: ${{ needs.ensure_project.result == 'success' }}
+    if: ${{ always() && needs.ensure_project.result == 'success' }}
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
@@ -375,8 +375,9 @@ jobs:
   dispatch_next:
     needs:
       - prepare
+      - ensure_project
       - audit_mtls
-    if: ${{ needs.ensure_project.result == 'success' && needs.prepare.outputs.continue_chain == 'true' && needs.prepare.outputs.next_stack != '' }}
+    if: ${{ always() && needs.ensure_project.result == 'success' && needs.prepare.outputs.continue_chain == 'true' && needs.prepare.outputs.next_stack != '' }}
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Continue rollout chain

--- a/test/rollout-workflows-test.sh
+++ b/test/rollout-workflows-test.sh
@@ -15,7 +15,7 @@ assert_file_contains() {
   if [[ ! -f "${path}" ]]; then
     fail "missing file: ${path}"
   fi
-  if ! grep -Fq "${needle}" "${path}"; then
+  if ! grep -Fq -- "${needle}" "${path}"; then
     fail "expected ${path} to contain: ${needle}"
   fi
 }
@@ -26,7 +26,7 @@ assert_file_not_contains() {
   if [[ ! -f "${path}" ]]; then
     fail "missing file: ${path}"
   fi
-  if grep -Fq "${needle}" "${path}"; then
+  if grep -Fq -- "${needle}" "${path}"; then
     fail "expected ${path} to not contain: ${needle}"
   fi
 }
@@ -77,6 +77,7 @@ assert_file_contains "${rollout_hop_workflow}" "name: Validate Pulumi stack conf
 assert_file_contains "${rollout_hop_workflow}" "./scripts/check-pulumi-stack-config.sh --stack \${{ needs.prepare.outputs.target_stack }}"
 assert_file_contains "${rollout_hop_workflow}" "name: Publish customer schemas"
 assert_file_contains "${rollout_hop_workflow}" "./scripts/publish-schemas.sh --schema-bucket"
+assert_file_contains "${rollout_hop_workflow}" 'if: ${{ always() && needs.rollout.result == '\''success'\'' }}'
 assert_file_contains "${rollout_hop_workflow}" "name: Validate schema bucket contract"
 assert_file_contains "${rollout_hop_workflow}" "deployment outputs schemaBucket does not match"
 assert_file_contains "${rollout_hop_workflow}" 'SCHEMA_BUCKET: ${{ vars[format('\''SCHEMA_BUCKET_{0}'\'', needs.prepare.outputs.target_stack_upper)] }}'
@@ -86,7 +87,11 @@ assert_file_contains "${rollout_hop_workflow}" "aws lambda invoke"
 assert_file_contains "${rollout_hop_workflow}" "name: Advance applied schema pointer"
 assert_file_contains "${rollout_hop_workflow}" "s3://\${SCHEMA_BUCKET}/schemas/published/manifest.json"
 assert_file_contains "${rollout_hop_workflow}" "s3://\${SCHEMA_BUCKET}/schemas/applied/manifest.json"
+assert_file_contains "${rollout_hop_workflow}" 'if: ${{ always() && needs.rollout.result == '\''success'\'' && needs.publish_schemas.result == '\''success'\'' }}'
 assert_file_contains "${rollout_hop_workflow}" "needs.publish_schemas.result == 'success'"
+assert_file_contains "${rollout_hop_workflow}" 'if: ${{ always() && needs.ensure_project.result == '\''success'\'' }}'
+assert_file_contains "${rollout_hop_workflow}" "- ensure_project"
+assert_file_contains "${rollout_hop_workflow}" "if: \${{ always() && needs.ensure_project.result == 'success' && needs.prepare.outputs.continue_chain == 'true' && needs.prepare.outputs.next_stack != '' }}"
 assert_file_contains "${rollout_hop_workflow}" 'CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}'
 assert_file_contains "${rollout_hop_workflow}" "MTLS_TRUSTSTORE_KEY: mtls/cloudflare-origin-pull-ca.pem"
 assert_file_contains "${rollout_hop_workflow}" "reconcile_managed_dsql_endpoint: true"


### PR DESCRIPTION
## Summary
- add `always()` to rollout follow-up jobs so `publish_schemas` and later jobs are not pruned when `approve` is skipped for the first stack
- add `ensure_project` to `dispatch_next` needs so its condition only references declared dependencies
- extend rollout workflow regression coverage and harden the grep helper for needles starting with `-`

## Verification
- `bash test/rollout-workflows-test.sh`