### PR TITLE
read mTLS audit inputs from Pulumi stack config

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -101,23 +101,57 @@ jobs:
         env:
           STACKS: ${{ vars.STACKS || 'devo,prod' }}
           PROMOTION_PATH: ${{ vars.PROMOTION_PATH || vars.STACKS || 'devo,prod' }}
-          AWS_REGION: ${{ vars[format('AWS_REGION_{0}', needs.prepare.outputs.target_stack_upper)] }}
-          API_DOMAIN: ${{ vars[format('API_DOMAIN_{0}', needs.prepare.outputs.target_stack_upper)] }}
-          CONTROL_DOMAIN: ${{ vars[format('CONTROL_DOMAIN_{0}', needs.prepare.outputs.target_stack_upper)] }}
-          AUTH_DOMAIN: ${{ vars[format('AUTH_DOMAIN_{0}', needs.prepare.outputs.target_stack_upper)] }}
-          RUNTIME_BUCKET: ${{ vars[format('RUNTIME_BUCKET_{0}', needs.prepare.outputs.target_stack_upper)] }}
-          CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
           MTLS_TRUSTSTORE_KEY: mtls/cloudflare-origin-pull-ca.pem
         run: |
+          stack_file="infra/Pulumi.${{ needs.prepare.outputs.target_stack }}.yaml"
+          if [[ ! -f "${stack_file}" ]]; then
+            echo "Missing Pulumi stack file ${stack_file}" >&2
+            exit 1
+          fi
+
+          extract_stack_value() {
+            local config_key="$1"
+            local raw_line value
+
+            raw_line="$(grep -E "^[[:space:]]*${config_key}:[[:space:]]*" "${stack_file}" | head -n 1 || true)"
+            if [[ -z "${raw_line}" ]]; then
+              return 0
+            fi
+
+            value="${raw_line#*: }"
+            value="${value#*:}"
+            value="${value# }"
+            value="${value%\"}"
+            value="${value#\"}"
+            printf '%s' "${value}"
+          }
+
+          aws_region="$(extract_stack_value "ltbase-infra:awsRegion")"
+          api_domain="$(extract_stack_value "ltbase-infra:apiDomain")"
+          control_domain="$(extract_stack_value "ltbase-infra:controlPlaneDomain")"
+          auth_domain="$(extract_stack_value "ltbase-infra:authDomain")"
+          runtime_bucket="$(extract_stack_value "ltbase-infra:runtimeBucket")"
+          cloudflare_zone_id="$(extract_stack_value "ltbase-infra:cloudflareZoneId")"
+
+          if [[ -z "${aws_region}" || -z "${api_domain}" || -z "${control_domain}" || -z "${auth_domain}" || -z "${runtime_bucket}" ]]; then
+            echo "Required mTLS audit values missing from ${stack_file}" >&2
+            exit 1
+          fi
+
+          if [[ -z "${cloudflare_zone_id}" ]]; then
+            echo "Cloudflare zone ID missing from ${stack_file}" >&2
+            exit 1
+          fi
+
           cat > .github/mTLS-audit.env <<EOF
           STACKS=${STACKS}
           PROMOTION_PATH=${PROMOTION_PATH}
-          AWS_REGION_${{ needs.prepare.outputs.target_stack_upper }}=${AWS_REGION}
-          API_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${API_DOMAIN}
-          CONTROL_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${CONTROL_DOMAIN}
-          AUTH_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${AUTH_DOMAIN}
-          RUNTIME_BUCKET_${{ needs.prepare.outputs.target_stack_upper }}=${RUNTIME_BUCKET}
-          CLOUDFLARE_ZONE_ID=${CLOUDFLARE_ZONE_ID}
+          AWS_REGION_${{ needs.prepare.outputs.target_stack_upper }}=${aws_region}
+          API_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${api_domain}
+          CONTROL_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${control_domain}
+          AUTH_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${auth_domain}
+          RUNTIME_BUCKET_${{ needs.prepare.outputs.target_stack_upper }}=${runtime_bucket}
+          CLOUDFLARE_ZONE_ID=${cloudflare_zone_id}
           MTLS_TRUSTSTORE_KEY=${MTLS_TRUSTSTORE_KEY}
           EOF
 

