### PR TITLE
ci: update GitHub Actions major versions

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -52,7 +52,7 @@ jobs:
     needs: prepare
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Validate Pulumi stack config
         run: ./scripts/check-pulumi-stack-config.sh --stack ${{ needs.prepare.outputs.target_stack }}
@@ -86,10 +86,10 @@ jobs:
     if: ${{ needs.preview.result == 'success' }}
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets[format('AWS_ROLE_ARN_{0}', needs.prepare.outputs.target_stack_upper)] }}
           aws-region: ${{ vars[format('AWS_REGION_{0}', needs.prepare.outputs.target_stack_upper)] }}

--- a/.github/workflows/rollout-hop.yml
+++ b/.github/workflows/rollout-hop.yml
@@ -162,7 +162,7 @@ jobs:
     needs: prepare
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Validate Pulumi stack config
         run: ./scripts/check-pulumi-stack-config.sh --stack ${{ needs.prepare.outputs.target_stack }}
@@ -185,7 +185,7 @@ jobs:
     outputs:
       runtime_config_json: ${{ steps.capture.outputs.runtime_config_json }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Render Control Plane UI runtime config
         run: ./scripts/render-controlplane-ui-config.sh --stack-config-json '${{ vars.CONTROLPLANE_UI_STACK_CONFIG }}' --output-path .github/ltbase-controlplane.config.json
@@ -227,10 +227,10 @@ jobs:
     if: ${{ always() && needs.rollout.result == 'success' }}
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets[format('AWS_ROLE_ARN_{0}', needs.prepare.outputs.target_stack_upper)] }}
           aws-region: ${{ vars[format('AWS_REGION_{0}', needs.prepare.outputs.target_stack_upper)] }}
@@ -249,7 +249,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets[format('AWS_ROLE_ARN_{0}', needs.prepare.outputs.target_stack_upper)] }}
           aws-region: ${{ vars[format('AWS_REGION_{0}', needs.prepare.outputs.target_stack_upper)] }}
@@ -352,10 +352,10 @@ jobs:
     if: ${{ always() && needs.ensure_project.result == 'success' }}
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets[format('AWS_ROLE_ARN_{0}', needs.prepare.outputs.target_stack_upper)] }}
           aws-region: ${{ vars[format('AWS_REGION_{0}', needs.prepare.outputs.target_stack_upper)] }}


### PR DESCRIPTION
## Summary
- upgrade actions/checkout from v4 to v6
- upgrade aws-actions/configure-aws-credentials from v4 to v6
- keep workflow behavior unchanged aside from action major versions

## Test Plan
- [x] run `git diff --check -- .github/workflows`
- [x] confirm no `actions/checkout@v4` matches remain in workspace
- [x] confirm no `aws-actions/configure-aws-credentials@v4` or `@v5` matches remain in workspace