### PR TITLE
fix: store firebase api key as pulumi secret

### DIFF
--- a/infra/cmd/ltbase-infra/main.go
+++ b/infra/cmd/ltbase-infra/main.go
@@ -66,7 +66,7 @@ func main() {
 		ctx.Export("projectId", pulumi.String(cfg.ProjectID))
 		ctx.Export("apiId", apis.API.ID())
 		ctx.Export("apiBaseUrl", pulumi.String(services.APIBaseURL(cfg)))
-		ctx.Export("controlplaneUiStackConfig", pulumi.String(controlPlaneUIStackConfig))
+		ctx.Export("controlplaneUiStackConfig", controlPlaneUIStackConfig)
 		ctx.Export("dsqlClusterArn", runtime.DSQL.Cluster.Arn)
 		ctx.Export("dsqlClusterIdentifier", runtime.DSQL.Cluster.Identifier)
 		ctx.Export("dsqlVpcEndpointServiceName", runtime.DSQL.Cluster.VpcEndpointServiceName)

--- a/infra/internal/config/config.go
+++ b/infra/internal/config/config.go
@@ -31,7 +31,7 @@ type StackConfig struct {
 	ProjectID                    string
 	DeploymentProjectName        string
 	AuthProviderConfigFile       string
-	FirebaseAPIKey               string
+	FirebaseAPIKey               pulumi.StringOutput
 	FirebaseProjectID            string
 	SupabaseURL                  string
 	SupabaseAnonKey              string
@@ -81,7 +81,7 @@ func Load(ctx *pulumi.Context) (StackConfig, error) {
 		ProjectID:                    cfg.Require("projectId"),
 		DeploymentProjectName:        valueOrDefault(cfg.Get("deploymentProjectName"), humanizeProjectName(ctx.Project())),
 		AuthProviderConfigFile:       cfg.Require("authProviderConfigFile"),
-		FirebaseAPIKey:               cfg.Require("firebaseApiKey"),
+		FirebaseAPIKey:               cfg.RequireSecret("firebaseApiKey"),
 		FirebaseProjectID:            cfg.Require("firebaseProjectId"),
 		SupabaseURL:                  cfg.Require("supabaseUrl"),
 		SupabaseAnonKey:              cfg.Require("supabaseAnonKey"),

--- a/infra/internal/config/config_test.go
+++ b/infra/internal/config/config_test.go
@@ -1,6 +1,10 @@
 package config
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
 
 func TestValueOrDefault(t *testing.T) {
 	if got := valueOrDefault(" ", "fallback"); got != "fallback" {
@@ -80,7 +84,7 @@ func TestValidateAllowsProjectIDAndAuthProviderConfigFile(t *testing.T) {
 		ManageGitHubOIDCProvider: true,
 		ProjectID:                "11111111-1111-4111-8111-111111111111",
 		AuthProviderConfigFile:   "infra/auth-providers.devo.json",
-		FirebaseAPIKey:           "public-firebase-key",
+		FirebaseAPIKey:           pulumi.String("public-firebase-key").ToStringOutput(),
 		FirebaseProjectID:        "firebase-project-id",
 		SupabaseURL:              "https://project.supabase.co",
 		SupabaseAnonKey:          "public-anon-key",
@@ -96,7 +100,7 @@ func TestValidateAllowsProjectIDAndAuthProviderConfigFile(t *testing.T) {
 	if cfg.AuthProviderConfigFile == "" {
 		t.Fatal("AuthProviderConfigFile should be preserved")
 	}
-	if cfg.FirebaseAPIKey == "" || cfg.FirebaseProjectID == "" || cfg.SupabaseURL == "" || cfg.SupabaseAnonKey == "" {
+	if cfg.FirebaseAPIKey == (pulumi.StringOutput{}) || cfg.FirebaseProjectID == "" || cfg.SupabaseURL == "" || cfg.SupabaseAnonKey == "" {
 		t.Fatal("browser-safe auth provider config should be preserved")
 	}
 	if cfg.MTLSTruststoreFile == "" {

--- a/infra/internal/services/controlplane_ui_stack_config.go
+++ b/infra/internal/services/controlplane_ui_stack_config.go
@@ -3,6 +3,8 @@ package services
 import (
 	"encoding/json"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
 	"lychee.technology/ltbase/infra/internal/config"
 )
 
@@ -29,10 +31,10 @@ type controlPlaneUIAuthProvider struct {
 	SupabaseAnonKey   string `json:"supabaseAnonKey,omitempty"`
 }
 
-func controlPlaneUIStackConfigJSON(rootDir string, cfg config.StackConfig) (string, error) {
+func controlPlaneUIStackConfigJSON(rootDir string, cfg config.StackConfig) (pulumi.StringOutput, error) {
 	providerCfg, err := loadAuthProviderConfig(rootDir, cfg.AuthProviderConfigFile)
 	if err != nil {
-		return "", err
+		return pulumi.String("").ToStringOutput(), err
 	}
 
 	providerNames := controlPlaneUIProviderNames(providerCfg, cfg.FirebaseProjectID, cfg.SupabaseURL)
@@ -45,18 +47,21 @@ func controlPlaneUIStackConfigJSON(rootDir string, cfg config.StackConfig) (stri
 		APIBaseURL:          APIBaseURL(cfg),
 		OIDCClientID:        controlPlaneUIOIDCClientID,
 		AuthProviders: []controlPlaneUIAuthProvider{
-			{Type: "firebase", Name: providerNames.Firebase, Label: titleizeKey(providerNames.Firebase), FirebaseProjectID: cfg.FirebaseProjectID, FirebaseAPIKey: cfg.FirebaseAPIKey},
+			{Type: "firebase", Name: providerNames.Firebase, Label: titleizeKey(providerNames.Firebase), FirebaseProjectID: cfg.FirebaseProjectID},
 			{Type: "supabase", Name: providerNames.Supabase, Label: titleizeKey(providerNames.Supabase), SupabaseURL: cfg.SupabaseURL, SupabaseAnonKey: cfg.SupabaseAnonKey},
 		},
 	}
 
-	raw, err := json.Marshal(payload)
-	if err != nil {
-		return "", err
-	}
-	return string(raw), nil
+	return cfg.FirebaseAPIKey.ApplyT(func(firebaseAPIKey string) string {
+		payload.AuthProviders[0].FirebaseAPIKey = firebaseAPIKey
+		raw, err := json.Marshal(payload)
+		if err != nil {
+			return ""
+		}
+		return string(raw)
+	}).(pulumi.StringOutput), nil
 }
 
-func ControlPlaneUIStackConfigJSON(rootDir string, cfg config.StackConfig) (string, error) {
+func ControlPlaneUIStackConfigJSON(rootDir string, cfg config.StackConfig) (pulumi.StringOutput, error) {
 	return controlPlaneUIStackConfigJSON(rootDir, cfg)
 }

--- a/infra/internal/services/controlplane_ui_stack_config_test.go
+++ b/infra/internal/services/controlplane_ui_stack_config_test.go
@@ -2,12 +2,27 @@ package services
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
 	"lychee.technology/ltbase/infra/internal/config"
 )
+
+type controlPlaneUIStackConfigMocks struct{}
+
+func (controlPlaneUIStackConfigMocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return resource.PropertyMap{}, nil
+}
+
+func (controlPlaneUIStackConfigMocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	return args.Name + "_id", args.Inputs, nil
+}
 
 func TestControlPlaneUIStackConfigJSONReusesLoginProviderNamesAndOmitsRedirectURI(t *testing.T) {
 	rootDir := t.TempDir()
@@ -22,18 +37,36 @@ func TestControlPlaneUIStackConfigJSONReusesLoginProviderNamesAndOmitsRedirectUR
 		t.Fatalf("os.WriteFile() error = %v", err)
 	}
 
-	got, err := controlPlaneUIStackConfigJSON(rootDir, config.StackConfig{
-		Stack:                  "devo_env",
-		ProjectID:              "11111111-1111-4111-8111-111111111111",
-		AuthDomain:             "auth.devo.example.com",
-		ControlPlaneDomain:     "control.devo.example.com",
-		APIDomain:              "api.devo.example.com",
-		FirebaseProjectID:      "firebase-project-devo",
-		FirebaseAPIKey:         "public-firebase-key-devo",
-		SupabaseURL:            "https://devo-project.supabase.co",
-		SupabaseAnonKey:        "public-supabase-key-devo",
-		AuthProviderConfigFile: filepath.Base(configPath),
-	})
+	var got string
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		controlPlaneUIStackConfig, err := controlPlaneUIStackConfigJSON(rootDir, config.StackConfig{
+			Project:                "ltbase-infra",
+			Stack:                  "devo_env",
+			ProjectID:              "11111111-1111-4111-8111-111111111111",
+			AuthDomain:             "auth.devo.example.com",
+			ControlPlaneDomain:     "control.devo.example.com",
+			APIDomain:              "api.devo.example.com",
+			FirebaseProjectID:      "firebase-project-devo",
+			FirebaseAPIKey:         pulumi.String("public-firebase-key-devo").ToStringOutput(),
+			SupabaseURL:            "https://devo-project.supabase.co",
+			SupabaseAnonKey:        "public-supabase-key-devo",
+			AuthProviderConfigFile: filepath.Base(configPath),
+		})
+		if err != nil {
+			return err
+		}
+		resultCh := make(chan string, 1)
+		controlPlaneUIStackConfig.ApplyT(func(value string) string {
+			resultCh <- value
+			return value
+		})
+		select {
+		case got = <-resultCh:
+			return nil
+		case <-time.After(2 * time.Second):
+			return fmt.Errorf("timed out waiting for control plane UI stack config output")
+		}
+	}, pulumi.WithMocks("ltbase-infra", "devo_env", controlPlaneUIStackConfigMocks{}))
 	if err != nil {
 		t.Fatalf("controlPlaneUIStackConfigJSON() error = %v", err)
 	}
@@ -106,18 +139,36 @@ func TestControlPlaneUIStackConfigJSONReusesLoginProviderNamesAndOmitsRedirectUR
 }
 
 func TestControlPlaneUIStackConfigJSONFallsBackToDefaultProviderNamesWhenMissing(t *testing.T) {
-	got, err := controlPlaneUIStackConfigJSON(t.TempDir(), config.StackConfig{
-		Stack:                  "prod",
-		ProjectID:              "11111111-1111-4111-8111-111111111111",
-		AuthDomain:             "auth.example.com",
-		ControlPlaneDomain:     "control.example.com",
-		APIDomain:              "api.example.com",
-		FirebaseProjectID:      "firebase-project-prod",
-		FirebaseAPIKey:         "public-firebase-key-prod",
-		SupabaseURL:            "https://prod-project.supabase.co",
-		SupabaseAnonKey:        "public-supabase-key-prod",
-		AuthProviderConfigFile: "missing.json",
-	})
+	var got string
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		controlPlaneUIStackConfig, err := controlPlaneUIStackConfigJSON(t.TempDir(), config.StackConfig{
+			Project:                "ltbase-infra",
+			Stack:                  "prod",
+			ProjectID:              "11111111-1111-4111-8111-111111111111",
+			AuthDomain:             "auth.example.com",
+			ControlPlaneDomain:     "control.example.com",
+			APIDomain:              "api.example.com",
+			FirebaseProjectID:      "firebase-project-prod",
+			FirebaseAPIKey:         pulumi.String("public-firebase-key-prod").ToStringOutput(),
+			SupabaseURL:            "https://prod-project.supabase.co",
+			SupabaseAnonKey:        "public-supabase-key-prod",
+			AuthProviderConfigFile: "missing.json",
+		})
+		if err != nil {
+			return err
+		}
+		resultCh := make(chan string, 1)
+		controlPlaneUIStackConfig.ApplyT(func(value string) string {
+			resultCh <- value
+			return value
+		})
+		select {
+		case got = <-resultCh:
+			return nil
+		case <-time.After(2 * time.Second):
+			return fmt.Errorf("timed out waiting for control plane UI stack config output")
+		}
+	}, pulumi.WithMocks("ltbase-infra", "prod", controlPlaneUIStackConfigMocks{}))
 	if err != nil {
 		t.Fatalf("controlPlaneUIStackConfigJSON() error = %v", err)
 	}

--- a/scripts/bootstrap-deployment-repo.sh
+++ b/scripts/bootstrap-deployment-repo.sh
@@ -163,7 +163,7 @@ bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set authCorsAllowOrigins
 bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set controlPlaneCorsAllowOrigins "${selected_control_plane_cors_allow_origins}" --stack "${STACK}"
 bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set projectId "${selected_project_id}" --stack "${STACK}"
 bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set authProviderConfigFile "${selected_auth_provider_config_file}" --stack "${STACK}"
-bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set firebaseApiKey "${selected_firebase_api_key}" --stack "${STACK}"
+bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set --secret firebaseApiKey "${selected_firebase_api_key}" --stack "${STACK}"
 bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set firebaseProjectId "${selected_firebase_project_id}" --stack "${STACK}"
 bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set supabaseUrl "${selected_supabase_url}" --stack "${STACK}"
 bootstrap_env_run_quiet "${stack_env[@]}" pulumi config set supabaseAnonKey "${selected_supabase_anon_key}" --stack "${STACK}"

--- a/scripts/check-pulumi-stack-config.sh
+++ b/scripts/check-pulumi-stack-config.sh
@@ -63,7 +63,7 @@ required_keys=(
 )
 
 for key in "${required_keys[@]}"; do
-  if ! grep -Fq "  ${key}:" "${stack_file}"; then
+  if ! grep -Eq "^[[:space:]]{2}${key}:($|[[:space:]])" "${stack_file}"; then
     printf "Missing required Pulumi config key '%s' in %s. Rerun bootstrap-deployment-repo.sh or update the stack config file.\n" "${key}" "${stack_file}" >&2
     exit 1
   fi

--- a/test/bootstrap-deployment-repo-test.sh
+++ b/test/bootstrap-deployment-repo-test.sh
@@ -420,7 +420,7 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
   assert_log_contains "${log_file}" "pulumi config set controlPlaneCorsAllowOrigins https://control.example.com,https://admin.example.com --stack prod"
   assert_log_contains "${log_file}" "pulumi config set projectId 33333333-3333-4333-8333-333333333333 --stack prod"
   assert_log_contains "${log_file}" "pulumi config set authProviderConfigFile infra/auth-providers.prod.json --stack prod"
-  assert_log_contains "${log_file}" "pulumi config set firebaseApiKey public-firebase-key-prod --stack prod"
+  assert_log_contains "${log_file}" "pulumi config set --secret firebaseApiKey public-firebase-key-prod --stack prod"
   assert_log_contains "${log_file}" "pulumi config set firebaseProjectId firebase-project-prod --stack prod"
   assert_log_contains "${log_file}" "pulumi config set supabaseUrl https://prod-project.supabase.co --stack prod"
   assert_log_contains "${log_file}" "pulumi config set supabaseAnonKey public-supabase-key-prod --stack prod"

--- a/test/check-pulumi-stack-config-test.sh
+++ b/test/check-pulumi-stack-config-test.sh
@@ -37,7 +37,8 @@ config:
   ltbase-infra:authDomain: auth.example.com
   ltbase-infra:projectId: 11111111-1111-4111-8111-111111111111
   ltbase-infra:authProviderConfigFile: infra/auth-providers.devo.json
-  ltbase-infra:firebaseApiKey: public-firebase-key-devo
+  ltbase-infra:firebaseApiKey:
+    secure: test-firebase-secret
   ltbase-infra:firebaseProjectId: firebase-project-devo
   ltbase-infra:supabaseUrl: https://devo-project.supabase.co
   ltbase-infra:supabaseAnonKey: public-supabase-key-devo
@@ -150,7 +151,7 @@ from pathlib import Path
 import sys
 
 path = Path(sys.argv[1])
-path.write_text(path.read_text().replace('  ltbase-infra:firebaseApiKey: public-firebase-key-devo\n', ''))
+path.write_text(path.read_text().replace('  ltbase-infra:firebaseApiKey:\n    secure: test-firebase-secret\n', ''))
 PY
 
 if output="$(${SCRIPT_PATH} --stack devo --infra-dir "${temp_dir}/infra" 2>&1)"; then


### PR DESCRIPTION
## Summary
- store `firebaseApiKey` in Pulumi stack config with `pulumi config set --secret`
- load the Firebase API key as a Pulumi secret in the infra program while still exporting browser runtime JSON with the same public field
- update stack-config validation and regression tests to accept Pulumi secret YAML entries

## Test Plan
- [x] `bash test/bootstrap-deployment-repo-test.sh`
- [x] `bash test/check-pulumi-stack-config-test.sh`
- [x] `go test ./...` (in `infra/`)

## Issue
- none