### PR TITLE
ci: bootstrap deployment repo sets CLOUDFLARE_ACCOUNT_ID

### DIFF
--- a/scripts/bootstrap-deployment-repo.sh
+++ b/scripts/bootstrap-deployment-repo.sh
@@ -42,7 +42,7 @@ if ! bootstrap_env_has_stack "${STACK}"; then
   exit 1
 fi
 
-required_vars=(DEPLOYMENT_REPO PULUMI_BACKEND_URL LTBASE_RELEASES_REPO LTBASE_RELEASE_ID LTBASE_RELEASES_TOKEN CLOUDFLARE_API_TOKEN GEMINI_API_KEY CLOUDFLARE_ZONE_ID GITHUB_ORG GITHUB_REPO GEMINI_MODEL DSQL_PORT DSQL_DB DSQL_USER DSQL_PROJECT_SCHEMA MTLS_TRUSTSTORE_FILE MTLS_TRUSTSTORE_KEY)
+required_vars=(DEPLOYMENT_REPO PULUMI_BACKEND_URL LTBASE_RELEASES_REPO LTBASE_RELEASE_ID LTBASE_RELEASES_TOKEN CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID GEMINI_API_KEY CLOUDFLARE_ZONE_ID GITHUB_ORG GITHUB_REPO GEMINI_MODEL DSQL_PORT DSQL_DB DSQL_USER DSQL_PROJECT_SCHEMA MTLS_TRUSTSTORE_FILE MTLS_TRUSTSTORE_KEY)
 for name in "${required_vars[@]}"; do
   if [[ -z "${!name:-}" ]]; then
     echo "${name} is required" >&2
@@ -90,6 +90,7 @@ bootstrap_env_run_quiet gh variable set PROMOTION_PATH --repo "${DEPLOYMENT_REPO
 bootstrap_env_run_quiet gh variable set PREVIEW_DEFAULT_STACK --repo "${DEPLOYMENT_REPO}" --body "${PREVIEW_DEFAULT_STACK}"
 bootstrap_env_run_quiet gh variable set CONTROLPLANE_UI_STACK_CONFIG --repo "${DEPLOYMENT_REPO}" --body "$(bootstrap_env_controlplane_ui_stack_config_json)"
 bootstrap_env_run_quiet gh variable set CONTROLPLANE_UI_DOMAIN --repo "${DEPLOYMENT_REPO}" --body "${CONTROLPLANE_UI_DOMAIN}"
+bootstrap_env_run_quiet gh variable set CLOUDFLARE_ACCOUNT_ID --repo "${DEPLOYMENT_REPO}" --body "${CLOUDFLARE_ACCOUNT_ID}"
 bootstrap_env_run_quiet gh variable set CONTROLPLANE_UI_PAGES_PROJECT --repo "${DEPLOYMENT_REPO}" --body "${CONTROLPLANE_UI_PAGES_PROJECT}"
 
 bootstrap_env_run_quiet gh secret set LTBASE_RELEASES_TOKEN --repo "${DEPLOYMENT_REPO}" --body "${LTBASE_RELEASES_TOKEN}"

--- a/test/bootstrap-deployment-repo-test.sh
+++ b/test/bootstrap-deployment-repo-test.sh
@@ -63,6 +63,7 @@ LTBASE_RELEASES_REPO=Lychee-Technology/ltbase-releases
 LTBASE_RELEASE_ID=v1.0.0
 LTBASE_RELEASES_TOKEN=test-release-token
 CLOUDFLARE_API_TOKEN=test-cloudflare-token
+CLOUDFLARE_ACCOUNT_ID=cf-account-123
 GEMINI_API_KEY=test-gemini-key
 API_DOMAIN_DEVO=api.devo.example.com
 API_DOMAIN_STAGING=api.staging.example.com
@@ -138,6 +139,7 @@ LTBASE_RELEASES_REPO=Lychee-Technology/ltbase-releases
 LTBASE_RELEASE_ID=v1.0.0
 LTBASE_RELEASES_TOKEN=test-release-token
 CLOUDFLARE_API_TOKEN=test-cloudflare-token
+CLOUDFLARE_ACCOUNT_ID=cf-account-123
 GEMINI_API_KEY=test-gemini-key
 API_DOMAIN_DEVO=api.devo.example.com
 API_DOMAIN_STAGING=api.staging.example.com
@@ -213,6 +215,7 @@ LTBASE_RELEASES_REPO=Lychee-Technology/ltbase-releases
 LTBASE_RELEASE_ID=v1.0.0
 LTBASE_RELEASES_TOKEN=test-release-token
 CLOUDFLARE_API_TOKEN=test-cloudflare-token
+CLOUDFLARE_ACCOUNT_ID=cf-account-123
 GEMINI_API_KEY=test-gemini-key
 API_DOMAIN_DEVO=api.devo.example.com
 API_DOMAIN_STAGING=api.staging.example.com
@@ -288,6 +291,7 @@ LTBASE_RELEASES_REPO=Lychee-Technology/ltbase-releases
 LTBASE_RELEASE_ID=v1.0.0
 LTBASE_RELEASES_TOKEN=test-release-token
 CLOUDFLARE_API_TOKEN=test-cloudflare-token
+CLOUDFLARE_ACCOUNT_ID=cf-account-123
 GEMINI_API_KEY=test-gemini-key
 API_DOMAIN_DEVO=api.devo.example.com
 API_DOMAIN_STAGING=api.staging.example.com
@@ -400,6 +404,7 @@ if [[ -x "${SCRIPT_PATH}" ]]; then
   assert_log_contains "${log_file}" "gh variable set SCHEMA_BUCKET_STAGING --repo Lychee-Technology/ltbase-private-deployment --body ltbase-private-deployment-schema-staging"
   assert_log_contains "${log_file}" "gh variable set SCHEMA_BUCKET_PROD --repo Lychee-Technology/ltbase-private-deployment --body ltbase-private-deployment-schema-prod"
   assert_log_contains "${log_file}" "gh variable set CONTROLPLANE_UI_DOMAIN --repo Lychee-Technology/ltbase-private-deployment --body admin.example.com"
+  assert_log_contains "${log_file}" "gh variable set CLOUDFLARE_ACCOUNT_ID --repo Lychee-Technology/ltbase-private-deployment --body cf-account-123"
   assert_log_contains "${log_file}" "gh variable set CONTROLPLANE_UI_PAGES_PROJECT --repo Lychee-Technology/ltbase-private-deployment --body ltbase-private-deployment-controlplane-ui"
   assert_log_contains "${log_file}" "gh variable set STACKS --repo Lychee-Technology/ltbase-private-deployment --body devo,staging,prod"
   assert_log_contains "${log_file}" "gh variable set PROMOTION_PATH --repo Lychee-Technology/ltbase-private-deployment --body devo,staging,prod"


### PR DESCRIPTION
## Summary
- require  during deployment repo bootstrap
- write  into deployment repo variables for rollout workflows
- cover the bootstrap behavior with regression assertions

## Testing
- PASS: bootstrap-deployment-repo tests
- PASS: rollout workflow tests

## Related
- refs #75
- backports the deployment repo fix for empty Cloudflare Pages account IDs in rollout UI deploys