--- a/.github/workflows/rollout-hop.yml
+++ b/.github/workflows/rollout-hop.yml
@@ -347,23 +347,57 @@ jobs:
         env:
           STACKS: ${{ vars.STACKS || 'devo,prod' }}
           PROMOTION_PATH: ${{ vars.PROMOTION_PATH || vars.STACKS || 'devo,prod' }}
-          AWS_REGION: ${{ vars[format('AWS_REGION_{0}', needs.prepare.outputs.target_stack_upper)] }}
-          API_DOMAIN: ${{ vars[format('API_DOMAIN_{0}', needs.prepare.outputs.target_stack_upper)] }}
-          CONTROL_DOMAIN: ${{ vars[format('CONTROL_DOMAIN_{0}', needs.prepare.outputs.target_stack_upper)] }}
-          AUTH_DOMAIN: ${{ vars[format('AUTH_DOMAIN_{0}', needs.prepare.outputs.target_stack_upper)] }}
-          RUNTIME_BUCKET: ${{ vars[format('RUNTIME_BUCKET_{0}', needs.prepare.outputs.target_stack_upper)] }}
-          CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}
           MTLS_TRUSTSTORE_KEY: mtls/cloudflare-origin-pull-ca.pem
         run: |
+          stack_file="infra/Pulumi.${{ needs.prepare.outputs.target_stack }}.yaml"
+          if [[ ! -f "${stack_file}" ]]; then
+            echo "Missing Pulumi stack file ${stack_file}" >&2
+            exit 1
+          fi
+
+          extract_stack_value() {
+            local config_key="$1"
+            local raw_line value
+
+            raw_line="$(grep -E "^[[:space:]]*${config_key}:[[:space:]]*" "${stack_file}" | head -n 1 || true)"
+            if [[ -z "${raw_line}" ]]; then
+              return 0
+            fi
+
+            value="${raw_line#*: }"
+            value="${value#*:}"
+            value="${value# }"
+            value="${value%\"}"
+            value="${value#\"}"
+            printf '%s' "${value}"
+          }
+
+          aws_region="$(extract_stack_value "ltbase-infra:awsRegion")"
+          api_domain="$(extract_stack_value "ltbase-infra:apiDomain")"
+          control_domain="$(extract_stack_value "ltbase-infra:controlPlaneDomain")"
+          auth_domain="$(extract_stack_value "ltbase-infra:authDomain")"
+          runtime_bucket="$(extract_stack_value "ltbase-infra:runtimeBucket")"
+          cloudflare_zone_id="$(extract_stack_value "ltbase-infra:cloudflareZoneId")"
+
+          if [[ -z "${aws_region}" || -z "${api_domain}" || -z "${control_domain}" || -z "${auth_domain}" || -z "${runtime_bucket}" ]]; then
+            echo "Required mTLS audit values missing from ${stack_file}" >&2
+            exit 1
+          fi
+
+          if [[ -z "${cloudflare_zone_id}" ]]; then
+            echo "Cloudflare zone ID missing from ${stack_file}" >&2
+            exit 1
+          fi
+
           cat > .github/mTLS-audit.env <<EOF
           STACKS=${STACKS}
           PROMOTION_PATH=${PROMOTION_PATH}
-          AWS_REGION_${{ needs.prepare.outputs.target_stack_upper }}=${AWS_REGION}
-          API_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${API_DOMAIN}
-          CONTROL_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${CONTROL_DOMAIN}
-          AUTH_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${AUTH_DOMAIN}
-          RUNTIME_BUCKET_${{ needs.prepare.outputs.target_stack_upper }}=${RUNTIME_BUCKET}
-          CLOUDFLARE_ZONE_ID=${CLOUDFLARE_ZONE_ID}
+          AWS_REGION_${{ needs.prepare.outputs.target_stack_upper }}=${aws_region}
+          API_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${api_domain}
+          CONTROL_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${control_domain}
+          AUTH_DOMAIN_${{ needs.prepare.outputs.target_stack_upper }}=${auth_domain}
+          RUNTIME_BUCKET_${{ needs.prepare.outputs.target_stack_upper }}=${runtime_bucket}
+          CLOUDFLARE_ZONE_ID=${cloudflare_zone_id}
           MTLS_TRUSTSTORE_KEY=${MTLS_TRUSTSTORE_KEY}
           EOF
 

