### PR TITLE
feat(auth): add LTBaseRefresh JWT authorizer for refresh endpoint

### DIFF
--- a/infra/internal/services/apigateway.go
+++ b/infra/internal/services/apigateway.go
@@ -103,6 +103,14 @@ func ltbaseAuthorizerSpec(cfg config.StackConfig) authorizerSpec {
 	}
 }
 
+func ltbaseRefreshAuthorizerSpec(cfg config.StackConfig) authorizerSpec {
+	return authorizerSpec{
+		Name:      "LTBaseRefresh",
+		Issuer:    cfg.OIDCIssuerURL,
+		Audiences: []string{"https://" + cfg.AuthDomain},
+	}
+}
+
 func buildAPIRouteSpecs() []routeSpec {
 	return []routeSpec{
 		{RouteKey: "GET /api/ai/v1/notes", AuthorizerName: "LTBase"},
@@ -151,7 +159,7 @@ func routeAliases(cfg config.StackConfig, suffix string, spec routeSpec) []pulum
 }
 
 func buildAuthAuthorizerSpecs(cfg config.StackConfig, providerCfg AuthProviderConfig) []authorizerSpec {
-	specs := []authorizerSpec{ltbaseAuthorizerSpec(cfg)}
+	specs := []authorizerSpec{ltbaseAuthorizerSpec(cfg), ltbaseRefreshAuthorizerSpec(cfg)}
 	for _, provider := range providerCfg.Providers {
 		specs = append(specs, authorizerSpec{
 			Name:      provider.Name,
@@ -165,7 +173,7 @@ func buildAuthAuthorizerSpecs(cfg config.StackConfig, providerCfg AuthProviderCo
 func buildAuthRouteSpecs(providerCfg AuthProviderConfig) []routeSpec {
 	routes := []routeSpec{
 		{RouteKey: "GET /api/v1/auth/health"},
-		{RouteKey: "POST /api/v1/auth/refresh", AuthorizerName: "LTBase"},
+		{RouteKey: "POST /api/v1/auth/refresh", AuthorizerName: "LTBaseRefresh"},
 	}
 	for _, provider := range providerCfg.Providers {
 		if provider.EnableIDBinding {

--- a/infra/internal/services/apigateway_test.go
+++ b/infra/internal/services/apigateway_test.go
@@ -40,15 +40,18 @@ func TestBuildAuthProviderAuthorizerSpecs(t *testing.T) {
 			{Name: "firebase", Issuer: "https://issuer.example.com", Audiences: []string{"aud-1"}, EnableLogin: true, EnableIDBinding: true},
 		},
 	}
-	authorizers := buildAuthAuthorizerSpecs(config.StackConfig{OIDCIssuerURL: "https://oidc.example.com/devo", ProjectID: "11111111-1111-4111-8111-111111111111"}, providerCfg)
-	if len(authorizers) != 2 {
-		t.Fatalf("authorizer count = %d, want 2", len(authorizers))
+	authorizers := buildAuthAuthorizerSpecs(config.StackConfig{OIDCIssuerURL: "https://oidc.example.com/devo", ProjectID: "11111111-1111-4111-8111-111111111111", AuthDomain: "auth.example.com"}, providerCfg)
+	if len(authorizers) != 3 {
+		t.Fatalf("authorizer count = %d, want 3", len(authorizers))
 	}
 	if authorizers[0].Name != "LTBase" {
 		t.Fatalf("first authorizer = %q, want LTBase", authorizers[0].Name)
 	}
-	if authorizers[1].Name != "firebase" {
-		t.Fatalf("provider authorizer = %q, want firebase", authorizers[1].Name)
+	if authorizers[1].Name != "LTBaseRefresh" {
+		t.Fatalf("second authorizer = %q, want LTBaseRefresh", authorizers[1].Name)
+	}
+	if authorizers[2].Name != "firebase" {
+		t.Fatalf("provider authorizer = %q, want firebase", authorizers[2].Name)
 	}
 }
 
@@ -66,7 +69,7 @@ func TestBuildAuthRouteSpecs(t *testing.T) {
 	if routes[0].RouteKey != "GET /api/v1/auth/health" || routes[0].AuthorizerName != "" {
 		t.Fatalf("unexpected health route: %#v", routes[0])
 	}
-	if routes[1].RouteKey != "POST /api/v1/auth/refresh" || routes[1].AuthorizerName != "LTBase" {
+	if routes[1].RouteKey != "POST /api/v1/auth/refresh" || routes[1].AuthorizerName != "LTBaseRefresh" {
 		t.Fatalf("unexpected refresh route: %#v", routes[1])
 	}
 	if routes[4].RouteKey != "POST /api/v1/login/apple" {
@@ -194,6 +197,22 @@ func TestLTBaseAuthorizerSpecUsesIssuerAndProjectID(t *testing.T) {
 	}
 	if len(spec.Audiences) != 1 || spec.Audiences[0] != "11111111-1111-4111-8111-111111111111" {
 		t.Fatalf("ltbaseAuthorizerSpec() audiences = %#v", spec.Audiences)
+	}
+}
+
+func TestLTBaseRefreshAuthorizerSpecUsesAuthDomain(t *testing.T) {
+	spec := ltbaseRefreshAuthorizerSpec(config.StackConfig{
+		OIDCIssuerURL: "https://oidc.example.com/devo",
+		AuthDomain:    "auth.example.com",
+	})
+	if spec.Name != "LTBaseRefresh" {
+		t.Fatalf("ltbaseRefreshAuthorizerSpec() name = %q", spec.Name)
+	}
+	if spec.Issuer != "https://oidc.example.com/devo" {
+		t.Fatalf("ltbaseRefreshAuthorizerSpec() issuer = %q", spec.Issuer)
+	}
+	if len(spec.Audiences) != 1 || spec.Audiences[0] != "https://auth.example.com" {
+		t.Fatalf("ltbaseRefreshAuthorizerSpec() audiences = %#v", spec.Audiences)
 	}
 }
 

--- a/infra/internal/services/lambda.go
+++ b/infra/internal/services/lambda.go
@@ -183,6 +183,7 @@ func authLambdaEnv(cfg config.StackConfig, providerNames []string, authKeyID pul
 		"AUTH_ISSUER":               pulumi.String(cfg.OIDCIssuerURL),
 		"AUTH_JWKS_FILE_PATH":       pulumi.String("/var/task/jwt/jwks.json"),
 		"AUTH_DEFAULT_API_BASE_URL": pulumi.String("https://" + cfg.APIDomain),
+		"AUTH_ACCESS_AUD":           pulumi.String("https://" + cfg.AuthDomain),
 		"AUTH_PROVIDERS":            pulumi.String(strings.Join(providerNames, ",")),
 	})
 }


### PR DESCRIPTION
## Summary
- Add `ltbaseRefreshAuthorizerSpec` — JWT authorizer with `audiences: ["https://<authDomain>"]`
- Switch `POST /api/v1/auth/refresh` route from `"LTBase"` to `"LTBaseRefresh"` authorizer
- Add `AUTH_ACCESS_AUD` env var to auth Lambda (`https://<authDomain>`)
- Update tests

## Related
- `Lychee-Technology/ltbase.api#118` (source code PR — access token audience array changes)