### PR TITLE
clarify Cloudflare token permissions for mTLS audit

### DIFF
--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -109,4 +109,5 @@ Manual path:
 - the template now assumes `api`, `auth`, and `control-plane` are served through Cloudflare-proxied custom domains
 - set Cloudflare SSL mode to `Full (strict)` before enabling production traffic
 - enable Cloudflare Authenticated Origin Pulls before expecting API Gateway mTLS to succeed
+- make sure `CLOUDFLARE_API_TOKEN` can also read Cloudflare zone settings if you want preview and rollout mTLS audits to verify those checks
 - direct `execute-api` access is expected to fail once the mTLS rollout is applied

--- a/docs/BOOTSTRAP.zh.md
+++ b/docs/BOOTSTRAP.zh.md
@@ -109,4 +109,5 @@
 - 当前模板默认假设 `api`、`auth`、`control-plane` 都通过 Cloudflare 代理的自定义域名对外提供访问
 - 在承载正式流量前，将 Cloudflare SSL 模式设置为 `Full (strict)`
 - 在期待 API Gateway mTLS 生效前，先启用 Cloudflare Authenticated Origin Pulls
+- 如果你希望 preview 与 rollout 的 mTLS audit 能验证这些检查项，确认 `CLOUDFLARE_API_TOKEN` 也具备读取 Cloudflare zone settings 的权限
 - 一旦应用 mTLS rollout，直接访问 `execute-api` endpoint 失败属于预期行为

--- a/docs/onboarding/01-prerequisites.md
+++ b/docs/onboarding/01-prerequisites.md
@@ -152,6 +152,8 @@ The `CLOUDFLARE_API_TOKEN` used for bootstrap must be able to:
 - read and create custom domain bindings for the OIDC discovery Pages project
 - read and create the `CNAME` record for `OIDC_DISCOVERY_DOMAIN` in `CLOUDFLARE_ZONE_ID`
 
+If you want preview and rollout mTLS audits to check Cloudflare SSL mode and Authenticated Origin Pulls successfully, that token must also be able to read zone settings for `CLOUDFLARE_ZONE_ID`.
+
 This is enough for bootstrap to check whether the Pages project, domain binding, and required Pages `CNAME` already exist, then create them if needed.
 
 ### 4. Confirm local tools

--- a/docs/onboarding/01-prerequisites.zh.md
+++ b/docs/onboarding/01-prerequisites.zh.md
@@ -152,6 +152,8 @@ bootstrap 使用的 `CLOUDFLARE_API_TOKEN` 至少需要能够：
 - 读取和创建 OIDC discovery Pages 项目的自定义域名绑定
 - 管理 `OIDC_DISCOVERY_DOMAIN` 所在的目标 zone
 
+如果你希望 preview 与 rollout 的 mTLS audit 能成功检查 Cloudflare SSL 模式和 Authenticated Origin Pulls，这个 token 还必须具备读取 `CLOUDFLARE_ZONE_ID` 对应 zone settings 的权限。
+
 这样 bootstrap 才能先检查 Pages project 和 domain binding 是否已存在，并在缺失时创建它们。
 
 ### 4. 确认本地工具

--- a/scripts/check-cloudflare-mtls.sh
+++ b/scripts/check-cloudflare-mtls.sh
@@ -73,7 +73,7 @@ fail_check() {
 cloudflare_get_json() {
   local url="$1"
   local action="$2"
-  local response_file status response success
+  local response_file status response success error_codes
 
   response_file="$(mktemp)"
   if ! status="$(curl -sS -o "${response_file}" -w '%{http_code}' "${cloudflare_headers[@]}" "${url}")"; then
@@ -88,6 +88,14 @@ cloudflare_get_json() {
   if [[ "${status}" != "200" ]]; then
     printf 'Cloudflare API request failed: %s (HTTP %s)\n' "${action}" "${status}" >&2
     printf '%s\n' "${response}" >&2
+    if [[ "${status}" == "403" ]]; then
+      error_codes="$(printf '%s' "${response}" | jq -r '[.errors[]?.code // empty] | join(",")' 2>/dev/null || true)"
+      case ",${error_codes}," in
+        *,9109,*|*,10000,*)
+          printf 'Cloudflare token may be missing zone settings read permissions required for mTLS audit.\n' >&2
+          ;;
+      esac
+    fi
     return 1
   fi
 

--- a/test/check-cloudflare-mtls-test.sh
+++ b/test/check-cloudflare-mtls-test.sh
@@ -91,18 +91,28 @@ body='{"success":true,"result":{}}'
 
 case "${url}" in
   *"/zones/zone-123/settings/ssl")
-    ssl_value="strict"
-    if [[ "${SCENARIO}" == "failure" ]]; then
-      ssl_value="full"
+    if [[ "${SCENARIO}" == "forbidden-settings" ]]; then
+      status="403"
+      body='{"success":false,"errors":[{"code":9109,"message":"Unauthorized to access requested resource"}],"messages":[],"result":null}'
+    else
+      ssl_value="strict"
+      if [[ "${SCENARIO}" == "failure" ]]; then
+        ssl_value="full"
+      fi
+      body="{\"success\":true,\"result\":{\"id\":\"ssl\",\"value\":\"${ssl_value}\"}}"
     fi
-    body="{\"success\":true,\"result\":{\"id\":\"ssl\",\"value\":\"${ssl_value}\"}}"
     ;;
   *"/zones/zone-123/settings/tls_client_auth")