--- a/docs/CUSTOMER_ONBOARDING.md
+++ b/docs/CUSTOMER_ONBOARDING.md
@@ -95,7 +95,8 @@ Before you run any bootstrap automation, confirm all of the following:
   - Test each account access before bootstrap, for example `AWS_PROFILE_STAGING=customer-staging aws sts get-caller-identity`.
   - Remember that the shared Pulumi backend bucket is created in the AWS account for the first stack in `PROMOTION_PATH`, so the credentials for that stack must be able to create and manage the bucket.
 - Cloudflare inputs are ready.
-  - Confirm `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_ZONE_ID`, `CLOUDFLARE_API_TOKEN`, and `OIDC_DISCOVERY_DOMAIN` are final.
+  - Confirm `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_ZONE_ID`, `CLOUDFLARE_API_TOKEN`, and `OIDC_DISCOVERY_DOMAIN` are final in `.env` before bootstrap.
+  - Confirm bootstrap has written the expected per-stack mTLS audit inputs into `infra/Pulumi.<stack>.yaml`, including `ltbase-infra:awsRegion`, domains, `ltbase-infra:runtimeBucket`, and `ltbase-infra:cloudflareZoneId`, because preview and rollout mTLS audits read those stored stack config values.
   - Confirm the token can manage the Pages project and custom domain that bootstrap creates for OIDC discovery.
   - If the operator account or token does not meet the minimum permission matrix, use the manual path instead of one-click bootstrap.
   - Confirm the zone can proxy the `api`, `auth`, and `control-plane` hostnames through Cloudflare.

--- a/docs/CUSTOMER_ONBOARDING.zh.md
+++ b/docs/CUSTOMER_ONBOARDING.zh.md
@@ -95,7 +95,8 @@
   - 在 bootstrap 前测试每个账户访问，例如 `AWS_PROFILE_STAGING=customer-staging aws sts get-caller-identity`。
   - 记住共享的 Pulumi backend bucket 会创建在 `PROMOTION_PATH` 第一个 stack 对应的 AWS 账户里，因此该 stack 的凭据必须能够创建和管理这个 bucket。
 - Cloudflare 输入值已经准备好。
-  - 确认 `CLOUDFLARE_ACCOUNT_ID`、`CLOUDFLARE_ZONE_ID`、`CLOUDFLARE_API_TOKEN` 和 `OIDC_DISCOVERY_DOMAIN` 都已经定稿。
+  - 确认 `.env` 中的 `CLOUDFLARE_ACCOUNT_ID`、`CLOUDFLARE_ZONE_ID`、`CLOUDFLARE_API_TOKEN` 和 `OIDC_DISCOVERY_DOMAIN` 都已经定稿。
+  - 确认 bootstrap 已把每个 stack 所需的 mTLS audit 输入写入 `infra/Pulumi.<stack>.yaml`，包括 `ltbase-infra:awsRegion`、各域名、`ltbase-infra:runtimeBucket` 和 `ltbase-infra:cloudflareZoneId`；preview 与 rollout 的 mTLS audit 会读取这里保存的值。
   - 确认该 token 可以管理 bootstrap 将创建的 OIDC discovery Cloudflare Pages 项目和自定义域名绑定。
   - 如果操作者账号或 token 不满足最小权限矩阵，请改用手动路径，而不是直接执行一键 bootstrap。
   - 确认该 zone 可以将 `api`、`auth`、`control-plane` 这些 hostname 通过 Cloudflare 代理出去。

--- a/docs/onboarding/04-prepare-env-file.md
+++ b/docs/onboarding/04-prepare-env-file.md
@@ -56,12 +56,13 @@ Use this guide to create the local `.env` file that drives the bootstrap scripts
      - `API_DOMAIN_<STACK>`
      - `CONTROL_DOMAIN_<STACK>`
      - `AUTH_DOMAIN_<STACK>`
