### PR TITLE
feat(auth): pass AUTH_JWKS_URL to authservice lambda

### DIFF
--- a/infra/internal/services/lambda.go
+++ b/infra/internal/services/lambda.go
@@ -181,7 +181,7 @@ func authLambdaEnv(cfg config.StackConfig, providerNames []string, authKeyID pul
 		"AUTH_KMS_KEY_ID":           authKeyID,
 		"AUTH_STAGE":                pulumi.String(cfg.AuthStage),
 		"AUTH_ISSUER":               pulumi.String(cfg.OIDCIssuerURL),
-		"AUTH_JWKS_FILE_PATH":       pulumi.String("/var/task/jwt/jwks.json"),
+		"AUTH_JWKS_URL":             pulumi.String(cfg.JWKSURL),
 		"AUTH_DEFAULT_API_BASE_URL": pulumi.String("https://" + cfg.APIDomain),
 		"AUTH_ACCESS_AUD":           pulumi.String("https://" + cfg.AuthDomain),
 		"AUTH_REFRESH_AUD":          pulumi.String("https://" + cfg.AuthDomain),

--- a/infra/internal/services/lambda_test.go
+++ b/infra/internal/services/lambda_test.go
@@ -87,7 +87,7 @@ func TestAuthLambdaEnvIncludesProviderNames(t *testing.T) {
 		OIDCIssuerURL:     "https://oidc.example.com/devo",
 	}, []string{"firebase", "supabase"}, pulumi.String("kms-key-id"), pulumi.String("table-name"), pulumi.String("bucket-name"))
 
-	for _, key := range []string{"AUTH_PROVIDERS", "AUTH_SIGNER_MODE", "AUTH_KMS_KEY_ID", "AUTH_ISSUER", "AUTH_REFRESH_AUD"} {
+	for _, key := range []string{"AUTH_PROVIDERS", "AUTH_SIGNER_MODE", "AUTH_KMS_KEY_ID", "AUTH_ISSUER", "AUTH_REFRESH_AUD", "AUTH_JWKS_URL"} {
 		if _, ok := env[key]; !ok {
 			t.Fatalf("authLambdaEnv() missing %s", key)
 		}


### PR DESCRIPTION
## Summary
- Replace `AUTH_JWKS_FILE_PATH=/var/task/jwt/jwks.json` with `AUTH_JWKS_URL=<cfg.JWKSURL>`
- Update test to verify `AUTH_JWKS_URL` is present in auth lambda env
- Paired with https://github.com/Lychee-Technology/ltbase.api/pull/120