### PR TITLE
fix: pass PROJECT_ID to authservice lambda

### DIFF
--- a/infra/internal/services/lambda.go
+++ b/infra/internal/services/lambda.go
@@ -176,6 +176,7 @@ func NewLambdaServices(ctx *pulumi.Context, cfg config.StackConfig, runtime *Run
 
 func authLambdaEnv(cfg config.StackConfig, providerNames []string, authKeyID pulumi.StringInput, tableName pulumi.StringInput, bucketName pulumi.StringInput) pulumi.StringMap {
 	return mergeEnv(commonLambdaEnv(cfg, tableName, bucketName), pulumi.StringMap{
+		"PROJECT_ID":                pulumi.String(cfg.ProjectID),
 		"AUTH_SIGNER_MODE":          pulumi.String("kms"),
 		"AUTH_KMS_KEY_ID":           authKeyID,
 		"AUTH_STAGE":                pulumi.String(cfg.AuthStage),

--- a/infra/internal/services/lambda_test.go
+++ b/infra/internal/services/lambda_test.go
@@ -92,6 +92,23 @@ func TestAuthLambdaEnvIncludesProviderNames(t *testing.T) {
 	}
 }
 
+func TestAuthLambdaEnvIncludesProjectID(t *testing.T) {
+	env := authLambdaEnv(config.StackConfig{
+		Stack:             "devo",
+		ProjectID:         "33333333-3333-4333-8333-333333333333",
+		APIDomain:         "api.devo.example.com",
+		AWSRegion:         "ap-northeast-1",
+		DSQLPort:          "5432",
+		DSQLDB:            "postgres",
+		DSQLUser:          "admin",
+		DSQLProjectSchema: "ltbase",
+	}, []string{"firebase"}, pulumi.String("kms-key-id"), pulumi.String("table-name"), pulumi.String("bucket-name"))
+
+	if _, ok := env["PROJECT_ID"]; !ok {
+		t.Fatal("authLambdaEnv() missing PROJECT_ID")
+	}
+}
+
 func TestControlPlaneLambdaEnvIncludesBootstrapProjectConfig(t *testing.T) {
 	env := controlPlaneLambdaEnv(config.StackConfig{
 		Stack:                  "devo",


### PR DESCRIPTION
## Summary
- pass `PROJECT_ID` through the authservice Lambda environment so authservice cold start matches the runtime config contract in `ltbase.api`
- add a focused regression test proving `authLambdaEnv(...)` includes `PROJECT_ID`

## Verification
- `go test ./internal/services -run TestAuthLambdaEnvIncludesProjectID`
- `go test ./internal/services`
- `./test/managed-dsql-consistency-test.sh`