-    - `PROJECT_ID`
-    - `AUTH_PROVIDER_CONFIG_FILE_<STACK>`
-    - `CLOUDFLARE_ZONE_ID`
-    - Source: your final DNS plan in the target Cloudflare zone
-    - For `AUTH_PROVIDER_CONFIG_FILE_<STACK>`, point to a checked-in JSON file that lists the external JWT providers enabled for that stack.
-    - Start by copying `infra/auth-providers.<stack>.json.example` to `infra/auth-providers.<stack>.json`, then edit the real file in the generated customer deployment repository.
+     - `PROJECT_ID`
+     - `AUTH_PROVIDER_CONFIG_FILE_<STACK>`
+     - `CLOUDFLARE_ZONE_ID`
+     - Source: your final DNS plan in the target Cloudflare zone
+     - Bootstrap uses `CLOUDFLARE_ZONE_ID` from `.env` when it writes each `infra/Pulumi.<stack>.yaml` stack config. Preview and rollout mTLS audits then read `ltbase-infra:awsRegion`, `ltbase-infra:apiDomain`, `ltbase-infra:controlPlaneDomain`, `ltbase-infra:authDomain`, `ltbase-infra:runtimeBucket`, and `ltbase-infra:cloudflareZoneId` from that stack file.
+     - For `AUTH_PROVIDER_CONFIG_FILE_<STACK>`, point to a checked-in JSON file that lists the external JWT providers enabled for that stack.
+     - Start by copying `infra/auth-providers.<stack>.json.example` to `infra/auth-providers.<stack>.json`, then edit the real file in the generated customer deployment repository.
 10. Fill in application defaults:
     - `GEMINI_MODEL`
     - `DSQL_PORT`, `DSQL_DB`, `DSQL_USER`, `DSQL_PROJECT_SCHEMA`
@@ -90,6 +91,7 @@ These values are customer-controlled inputs and should usually be set explicitly
 - `LTBASE_RELEASES_REPO`, `LTBASE_RELEASE_ID`
 - `MTLS_TRUSTSTORE_FILE`, `MTLS_TRUSTSTORE_KEY` with the template defaults intact
 - `API_DOMAIN_<STACK>`, `CONTROL_DOMAIN_<STACK>`, `AUTH_DOMAIN_<STACK>`, `PROJECT_ID`, `AUTH_PROVIDER_CONFIG_FILE_<STACK>`, `CLOUDFLARE_ZONE_ID`
+  - `CLOUDFLARE_ZONE_ID` is still a manual bootstrap input in `.env`, but preview and rollout mTLS audits consume per-stack values stored in `infra/Pulumi.<stack>.yaml`, including `ltbase-infra:cloudflareZoneId`, domains, `awsRegion`, and `runtimeBucket`.
 - `GEMINI_MODEL`, `DSQL_PORT`, `DSQL_DB`, `DSQL_USER`, `DSQL_PROJECT_SCHEMA`
 - `GEMINI_API_KEY`, `CLOUDFLARE_API_TOKEN`, `LTBASE_RELEASES_TOKEN`
 

--- a/docs/onboarding/04-prepare-env-file.zh.md
+++ b/docs/onboarding/04-prepare-env-file.zh.md
@@ -56,12 +56,13 @@
      - `API_DOMAIN_<STACK>`
      - `CONTROL_DOMAIN_<STACK>`
      - `AUTH_DOMAIN_<STACK>`
