### PR TITLE
fix: set pages production branch on bootstrap

### DIFF
--- a/scripts/bootstrap-controlplane-ui-companion.sh
+++ b/scripts/bootstrap-controlplane-ui-companion.sh
@@ -76,6 +76,10 @@ cloudflare_headers=(
   -H "Content-Type: application/json"
 )
 
+capture_stdout_quiet repo_metadata gh api "repos/${DEPLOYMENT_REPO}"
+default_branch="$(python3 -c 'import json, sys; data = json.load(sys.stdin); print(data.get("default_branch", "main"))' <<<"${repo_metadata}"
+)"
+
 cloudflare_require_success() {
   local action="$1"
   local response="$2"
@@ -303,12 +307,13 @@ bootstrap_env_info "Ensuring Control Plane UI Pages project: ${CONTROLPLANE_UI_P
 
 bootstrap_env_info "Ensuring Pages project: ${CONTROLPLANE_UI_PAGES_PROJECT}"
 if ! cloudflare_get_exists "get Pages project" "${pages_project_url}"; then
-  project_payload="$(python3 - "${CONTROLPLANE_UI_PAGES_PROJECT}" <<'PY'
+  project_payload="$(python3 - "${CONTROLPLANE_UI_PAGES_PROJECT}" "${default_branch}" <<'PY'
 import json
 import sys
 
 print(json.dumps({
     "name": sys.argv[1],
+    "production_branch": sys.argv[2],
 }, separators=(",", ":")))
 PY
 )"

--- a/test/bootstrap-controlplane-ui-companion-test.sh
+++ b/test/bootstrap-controlplane-ui-companion-test.sh
@@ -167,6 +167,11 @@ if [[ "${cmd} ${sub}" == "api repos/customer-org/customer-ltbase-controlplane-ui
   printf '{"default_branch":"main","private":false}'
   exit 0
 fi
+if [[ "${cmd} ${sub}" == "api repos/customer-org/customer-ltbase" ]]; then
+  printf 'NOISY_GH_STDERR deployment repo metadata success\n' >&2
+  printf '{"default_branch":"main","private":false}'
+  exit 0
+fi
 if [[ "${cmd} ${sub}" == "repo clone" ]]; then
   dest="${4:-}"
   mkdir -p "${dest}"
@@ -372,6 +377,7 @@ assert_log_contains "${log_file}" "https://api.cloudflare.com/client/v4/accounts
 assert_log_contains "${log_file}" "https://api.cloudflare.com/client/v4/accounts/cf-account-123/pages/projects/customer-ltbase-controlplane-ui/domains"
 assert_log_contains "${log_file}" "https://api.cloudflare.com/client/v4/zones/zone-123/dns_records?name=admin.customer.example.com"
 assert_log_contains "${log_file}" "https://api.cloudflare.com/client/v4/zones/zone-123/dns_records"
+assert_log_contains "${log_file}" '"production_branch":"main"'
 assert_log_not_contains "${log_file}" "gh repo create customer-org/customer-ltbase-controlplane-ui"
 assert_log_not_contains "${log_file}" "gh variable set CONTROLPLANE_UI_DOMAIN --repo customer-org/customer-ltbase-controlplane-ui --body admin.customer.example.com"
 assert_log_not_contains "${log_file}" "gh variable set CONTROLPLANE_UI_STACK_CONFIG --repo customer-org/customer-ltbase-controlplane-ui"


### PR DESCRIPTION
## Summary
- include the deployment repo default branch when creating the Control Plane UI Cloudflare Pages project
- match the existing OIDC companion Pages bootstrap pattern so Cloudflare accepts the create request
- add regression coverage for the Pages project payload

## Validation
- bash ./test/bootstrap-controlplane-ui-companion-test.sh

## Context
Cloudflare now rejects Pages project creation without `production_branch` and returns:
`You must set a production branch.`
