### PR TITLE
feat(auth): set AUTH_REFRESH_AUD in authLambdaEnv

### DIFF
--- a/infra/internal/services/lambda.go
+++ b/infra/internal/services/lambda.go
@@ -184,6 +184,7 @@ func authLambdaEnv(cfg config.StackConfig, providerNames []string, authKeyID pul
 		"AUTH_JWKS_FILE_PATH":       pulumi.String("/var/task/jwt/jwks.json"),
 		"AUTH_DEFAULT_API_BASE_URL": pulumi.String("https://" + cfg.APIDomain),
 		"AUTH_ACCESS_AUD":           pulumi.String("https://" + cfg.AuthDomain),
+		"AUTH_REFRESH_AUD":          pulumi.String("https://" + cfg.AuthDomain),
 		"AUTH_PROVIDERS":            pulumi.String(strings.Join(providerNames, ",")),
 	})
 }

--- a/infra/internal/services/lambda_test.go
+++ b/infra/internal/services/lambda_test.go
@@ -78,6 +78,7 @@ func TestAuthLambdaEnvIncludesProviderNames(t *testing.T) {
 	env := authLambdaEnv(config.StackConfig{
 		Stack:             "devo",
 		APIDomain:         "api.devo.example.com",
+		AuthDomain:        "auth.devo.example.com",
 		AWSRegion:         "ap-northeast-1",
 		DSQLPort:          "5432",
 		DSQLDB:            "postgres",
@@ -86,13 +87,16 @@ func TestAuthLambdaEnvIncludesProviderNames(t *testing.T) {
 		OIDCIssuerURL:     "https://oidc.example.com/devo",
 	}, []string{"firebase", "supabase"}, pulumi.String("kms-key-id"), pulumi.String("table-name"), pulumi.String("bucket-name"))
 
-	for _, key := range []string{"AUTH_PROVIDERS", "AUTH_SIGNER_MODE", "AUTH_KMS_KEY_ID", "AUTH_ISSUER"} {
+	for _, key := range []string{"AUTH_PROVIDERS", "AUTH_SIGNER_MODE", "AUTH_KMS_KEY_ID", "AUTH_ISSUER", "AUTH_REFRESH_AUD"} {
 		if _, ok := env[key]; !ok {
 			t.Fatalf("authLambdaEnv() missing %s", key)
 		}
 	}
 	if env["AUTH_ISSUER"] != pulumi.String("https://oidc.example.com/devo") {
 		t.Fatalf("authLambdaEnv() AUTH_ISSUER = %v, want https://oidc.example.com/devo", env["AUTH_ISSUER"])
+	}
+	if env["AUTH_REFRESH_AUD"] != pulumi.String("https://auth.devo.example.com") {
+		t.Fatalf("authLambdaEnv() AUTH_REFRESH_AUD = %v, want https://auth.devo.example.com", env["AUTH_REFRESH_AUD"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `AUTH_REFRESH_AUD=https://{AuthDomain}` to `authLambdaEnv` so the authservice receives its own URL as the refresh token audience
- Update test to verify the new env var is present and correct

## Test Plan
- `TestAuthLambdaEnvIncludesProviderNames` now asserts `AUTH_REFRESH_AUD == "https://auth.devo.example.com"`
- All 43 services tests pass