-    - `PROJECT_ID`
-    - `AUTH_PROVIDER_CONFIG_FILE_<STACK>`
-    - `CLOUDFLARE_ZONE_ID`
-    - 来源：你在目标 Cloudflare zone 中规划好的最终域名
-    - `AUTH_PROVIDER_CONFIG_FILE_<STACK>` 应该指向一个已提交的 JSON 文件，该文件列出该 stack 启用的外部 JWT provider。
-    - 先把 `infra/auth-providers.<stack>.json.example` 复制成 `infra/auth-providers.<stack>.json`，再在生成出来的客户 deployment repo 中编辑这个真实文件。
+     - `PROJECT_ID`
+     - `AUTH_PROVIDER_CONFIG_FILE_<STACK>`
+     - `CLOUDFLARE_ZONE_ID`
+     - 来源：你在目标 Cloudflare zone 中规划好的最终域名
+     - bootstrap 会从 `.env` 里的 `CLOUDFLARE_ZONE_ID` 写入每个 `infra/Pulumi.<stack>.yaml` stack 配置；后续 preview 与 rollout 的 mTLS audit 会从该 stack 文件中读取 `ltbase-infra:awsRegion`、`ltbase-infra:apiDomain`、`ltbase-infra:controlPlaneDomain`、`ltbase-infra:authDomain`、`ltbase-infra:runtimeBucket` 和 `ltbase-infra:cloudflareZoneId`。
+     - `AUTH_PROVIDER_CONFIG_FILE_<STACK>` 应该指向一个已提交的 JSON 文件，该文件列出该 stack 启用的外部 JWT provider。
+     - 先把 `infra/auth-providers.<stack>.json.example` 复制成 `infra/auth-providers.<stack>.json`，再在生成出来的客户 deployment repo 中编辑这个真实文件。
 10. 填写应用默认值：
     - `GEMINI_MODEL`
     - `DSQL_PORT`、`DSQL_DB`、`DSQL_USER`、`DSQL_PROJECT_SCHEMA`
@@ -85,6 +86,7 @@
 - `LTBASE_RELEASES_REPO`、`LTBASE_RELEASE_ID`
 - 保持模板默认值不变的 `MTLS_TRUSTSTORE_FILE`、`MTLS_TRUSTSTORE_KEY`
 - `API_DOMAIN_<STACK>`、`CONTROL_DOMAIN_<STACK>`、`AUTH_DOMAIN_<STACK>`、`PROJECT_ID`、`AUTH_PROVIDER_CONFIG_FILE_<STACK>`、`CLOUDFLARE_ZONE_ID`
+  - `CLOUDFLARE_ZONE_ID` 仍然是 `.env` 中需要手动提供的 bootstrap 输入，但 preview 与 rollout 的 mTLS audit 实际读取的是 `infra/Pulumi.<stack>.yaml` 里保存的每个 stack 值，包括 `ltbase-infra:cloudflareZoneId`、域名、`awsRegion` 和 `runtimeBucket`。
 - `GEMINI_MODEL`、`DSQL_PORT`、`DSQL_DB`、`DSQL_USER`、`DSQL_PROJECT_SCHEMA`
 - `GEMINI_API_KEY`、`CLOUDFLARE_API_TOKEN`、`LTBASE_RELEASES_TOKEN`
 

--- a/docs/onboarding/06-bootstrap-manual.md
+++ b/docs/onboarding/06-bootstrap-manual.md
@@ -138,7 +138,7 @@ After each stack, confirm:
 
 Before you run this stage, confirm:
 
-- `OIDC_DISCOVERY_DOMAIN`, `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_ZONE_ID`, and `CLOUDFLARE_API_TOKEN` are correct
+- `OIDC_DISCOVERY_DOMAIN`, `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_ZONE_ID`, and `CLOUDFLARE_API_TOKEN` in `.env` are correct
 - you are ready for the script to create or update the companion repository, Pages project, custom domain binding, and required DNS `CNAME`
 
 Run:

--- a/docs/onboarding/06-bootstrap-manual.zh.md
+++ b/docs/onboarding/06-bootstrap-manual.zh.md
@@ -137,7 +137,7 @@ source dist/foundation.env
 
 执行前确认：
 
-- `OIDC_DISCOVERY_DOMAIN`、`CLOUDFLARE_ACCOUNT_ID`、`CLOUDFLARE_API_TOKEN` 已确认无误
+- `.env` 中的 `OIDC_DISCOVERY_DOMAIN`、`CLOUDFLARE_ACCOUNT_ID`、`CLOUDFLARE_ZONE_ID`、`CLOUDFLARE_API_TOKEN` 已确认无误
 - 你已经准备好让脚本创建或更新 Cloudflare Pages 项目、自定义域名绑定和 companion 仓库
 
 执行：