-    aop_value="on"
-    if [[ "${SCENARIO}" == "failure" ]]; then
-      aop_value="off"
+    if [[ "${SCENARIO}" == "forbidden-settings" ]]; then
+      status="403"
+      body='{"success":false,"errors":[{"code":10000,"message":"Authentication error"}],"messages":[],"result":null}'
+    else
+      aop_value="on"
+      if [[ "${SCENARIO}" == "failure" ]]; then
+        aop_value="off"
+      fi
+      body="{\"success\":true,\"result\":{\"id\":\"tls_client_auth\",\"value\":\"${aop_value}\"}}"
     fi
-    body="{\"success\":true,\"result\":{\"id\":\"tls_client_auth\",\"value\":\"${aop_value}\"}}"
     ;;
   *"/zones/zone-123/origin_tls_client_auth")
     result='[]'
@@ -225,6 +235,15 @@ assert_log_contains <(printf '%s' "${output}") "FAIL Cloudflare SSL mode is Full
 assert_log_contains <(printf '%s' "${output}") "FAIL Cloudflare Authenticated Origin Pulls is enabled: got off"
 assert_log_contains <(printf '%s' "${output}") "FAIL AWS truststore object exists: s3://customer-ltbase-runtime-prod/mtls/cloudflare-origin-pull-ca.pem"
 assert_log_contains <(printf '%s' "${output}") "FAIL API Gateway domain control.example.com mutual TLS truststore matches: got s3://customer-ltbase-runtime-prod/mtls/unexpected.pem"
+
+if output="$(PATH="${fake_bin}:$PATH" COMMAND_LOG="${log_file}" SCENARIO=forbidden-settings "${SCRIPT_PATH}" --env-file "${env_file}" --stack prod 2>&1)"; then
+  rm -rf "${temp_dir}"
+  fail "expected forbidden-settings scenario to exit non-zero"
+fi
+
+assert_log_contains <(printf '%s' "${output}") "Cloudflare token may be missing zone settings read permissions required for mTLS audit."
+assert_log_contains <(printf '%s' "${output}") "FAIL Cloudflare SSL mode is Full (strict): lookup failed"
+assert_log_contains <(printf '%s' "${output}") "FAIL Cloudflare Authenticated Origin Pulls is enabled: lookup failed"
 
 rm -rf "${temp_dir}"
 printf 'PASS: check-cloudflare-mtls tests\n'


### PR DESCRIPTION
## Summary
- add a clearer error hint when Cloudflare mTLS audit requests fail with 403 permission errors on zone settings endpoints
- cover the permission-denied scenario in `check-cloudflare-mtls` tests
- document that preview and rollout mTLS audits need Cloudflare token access to read zone settings, not just DNS

## Operator Note
If `audit_mtls` shows DNS checks passing but Cloudflare SSL mode / Authenticated Origin Pulls checks failing with HTTP 403, the most likely cause is insufficient `CLOUDFLARE_API_TOKEN` permissions.

The token used by preview and rollout must be able to:
- read DNS records in the target zone
- read Cloudflare zone settings in the target zone

Without zone settings read access, the audit can still resolve DNS records but will fail when it checks:
- SSL mode
- Authenticated Origin Pulls

The script now prints this hint when Cloudflare returns the known permission errors:
`Cloudflare token may be missing zone settings read permissions required for mTLS audit.`

## Verification
- bash test/check-cloudflare-mtls-test.sh
- bash test/rollout-workflows-test.sh