### PR TITLE
feat: include upper/lower case project_id as JWT authorizer audiences

### DIFF
--- a/__ref__/plan/2026-04-27-ltbase-authorizer-case-variant-audiences.md
+++ b/__ref__/plan/2026-04-27-ltbase-authorizer-case-variant-audiences.md
@@ -1,0 +1,12 @@
+# LTBase Authorizer: Add Case-Variant Audiences
+
+**Date:** 2026-04-27
+**Goal:** Make the data plane API Gateway JWT authorizer accept the project ID as audience in original, uppercase, and lowercase forms (deduplicated).
+
+**Change:** `ltbaseAuthorizerSpec` currently sets `Audiences: []string{cfg.ProjectID}`. After this change it will include `project_id`, `upper(project_id)`, and `lower(project_id)` with duplicates removed.
+
+**Files:**
+- Modify: `infra/internal/services/apigateway.go`
+- Modify: `infra/internal/services/apigateway_test.go`
+
+**Rationale:** JWT `aud` claim casing can vary across clients and identity providers. By accepting all three forms, the authorizer covers common casing mismatches without requiring clients to normalize.

--- a/infra/internal/services/apigateway.go
+++ b/infra/internal/services/apigateway.go
@@ -95,11 +95,24 @@ type httpAPIDomainConfig struct {
 	Truststore mtlsTruststore
 }
 
+func ltbaseProjectAudiences(projectID string) []string {
+	upper := strings.ToUpper(projectID)
+	lower := strings.ToLower(projectID)
+	out := []string{projectID}
+	if upper != projectID {
+		out = append(out, upper)
+	}
+	if lower != projectID && lower != upper {
+		out = append(out, lower)
+	}
+	return out
+}
+
 func ltbaseAuthorizerSpec(cfg config.StackConfig) authorizerSpec {
 	return authorizerSpec{
 		Name:      "LTBase",
 		Issuer:    cfg.OIDCIssuerURL,
-		Audiences: []string{cfg.ProjectID},
+		Audiences: ltbaseProjectAudiences(cfg.ProjectID),
 	}
 }
 

--- a/infra/internal/services/apigateway_test.go
+++ b/infra/internal/services/apigateway_test.go
@@ -200,6 +200,61 @@ func TestLTBaseAuthorizerSpecUsesIssuerAndProjectID(t *testing.T) {
 	}
 }
 
+func TestLTBaseProjectAudiencesAllLower(t *testing.T) {
+	aud := ltbaseProjectAudiences("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+	if len(aud) != 2 {
+		t.Fatalf("ltbaseProjectAudiences(all-lower) len = %d, want 2; got %#v", len(aud), aud)
+	}
+	if aud[0] != "a1b2c3d4-e5f6-7890-abcd-ef1234567890" {
+		t.Fatalf("original = %q", aud[0])
+	}
+	if aud[1] != "A1B2C3D4-E5F6-7890-ABCD-EF1234567890" {
+		t.Fatalf("upper = %q", aud[1])
+	}
+}
+
+func TestLTBaseProjectAudiencesAllUpper(t *testing.T) {
+	aud := ltbaseProjectAudiences("A1B2C3D4-E5F6-7890-ABCD-EF1234567890")
+	if len(aud) != 2 {
+		t.Fatalf("ltbaseProjectAudiences(all-upper) len = %d, want 2; got %#v", len(aud), aud)
+	}
+	if aud[0] != "A1B2C3D4-E5F6-7890-ABCD-EF1234567890" {
+		t.Fatalf("original = %q", aud[0])
+	}
+	if aud[1] != "a1b2c3d4-e5f6-7890-abcd-ef1234567890" {
+		t.Fatalf("lower = %q", aud[1])
+	}
+}
+
+func TestLTBaseProjectAudiencesMixedCase(t *testing.T) {
+	aud := ltbaseProjectAudiences("A1b2C3d4-E5f6-7890-AbcD-Ef1234567890")
+	if len(aud) != 3 {
+		t.Fatalf("ltbaseProjectAudiences(mixed-case) len = %d, want 3; got %#v", len(aud), aud)
+	}
+	if aud[0] != "A1b2C3d4-E5f6-7890-AbcD-Ef1234567890" {
+		t.Fatalf("original = %q", aud[0])
+	}
+	if aud[1] != "A1B2C3D4-E5F6-7890-ABCD-EF1234567890" {
+		t.Fatalf("upper = %q", aud[1])
+	}
+	if aud[2] != "a1b2c3d4-e5f6-7890-abcd-ef1234567890" {
+		t.Fatalf("lower = %q", aud[2])
+	}
+}
+
+func TestLTBaseProjectAudiencesNoDuplicates(t *testing.T) {
+	aud := ltbaseProjectAudiences("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	if len(aud) != 2 {
+		t.Fatalf("ltbaseProjectAudiences(all-lower) len = %d, want 2; got %#v", len(aud), aud)
+	}
+	if aud[0] != "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" {
+		t.Fatalf("original = %q", aud[0])
+	}
+	if aud[1] != "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE" {
+		t.Fatalf("upper = %q", aud[1])
+	}
+}
+
 func TestLTBaseRefreshAuthorizerSpecUsesAuthDomain(t *testing.T) {
 	spec := ltbaseRefreshAuthorizerSpec(config.StackConfig{
 		OIDCIssuerURL: "https://oidc.example.com/devo",


### PR DESCRIPTION
## Summary

- Add `ltbaseProjectAudiences` helper that returns deduplicated `project_id`, `upper(project_id)`, and `lower(project_id)`
- Update `ltbaseAuthorizerSpec` to use it so the LTBase JWT authorizer accepts any casing of the project ID as audience
- Add 4 new tests covering all-lower, all-upper, mixed-case, and no-duplicate scenarios

## Why

JWT `aud` claim casing can vary across clients and identity providers. By accepting all three forms, the authorizer covers common casing mismatches without requiring clients to normalize.