--- a/docs/onboarding/08-day-2-operations.md
+++ b/docs/onboarding/08-day-2-operations.md
@@ -16,6 +16,8 @@ Run `./scripts/check-cloudflare-mtls.sh --env-file .env --stack <stack>` from th
 
 The preview workflow and the rollout hop workflow both run this audit automatically after a successful job and fail if the Cloudflare or API Gateway mTLS posture drifts.
 
+For local runs, keep `.env` and `infra/Pulumi.<stack>.yaml` aligned. The workflow audit reads `ltbase-infra:awsRegion`, `ltbase-infra:apiDomain`, `ltbase-infra:controlPlaneDomain`, `ltbase-infra:authDomain`, `ltbase-infra:runtimeBucket`, and `ltbase-infra:cloudflareZoneId` from `infra/Pulumi.<stack>.yaml`, while the standalone script still expects those values in the env file you pass.
+
 The script checks:
 
 - Cloudflare proxying for `api`, `auth`, and `control-plane`

--- a/docs/onboarding/08-day-2-operations.zh.md
+++ b/docs/onboarding/08-day-2-operations.zh.md
@@ -10,6 +10,22 @@
 
 ## 常见操作
 
+### 审计 Cloudflare mTLS 连通性
+
+当你需要只读方式审计 Cloudflare 到 API Gateway 的 mTLS 链路时，请在 deployment repository 中运行 `./scripts/check-cloudflare-mtls.sh --env-file .env --stack <stack>`。
+
+preview workflow 与 rollout hop workflow 会在成功完成后自动运行这项审计；如果 Cloudflare 或 API Gateway 的 mTLS 配置发生漂移，工作流会直接失败。
+
+本地执行时，请保持 `.env` 与 `infra/Pulumi.<stack>.yaml` 一致。workflow 中的审计会从 `infra/Pulumi.<stack>.yaml` 读取 `ltbase-infra:awsRegion`、`ltbase-infra:apiDomain`、`ltbase-infra:controlPlaneDomain`、`ltbase-infra:authDomain`、`ltbase-infra:runtimeBucket` 和 `ltbase-infra:cloudflareZoneId`，而你手动执行脚本时，脚本仍然要求你传入的 env 文件中包含这些值。
+
+脚本会检查：
+
+- `api`、`auth`、`control-plane` 三个域名是否都通过 Cloudflare 代理
+- Cloudflare SSL 模式是否为 `Full (strict)`
+- Cloudflare Authenticated Origin Pulls 是否已启用
+- 该 stack 的 runtime bucket 中是否存在 truststore 对象
+- 每个 API Gateway 自定义域名是否报告了预期的 mutual TLS truststore URI 与版本
+
 ### 升级到新的 LTBase release
 
 1. 如果你想先拿到模板中的最新同步工具本身，请在部署仓库干净的本地 `main` 分支上运行 `./scripts/update-sync-template-tooling.sh`。

--- a/test/rollout-workflows-test.sh
+++ b/test/rollout-workflows-test.sh
@@ -47,7 +47,17 @@ assert_file_contains "${preview_workflow}" "name: Validate customer schemas"
 assert_file_contains "${preview_workflow}" "./scripts/publish-schemas.sh --dry-run --schema-bucket"
 assert_file_contains "${preview_workflow}" "name: Audit Cloudflare mTLS"
 assert_file_contains "${preview_workflow}" "./scripts/check-cloudflare-mtls.sh --env-file .github/mTLS-audit.env --stack"
-assert_file_contains "${preview_workflow}" 'CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}'
+assert_file_contains "${preview_workflow}" 'stack_file="infra/Pulumi.${{ needs.prepare.outputs.target_stack }}.yaml"'
+assert_file_contains "${preview_workflow}" 'extract_stack_value() {'
+assert_file_contains "${preview_workflow}" 'raw_line="$(grep -E "^[[:space:]]*${config_key}:[[:space:]]*" "${stack_file}" | head -n 1 || true)"'
+assert_file_contains "${preview_workflow}" 'aws_region="$(extract_stack_value "ltbase-infra:awsRegion")"'
+assert_file_contains "${preview_workflow}" 'api_domain="$(extract_stack_value "ltbase-infra:apiDomain")"'
+assert_file_contains "${preview_workflow}" 'control_domain="$(extract_stack_value "ltbase-infra:controlPlaneDomain")"'
+assert_file_contains "${preview_workflow}" 'auth_domain="$(extract_stack_value "ltbase-infra:authDomain")"'
+assert_file_contains "${preview_workflow}" 'runtime_bucket="$(extract_stack_value "ltbase-infra:runtimeBucket")"'
+assert_file_contains "${preview_workflow}" 'cloudflare_zone_id="$(extract_stack_value "ltbase-infra:cloudflareZoneId")"'
+assert_file_contains "${preview_workflow}" 'Required mTLS audit values missing from ${stack_file}'
+assert_file_contains "${preview_workflow}" 'Cloudflare zone ID missing from ${stack_file}'
 assert_file_contains "${rollout_hop_workflow}" "Lychee-Technology/ltbase-deploy-workflows/.github/workflows/rollout-hop.yml@main"
 
 assert_file_contains "${deploy_workflow}" "uses: ./.github/workflows/rollout-hop.yml"
@@ -92,7 +102,17 @@ assert_file_contains "${rollout_hop_workflow}" "needs.publish_schemas.result == 
 assert_file_contains "${rollout_hop_workflow}" 'if: ${{ always() && needs.ensure_project.result == '\''success'\'' }}'
 assert_file_contains "${rollout_hop_workflow}" "- ensure_project"
 assert_file_contains "${rollout_hop_workflow}" "if: \${{ always() && needs.ensure_project.result == 'success' && needs.prepare.outputs.continue_chain == 'true' && needs.prepare.outputs.next_stack != '' }}"
-assert_file_contains "${rollout_hop_workflow}" 'CLOUDFLARE_ZONE_ID: ${{ vars.CLOUDFLARE_ZONE_ID }}'
+assert_file_contains "${rollout_hop_workflow}" 'stack_file="infra/Pulumi.${{ needs.prepare.outputs.target_stack }}.yaml"'
+assert_file_contains "${rollout_hop_workflow}" 'extract_stack_value() {'
+assert_file_contains "${rollout_hop_workflow}" 'raw_line="$(grep -E "^[[:space:]]*${config_key}:[[:space:]]*" "${stack_file}" | head -n 1 || true)"'
+assert_file_contains "${rollout_hop_workflow}" 'aws_region="$(extract_stack_value "ltbase-infra:awsRegion")"'
+assert_file_contains "${rollout_hop_workflow}" 'api_domain="$(extract_stack_value "ltbase-infra:apiDomain")"'
+assert_file_contains "${rollout_hop_workflow}" 'control_domain="$(extract_stack_value "ltbase-infra:controlPlaneDomain")"'
+assert_file_contains "${rollout_hop_workflow}" 'auth_domain="$(extract_stack_value "ltbase-infra:authDomain")"'
+assert_file_contains "${rollout_hop_workflow}" 'runtime_bucket="$(extract_stack_value "ltbase-infra:runtimeBucket")"'
+assert_file_contains "${rollout_hop_workflow}" 'cloudflare_zone_id="$(extract_stack_value "ltbase-infra:cloudflareZoneId")"'
+assert_file_contains "${rollout_hop_workflow}" 'Required mTLS audit values missing from ${stack_file}'
+assert_file_contains "${rollout_hop_workflow}" 'Cloudflare zone ID missing from ${stack_file}'
 assert_file_contains "${rollout_hop_workflow}" "MTLS_TRUSTSTORE_KEY: mtls/cloudflare-origin-pull-ca.pem"
 assert_file_contains "${rollout_hop_workflow}" "reconcile_managed_dsql_endpoint: true"
 assert_file_not_contains "${rollout_hop_workflow}" "pulumi_stack: devo"


### PR DESCRIPTION
## Summary
- update preview and rollout mTLS audit jobs to read required inputs from `infra/Pulumi.<stack>.yaml` instead of GitHub Actions variables
- add workflow coverage for Pulumi-derived audit inputs and friendly missing-config failures
- sync onboarding and operations docs in English and Chinese to explain that bootstrap writes these values into the Pulumi stack config and workflow audits read them from there

## Verification
- bash test/rollout-workflows-test.sh
- bash test/check-cloudflare-mtls-test.sh