### PR TITLE
feat: replace catch-all API Gateway routes with explicit METHOD/path routes

### DIFF
--- a/__ref__/plan/2026-06-27-explicit-api-gateway-routes-plan.md
+++ b/__ref__/plan/2026-06-27-explicit-api-gateway-routes-plan.md
@@ -1,0 +1,607 @@
+# Explicit API Gateway Routes — Implementation Plan
+
+> **Goal:** Replace `ANY /{proxy+}` catch-all routes with explicit `METHOD /path` routes for Data Plane, Control Plane, and AuthService APIs. Only `OPTIONS /{proxy+}` preflight routes remain unauthenticated and catch-all. Add `PATCH` to CORS allowed methods.
+
+**Architecture:** Modify the Pulumi IaC route spec builders and their tests in `ltbase-private-deployment/infra/internal/services/apigateway.go`. Update `ltbase.api/AGENTS.md` to instruct agents to keep route specs in sync. Optionally update demo01 devo CORS config for local development.
+
+**Repos affected:** `ltbase-private-deployment` (primary), `ltbase.api` (AGENTS.md), `ltbase-private-deployment-demo01` (config only).
+
+---
+
+## Task 1: Add route spec helper utilities
+
+**Files:**
+- Modify: `ltbase-private-deployment/infra/internal/services/apigateway.go`
+- Modify: `ltbase-private-deployment/infra/internal/services/apigateway_test.go`
+
+- [ ] **Step 1: Add helper functions**
+
+Add helpers before the route builder functions to reduce duplication:
+
+```go
+// authorizedRoutes returns route specs with the given authorizer name applied to every route key.
+func authorizedRoutes(authorizerName string, routeKeys ...string) []routeSpec {
+	routes := make([]routeSpec, len(routeKeys))
+	for i, key := range routeKeys {
+		routes[i] = routeSpec{RouteKey: key, AuthorizerName: authorizerName}
+	}
+	return routes
+}
+
+// preflightRoutes returns unauthenticated OPTIONS preflight routes.
+func preflightRoutes() []routeSpec {
+	return []routeSpec{
+		{RouteKey: "OPTIONS /"},
+		{RouteKey: "OPTIONS /{proxy+}"},
+	}
+}
+
+// prefixedRouteKeys prepends a prefix to each route key.
+func prefixedRouteKeys(prefix string, routeKeys ...string) []string {
+	out := make([]string, len(routeKeys))
+	for i, key := range routeKeys {
+		out[i] = prefix + key
+	}
+	return out
+}
+
+// controlPlaneRoutes returns routes for both /api/v1/... and /api/control-plane/v1/... prefixes.
+func controlPlaneRoutes(routeKeys ...string) []routeSpec {
+	var all []string
+	all = append(all, prefixedRouteKeys("/api/v1", routeKeys...)...)
+	all = append(all, prefixedRouteKeys("/api/control-plane/v1", routeKeys...)...)
+	return authorizedRoutes("LTBase", all...)
+}
+```
+
+- [ ] **Step 2: Write/build tests for helpers**
+
+In `apigateway_test.go`, add:
+
+```go
+func TestAuthorizedRoutes(t *testing.T) {
+	routes := authorizedRoutes("LTBase", "GET /x", "POST /y")
+	if len(routes) != 2 {
+		t.Fatalf("route count = %d, want 2", len(routes))
+	}
+	if routes[0].AuthorizerName != "LTBase" || routes[1].AuthorizerName != "LTBase" {
+		t.Fatal("authorizer should be LTBase on all routes")
+	}
+}
+
+func TestPreflightRoutesNoAuthorizer(t *testing.T) {
+	routes := preflightRoutes()
+	for _, r := range routes {
+		if r.AuthorizerName != "" {
+			t.Fatalf("preflight route %q has authorizer %q, want empty", r.RouteKey, r.AuthorizerName)
+		}
+	}
+	if len(routes) != 2 {
+		t.Fatalf("preflight route count = %d, want 2", len(routes))
+	}
+}
+
+func TestPrefixedRouteKeys(t *testing.T) {
+	keys := prefixedRouteKeys("/prefix", "/a", "/b")
+	if len(keys) != 2 || keys[0] != "/prefix/a" || keys[1] != "/prefix/b" {
+		t.Fatalf("prefixedRouteKeys = %#v", keys)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+cd /Users/ruoshi/code/Lychee/LTBase/ltbase-private-deployment
+go test ./infra/internal/services
+```
+
+Expected: existing tests pass; new tests pass.
+
+---
+
+## Task 2: Replace Control Plane route specs
+
+**Files:**
+- Modify: `ltbase-private-deployment/infra/internal/services/apigateway.go:153-157`
+- Modify: `ltbase-private-deployment/infra/internal/services/apigateway_test.go:39-47`
+
+- [ ] **Step 1: Replace `buildControlPlaneRouteSpecs`**
+
+Replace the catch-all function with explicit routes plus preflight:
+
+```go
+func buildControlPlaneRouteSpecs() []routeSpec {
+	business := controlPlaneRoutes(
+		"/status",
+		"/schema/status",
+		"/workflows",
+		"/repair/dry-run",
+		"/repair/apply",
+		"/catalogs/capabilities",
+		"/catalogs/action-templates",
+		"/catalogs/assistant-roles",
+		"/compliance-profile",
+		"/auth-config",
+		"/auth/config",
+		"/referrals",
+		"/referrals/{code}",
+		"/referrals/{code}/disable",
+		"/auth/referrals",
+		"/auth/referrals/{code}",
+		"/auth/referrals/{code}/disable",
+		"/auth/users",
+		"/auth/users/{user_id}",
+		"/auth/users/{user_id}/roles/{role_id}",
+		"/auth/roles",
+		"/auth/roles/{role_id}",
+		"/auth/policies",
+		"/auth/policies/{policy_id}",
+		"/auth/binding-policies",
+		"/auth/binding-policies/{policy_id}",
+		"/auth/principals/{principal_type}/{principal_id}/policies",
+		"/auth/principals/{principal_type}/{principal_id}/policies/{policy_id}",
+		"/org/units",
+		"/org/units/{ou_id}",
+		"/org/units/{ou_id}/users",
+		"/org/units/{ou_id}/users/{user_id}",
+		"/org/units/{ou_id}/policies",
+		"/org/units/{ou_id}/policies/{policy_id}",
+		"/org/users/{user_id}/manager",
+		"/org/users/{user_id}/direct-reports",
+		"/org/charts",
+	)
+	return append(business, preflightRoutes()...)
+}
+```
+
+- [ ] **Step 2: Update test**
+
+Replace `TestBuildControlPlaneRouteSpecs`:
+
+```go
+func TestBuildControlPlaneRouteSpecs(t *testing.T) {
+	routes := buildControlPlaneRouteSpecs()
+	// Verify no ANY routes for normal traffic
+	for _, r := range routes {
+		if r.RouteKey != "OPTIONS /" && r.RouteKey != "OPTIONS /{proxy+}" {
+			if strings.Contains(r.RouteKey, "ANY") || strings.Contains(r.RouteKey, "{proxy+}") {
+				t.Fatalf("normal route %q should not use ANY or {proxy+}", r.RouteKey)
+			}
+			if r.AuthorizerName != "LTBase" {
+				t.Fatalf("route %q authorizer = %q, want LTBase", r.RouteKey, r.AuthorizerName)
+			}
+		} else {
+			if r.AuthorizerName != "" {
+				t.Fatalf("preflight route %q has authorizer %q, want empty", r.RouteKey, r.AuthorizerName)
+			}
+		}
+	}
+	// Spot-check key routes exist
+	routeSet := make(map[string]bool)
+	for _, r := range routes {
+		routeSet[r.RouteKey] = true
+	}
+	mustExist := []string{
+		"GET /api/v1/status",
+		"POST /api/v1/repair/apply",
+		"GET /api/v1/auth/config",
+		"PATCH /api/v1/auth/users/{user_id}",
+		"PUT /api/v1/org/units/{ou_id}/users/{user_id}",
+		"OPTIONS /{proxy+}",
+	}
+	for _, key := range mustExist {
+		if !routeSet[key] {
+			t.Fatalf("missing route %q", key)
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Remove `legacyRouteAliasName` and `routeAliases`**
+
+Since we're replacing `ANY /` and `ANY /{proxy+}` with explicit routes, the legacy alias machinery is no longer needed. Remove the functions and their tests (`TestControlRouteAliases`).
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./infra/internal/services
+```
+
+---
+
+## Task 3: Expand Data Plane route specs
+
+**Files:**
+- Modify: `ltbase-private-deployment/infra/internal/services/apigateway.go:135-151`
+- Modify: `ltbase-private-deployment/infra/internal/services/apigateway_test.go:12-37`
+
+- [ ] **Step 1: Replace `buildAPIRouteSpecs`**
+
+Replace with explicit routes plus preflight:
+
+```go
+func buildAPIRouteSpecs() []routeSpec {
+	business := authorizedRoutes("LTBase",
+		// Notes
+		"GET /api/ai/v1/notes",
+		"POST /api/ai/v1/notes",
+		"GET /api/ai/v1/notes/{note_id}",
+		"PUT /api/ai/v1/notes/{note_id}",
+		"DELETE /api/ai/v1/notes/{note_id}",
+		"GET /api/ai/v1/notes/{note_id}/model_sync",
+		"POST /api/ai/v1/notes/{note_id}/model_sync",
+		// CRUD sessions
+		"POST /api/ai/v1/sessions",
+		"GET /api/ai/v1/sessions/{session_id}",
+		"GET /api/ai/v1/sessions/{session_id}/messages",
+		"POST /api/ai/v1/sessions/{session_id}/messages",
+		"POST /api/ai/v1/operations",
+		// Agent sessions
+		"POST /api/ai/v1/agent/sessions",
+		"GET /api/ai/v1/agent/sessions/{session_id}",
+		"DELETE /api/ai/v1/agent/sessions/{session_id}",
+		"GET /api/ai/v1/agent/sessions/{session_id}/turns",
+		"POST /api/ai/v1/agent/sessions/{session_id}/turns",
+		"GET /api/ai/v1/agent/sessions/{session_id}/turns/{turn_id}/citations",
+		// Intent-to-action
+		"POST /api/ai/v1/intent-to-action/plans",
+		"POST /api/ai/v1/intent-to-action/executions",
+		"GET /api/ai/v1/intent-to-action/executions/{execution_id}",
+		// Governance action
+		"POST /api/ai/v1/governance/actions/execute",
+		// Compliance
+		"POST /api/ai/v1/compliance/decisions",
+		// Forma / metadata
+		"GET /api/v1/deepping",
+		"GET /api/v1/schemas",
+		"GET /api/v1/tools",
+		"GET /api/v1/audit_records",
+		"GET /api/v1/search",
+		"POST /api/v1/advanced_query",
+		"GET /api/v1/{schema_name}",
+		"POST /api/v1/{schema_name}",
+		"DELETE /api/v1/{schema_name}",
+		"GET /api/v1/{schema_name}/{row_id}",
+		"PUT /api/v1/{schema_name}/{row_id}",
+		"DELETE /api/v1/{schema_name}/{row_id}",
+		// LTFlow
+		"GET /api/ltflow/v1/tasks",
+		"GET /api/ltflow/v1/tasks/{task_id}",
+		"GET /api/ltflow/v1/instances",
+		"POST /api/ltflow/v1/instances",
+		"GET /api/ltflow/v1/instances/{instance_id}",
+		"POST /api/ltflow/v1/instances/{instance_id}/events",
+		"GET /api/ltflow/v1/instances/{instance_id}/history",
+		// Discovery
+		"POST /api/sys/v1/discovery/reachable",
+		"POST /api/sys/v1/discovery/paths",
+		// Ontology
+		"GET /api/sys/v1/ontology/object-types",
+		"GET /api/sys/v1/ontology/object-types/{type_name}",
+		"GET /api/sys/v1/ontology/link-types",
+		"GET /api/sys/v1/ontology/action-types",
+		"GET /api/sys/v1/ontology/objects/{type_name}/{row_id}",
+		"POST /api/sys/v1/ontology/objects/{type_name}/search",
+		"POST /api/sys/v1/ontology/objects/{type_name}/{row_id}/reachable",
+		"GET /api/sys/v1/ontology/objects/{type_name}/{row_id}/actions",
+		"GET /api/sys/v1/ontology/objects/{type_name}/{row_id}/provenance",
+		// Governance
+		"GET /api/sys/v1/governance/entities/{entity}/capabilities",
+		"GET /api/sys/v1/governance/capabilities/{capability}",
+		"GET /api/sys/v1/governance/policies/{policy}/capabilities",
+		"GET /api/sys/v1/governance/claims",
+		"POST /api/sys/v1/governance/claims",
+		"POST /api/sys/v1/governance/claims/{claim_id}/approve",
+		"POST /api/sys/v1/governance/claims/{claim_id}/reject",
+		"GET /api/sys/v1/governance/events",
+		"POST /api/sys/v1/governance/evidence",
+		"GET /api/sys/v1/governance/evidence/{evidence_id}/gaps",
+		"GET /api/sys/v1/governance/evidence/{evidence_id}/expired",
+		"POST /api/sys/v1/governance/evidence/{evidence_id}/validate",
+		"POST /api/sys/v1/governance/monitoring/re-evaluate",
+		// Compliance
+		"GET /api/sys/v1/compliance/entities/{entity}",
+		"GET /api/sys/v1/compliance/capabilities/{capability}",
+		"GET /api/sys/v1/compliance/policies/{policy}",
+		// Semantic
+		"GET /api/v1/semantic/resources",
+		"GET /api/v1/semantic/resources/{resource_id}",
+		"GET /api/v1/semantic/lineage/{resource_id}",
+	)
+	return append(business, preflightRoutes()...)
+}
+```
+
+Note the order: `GET /api/v1/{schema_name}` and `GET /api/v1/{schema_name}/{row_id}` must appear after `GET /api/v1/semantic/resources` etc. because API Gateway matches routes in specificity order (more static segments before parameterized ones). This is enforced naturally when routes have different static prefixes.
+
+- [ ] **Step 2: Update `TestBuildAPIRouteSpecs`**
+
+```go
+func TestBuildAPIRouteSpecs(t *testing.T) {
+	routes := buildAPIRouteSpecs()
+	routeSet := make(map[string]bool)
+	for _, r := range routes {
+		routeSet[r.RouteKey] = true
+		if r.RouteKey == "OPTIONS /" || r.RouteKey == "OPTIONS /{proxy+}" {
+			if r.AuthorizerName != "" {
+				t.Fatalf("preflight route %q has authorizer %q, want empty", r.RouteKey, r.AuthorizerName)
+			}
+			continue
+		}
+		if strings.Contains(r.RouteKey, "ANY") || strings.Contains(r.RouteKey, "{proxy+}") {
+			t.Fatalf("normal route %q should not use ANY or {proxy+}", r.RouteKey)
+		}
+		if r.AuthorizerName != "LTBase" {
+			t.Fatalf("route %q authorizer = %q, want LTBase", r.RouteKey, r.AuthorizerName)
+		}
+	}
+	mustExist := []string{
+		"GET /api/ai/v1/notes",
+		"POST /api/ai/v1/notes",
+		"GET /api/v1/deepping",
+		"POST /api/ai/v1/intent-to-action/plans",
+		"POST /api/sys/v1/discovery/reachable",
+		"GET /api/sys/v1/governance/claims",
+		"POST /api/sys/v1/governance/evidence",
+		"GET /api/sys/v1/compliance/entities/{entity}",
+		"GET /api/v1/semantic/resources",
+		"OPTIONS /{proxy+}",
+	}
+	for _, key := range mustExist {
+		if !routeSet[key] {
+			t.Fatalf("missing route %q", key)
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+go test ./infra/internal/services -run TestBuildAPIRouteSpecs
+```
+
+---
+
+## Task 4: Expand AuthService route specs
+
+**Files:**
+- Modify: `ltbase-private-deployment/infra/internal/services/apigateway.go:196-210`
+- Modify: `ltbase-private-deployment/infra/internal/services/apigateway_test.go:70-90`
+
+- [ ] **Step 1: Update `buildAuthRouteSpecs`**
+
+Add `revoke`, `profile`, and preflight routes:
+
+```go
+func buildAuthRouteSpecs(providerCfg AuthProviderConfig) []routeSpec {
+	routes := []routeSpec{
+		{RouteKey: "GET /api/v1/auth/health"},
+		{RouteKey: "POST /api/v1/auth/refresh", AuthorizerName: "LTBaseRefresh"},
+		{RouteKey: "POST /api/v1/auth/revoke", AuthorizerName: "LTBase"},
+		{RouteKey: "GET /api/v1/auth/profile/{user_id}", AuthorizerName: "LTBase"},
+	}
+	for _, provider := range providerCfg.Providers {
+		if provider.EnableIDBinding {
+			routes = append(routes, routeSpec{RouteKey: "POST /api/v1/id_bindings/" + provider.Name, AuthorizerName: provider.Name})
+		}
+		if provider.EnableLogin {
+			routes = append(routes, routeSpec{RouteKey: "POST /api/v1/login/" + provider.Name, AuthorizerName: provider.Name})
+		}
+	}
+	routes = append(routes, preflightRoutes()...)
+	return routes
+}
+```
+
+- [ ] **Step 2: Update `TestBuildAuthRouteSpecs`**
+
+```go
+func TestBuildAuthRouteSpecs(t *testing.T) {
+	providerCfg := AuthProviderConfig{
+		Providers: []AuthProvider{
+			{Name: "firebase", Issuer: "https://issuer.example.com", Audiences: []string{"aud-1"}, EnableLogin: true, EnableIDBinding: true},
+			{Name: "apple", Issuer: "https://apple.example.com", Audiences: []string{"aud-2"}, EnableLogin: true, EnableIDBinding: false},
+		},
+	}
+	routes := buildAuthRouteSpecs(providerCfg)
+	routeSet := make(map[string]bool)
+	for _, r := range routes {
+		routeSet[r.RouteKey] = true
+	}
+	check := func(wantKey, wantAuth string) {
+		t.Helper()
+		// find route
+		var auth string
+		for _, r := range routes {
+			if r.RouteKey == wantKey {
+				auth = r.AuthorizerName
+				break
+			}
+		}
+		if auth == "" && wantAuth != "" {
+			t.Fatalf("route %q not found", wantKey)
+		}
+		if auth != wantAuth {
+			t.Fatalf("route %q authorizer = %q, want %q", wantKey, auth, wantAuth)
+		}
+	}
+	check("GET /api/v1/auth/health", "")
+	check("POST /api/v1/auth/refresh", "LTBaseRefresh")
+	check("POST /api/v1/auth/revoke", "LTBase")
+	check("GET /api/v1/auth/profile/{user_id}", "LTBase")
+	check("POST /api/v1/login/firebase", "firebase")
+	check("POST /api/v1/login/apple", "apple")
+	check("POST /api/v1/id_bindings/firebase", "firebase")
+	check("OPTIONS /", "")
+	check("OPTIONS /{proxy+}", "")
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+go test ./infra/internal/services -run TestBuildAuth
+```
+
+---
+
+## Task 5: Fix CORS methods — add PATCH
+
+**Files:**
+- Modify: `ltbase-private-deployment/infra/internal/services/apigateway.go:393-399`
+- Modify: `ltbase-private-deployment/infra/internal/services/apigateway_test.go:211-228`
+
+- [ ] **Step 1: Add PATCH to CORS methods**
+
+```go
+func httpAPICorsConfigForOrigins(origins []string) httpAPICorsConfig {
+	return httpAPICorsConfig{
+		AllowOrigins:     origins,
+		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
+		AllowHeaders:     []string{"Authorization", "Content-Type"},
+		AllowCredentials: false,
+	}
+}
+```
+
+- [ ] **Step 2: Update CORS test**
+
+```go
+func TestHTTPAPICORSConfigurationUsesConfiguredOrigins(t *testing.T) {
+	config := httpAPICorsConfigForOrigins([]string{"https://app.example.com", "https://admin.example.com"})
+	if len(config.AllowOrigins) != 2 {
+		t.Fatalf("allow origins length = %d", len(config.AllowOrigins))
+	}
+	if config.AllowOrigins[0] != "https://app.example.com" || config.AllowOrigins[1] != "https://admin.example.com" {
+		t.Fatalf("allow origins = %#v", config.AllowOrigins)
+	}
+	methods := config.AllowMethods
+	if len(methods) == 0 {
+		t.Fatal("allow methods should not be empty")
+	}
+	hasPATCH := false
+	for _, m := range methods {
+		if m == "PATCH" {
+			hasPATCH = true
+			break
+		}
+	}
+	if !hasPATCH {
+		t.Fatalf("allow methods missing PATCH: %#v", methods)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+go test ./infra/internal/services -run TestHTTPAPICORSConfiguration
+```
+
+---
+
+## Task 6: Update `ltbase.api/AGENTS.md`
+
+**Files:**
+- Modify: `ltbase.api/AGENTS.md`
+
+- [ ] **Step 1: Add route sync section**
+
+After the "Key Environment Variables" table and before "Build Commands" (or at the end), add:
+
+```md
+## API Gateway Route Sync
+
+When adding, removing, renaming, or changing the HTTP method/path of any Data Plane,
+Control Plane, or AuthService API route in this repository, agents must sync the
+explicit API Gateway route configuration in
+[`ltbase-private-deployment/infra/internal/services/apigateway.go`](https://github.com/Lychee-Technology/ltbase-private-deployment/blob/main/infra/internal/services/apigateway.go)
+and its tests in
+[`apigateway_test.go`](https://github.com/Lychee-Technology/ltbase-private-deployment/blob/main/infra/internal/services/apigateway_test.go).
+
+**Rules:**
+
+- Every business API route must have an explicit `METHOD /path` route spec in the
+  corresponding builder function (`buildAPIRouteSpecs`, `buildControlPlaneRouteSpecs`,
+  `buildAuthRouteSpecs`).
+- Do not rely on `ANY /{proxy+}` for normal API traffic. Generic proxy matching is
+  allowed only for unauthenticated CORS preflight routes (`OPTIONS /` and
+  `OPTIONS /{proxy+}`).
+- Preflight routes must not carry a JWT authorizer; the API Gateway must pass them
+  to the Lambda handler without authentication.
+- Each builder function must be covered by a test that asserts every expected route
+  exists with the correct authorizer and that no normal route uses `/{proxy+}` or `ANY`.
+- For Control Plane APIs, routes must be added for both `/api/v1/...` and the legacy
+  `/api/control-plane/v1/...` prefixes.
+- When adding a new HTTP method (e.g., `PATCH`) that was not previously in the CORS
+  allowed-methods list, update `httpAPICorsConfigForOrigins` and its test.
+```
+
+---
+
+## Task 7: Update demo01 devo CORS for local development
+
+**Files:**
+- Modify: `ltbase-private-deployment-demo01/infra/Pulumi.devo.yaml`
+
+- [ ] **Step 1: Add localhost origin**
+
+Change the two CORS config lines to include `http://localhost:5173`:
+
+```yaml
+  ltbase-infra:controlPlaneCorsOrigins: https://demo01-admin.ltbase.dev,http://localhost:5173
+  ltbase-infra:controlPlaneCorsAllowOrigins: https://demo01-admin.ltbase.dev,http://localhost:5173
+```
+
+- [ ] **Step 2: Verify the change is syntactically valid**
+
+```bash
+cd /Users/ruoshi/code/Lychee/LTBase/ltbase-private-deployment-demo01
+# YAML is a superset of JSON; a quick parse check:
+python3 -c "import yaml; yaml.safe_load(open('infra/Pulumi.devo.yaml'))"
+```
+
+- [ ] **Step 3: After all Tasks 1-6 are merged in `ltbase-private-deployment`, run Pulumi preview for demo01 devo**
+
+```bash
+pulumi preview --stack devo
+```
+
+Expected: preview shows new explicit routes replacing `ANY /` and `ANY /{proxy+}`, no unexpected deletions, and CORS config includes both `https://demo01-admin.ltbase.dev` and `http://localhost:5173`.
+
+---
+
+## Task 8: Full verification
+
+- [ ] **Step 1: Run the full test suite for the infra services package**
+
+```bash
+cd /Users/ruoshi/code/Lychee/LTBase/ltbase-private-deployment
+go test ./infra/internal/services -v
+```
+
+- [ ] **Step 2: Run the full infra test suite**
+
+```bash
+cd /Users/ruoshi/code/Lychee/LTBase/ltbase-private-deployment
+go test ./infra/... -v
+```
+
+All tests must pass.
+
+---
+
+## GitHub Issues
+
+Corresponding issues to create:
+
+1. **ltbase-private-deployment**: "Replace catch-all API Gateway routes with explicit METHOD/path routes for Data Plane, Control Plane, and AuthService"
+   Covers Tasks 1-5.
+
+2. **ltbase.api**: "AGENTS.md: add API Gateway route sync instructions for explicit route config"
+   Covers Task 6.
+
+3. **ltbase-private-deployment-demo01**: "Allow localhost:5173 in devo Control Plane CORS configuration"
+   Covers Task 7.

--- a/__ref__/plan/2026-06-27-explicit-api-gateway-routes-plan.md
+++ b/__ref__/plan/2026-06-27-explicit-api-gateway-routes-plan.md
@@ -6,6 +6,21 @@
 
 **Repos affected:** `ltbase-private-deployment` (primary), `ltbase.api` (AGENTS.md), `ltbase-private-deployment-demo01` (config only).
 
+## Implementation Notes (post-implementation)
+
+The original plan had two bugs that were fixed during implementation:
+
+1. **Control Plane routes lacked HTTP methods.** The `controlPlaneRoutes` helper in Task 2 generated path-only route keys like `/api/v1/status` instead of `GET /api/v1/status`. API Gateway HTTP API routes require `METHOD /path` format. Fixed by generating explicit `"METHOD "+prefix+path` strings inside the builder, using a local closure `p(path)` for prefixing.
+
+2. **OPTIONS / suffix collision across APIs.** `OPTIONS /` appears in all three API route builders (Data Plane, Control Plane, AuthService). When `ensureUniqueRouteResourceSuffixes` was called with a combined route set in tests, identical FNV hashes caused duplicate disambiguated suffixes. Fixed by incorporating a disambiguation counter into the hash input.
+
+Additional implementation differences from the plan:
+- Route builders and helpers moved to new file `infra/internal/services/apigateway_routes.go` to keep `apigateway.go` under 500 lines.
+- `ensureUniqueRouteResourceSuffixes` added to handle Pulumi resource name collisions (e.g. `auth-config` vs `auth/config` both normalizing to the same suffix).
+- Control Plane routes enumerated with explicit `METHOD path` route keys rather than the buggy path-only helper.
+- `ltbase.api` AGENTS.md update deferred to separate issue (https://github.com/Lychee-Technology/ltbase.api/issues/397).
+- `ltbase-private-deployment-demo01` CORS update deferred (out of scope for #99).
+
 ---
 
 ## Task 1: Add route spec helper utilities

--- a/infra/internal/services/apigateway.go
+++ b/infra/internal/services/apigateway.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"fmt"
-	"hash/fnv"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -338,34 +337,26 @@ func ensureUniqueRouteResourceSuffixes(routes []routeSpec) []string {
 		bases[i] = routeResourceNameSuffix(r.RouteKey)
 		counts[bases[i]]++
 	}
-	colliding := make(map[string]bool)
-	for s, n := range counts {
-		if n > 1 {
-			colliding[s] = true
-		}
-	}
 	result := make([]string, len(routes))
 	used := make(map[string]bool)
 	disambiguator := make(map[string]int)
-	for i, r := range routes {
+	for i := range routes {
 		base := bases[i]
-		if colliding[base] {
-			for {
-				n := disambiguator[base]
-				disambiguator[base]++
-				h := fnv.New32a()
-				h.Write([]byte(r.RouteKey))
-				h.Write([]byte{byte(n), byte(n >> 8)})
-				candidate := fmt.Sprintf("%s-%x", base, h.Sum32())
-				if !used[candidate] {
-					result[i] = candidate
-					used[candidate] = true
-					break
-				}
-			}
-		} else {
+		if counts[base] == 1 {
 			result[i] = base
 			used[base] = true
+			continue
+		}
+		// Multiple route keys normalize to the same suffix; append an
+		// incrementing index until we reach an unused, deterministic name.
+		for {
+			disambiguator[base]++
+			candidate := fmt.Sprintf("%s-%d", base, disambiguator[base])
+			if !used[candidate] {
+				result[i] = candidate
+				used[candidate] = true
+				break
+			}
 		}
 	}
 	return result

--- a/infra/internal/services/apigateway.go
+++ b/infra/internal/services/apigateway.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	"hash/fnv"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -132,55 +133,6 @@ func ltbaseRefreshAuthorizerSpec(cfg config.StackConfig) authorizerSpec {
 	}
 }
 
-func buildAPIRouteSpecs() []routeSpec {
-	return []routeSpec{
-		{RouteKey: "GET /api/ai/v1/notes", AuthorizerName: "LTBase"},
-		{RouteKey: "POST /api/ai/v1/notes", AuthorizerName: "LTBase"},
-		{RouteKey: "GET /api/ai/v1/notes/{note_id}", AuthorizerName: "LTBase"},
-		{RouteKey: "PUT /api/ai/v1/notes/{note_id}", AuthorizerName: "LTBase"},
-		{RouteKey: "DELETE /api/ai/v1/notes/{note_id}", AuthorizerName: "LTBase"},
-		{RouteKey: "GET /api/ai/v1/notes/{note_id}/model_sync", AuthorizerName: "LTBase"},
-		{RouteKey: "POST /api/ai/v1/notes/{note_id}/model_sync", AuthorizerName: "LTBase"},
-		{RouteKey: "GET /api/v1/deepping", AuthorizerName: "LTBase"},
-		{RouteKey: "GET /api/v1/{schema_name}", AuthorizerName: "LTBase"},
-		{RouteKey: "POST /api/v1/{schema_name}", AuthorizerName: "LTBase"},
-		{RouteKey: "GET /api/v1/{schema_name}/{row_id}", AuthorizerName: "LTBase"},
-		{RouteKey: "PUT /api/v1/{schema_name}/{row_id}", AuthorizerName: "LTBase"},
-		{RouteKey: "DELETE /api/v1/{schema_name}/{row_id}", AuthorizerName: "LTBase"},
-	}
-}
-
-func buildControlPlaneRouteSpecs() []routeSpec {
-	return []routeSpec{
-		{RouteKey: "ANY /", AuthorizerName: "LTBase"},
-		{RouteKey: "ANY /{proxy+}", AuthorizerName: "LTBase"},
-	}
-}
-
-func legacyRouteAliasName(cfg config.StackConfig, suffix string, spec routeSpec) string {
-	if suffix != "control" {
-		return ""
-	}
-
-	switch spec.RouteKey {
-	case "ANY /":
-		return naming.ResourceName(cfg.Project, cfg.Stack, "control-root")
-	case "ANY /{proxy+}":
-		return naming.ResourceName(cfg.Project, cfg.Stack, "control-route")
-	default:
-		return ""
-	}
-}
-
-func routeAliases(cfg config.StackConfig, suffix string, spec routeSpec) []pulumi.Alias {
-	legacyName := legacyRouteAliasName(cfg, suffix, spec)
-	if legacyName == "" {
-		return nil
-	}
-
-	return []pulumi.Alias{{Name: pulumi.String(legacyName)}}
-}
-
 func buildAuthAuthorizerSpecs(cfg config.StackConfig, providerCfg AuthProviderConfig) []authorizerSpec {
 	specs := []authorizerSpec{ltbaseAuthorizerSpec(cfg), ltbaseRefreshAuthorizerSpec(cfg)}
 	for _, provider := range providerCfg.Providers {
@@ -191,22 +143,6 @@ func buildAuthAuthorizerSpecs(cfg config.StackConfig, providerCfg AuthProviderCo
 		})
 	}
 	return specs
-}
-
-func buildAuthRouteSpecs(providerCfg AuthProviderConfig) []routeSpec {
-	routes := []routeSpec{
-		{RouteKey: "GET /api/v1/auth/health"},
-		{RouteKey: "POST /api/v1/auth/refresh", AuthorizerName: "LTBaseRefresh"},
-	}
-	for _, provider := range providerCfg.Providers {
-		if provider.EnableIDBinding {
-			routes = append(routes, routeSpec{RouteKey: "POST /api/v1/id_bindings/" + provider.Name, AuthorizerName: provider.Name})
-		}
-		if provider.EnableLogin {
-			routes = append(routes, routeSpec{RouteKey: "POST /api/v1/login/" + provider.Name, AuthorizerName: provider.Name})
-		}
-	}
-	return routes
 }
 
 func newHTTPAPI(ctx *pulumi.Context, cfg config.StackConfig, providers Providers, domainCfg httpAPIDomainConfig, cert *acm.CertificateValidation, service *LambdaService, routes []routeSpec, authorizers []authorizerSpec) (*apigatewayv2.Api, error) {
@@ -256,8 +192,8 @@ func newHTTPAPI(ctx *pulumi.Context, cfg config.StackConfig, providers Providers
 		}
 		authorizerIDs[spec.Name] = authorizer.ID().ToStringOutput()
 	}
+	suffixes := ensureUniqueRouteResourceSuffixes(routes)
 	for i, spec := range routes {
-		_ = i
 		args := &apigatewayv2.RouteArgs{
 			ApiId:    api.ID(),
 			RouteKey: pulumi.String(spec.RouteKey),
@@ -267,11 +203,7 @@ func newHTTPAPI(ctx *pulumi.Context, cfg config.StackConfig, providers Providers
 			args.AuthorizationType = pulumi.StringPtr("JWT")
 			args.AuthorizerId = authorizerIDs[spec.AuthorizerName].ToStringPtrOutput()
 		}
-		options := []pulumi.ResourceOption{pulumi.Provider(providers.AWS)}
-		if aliases := routeAliases(cfg, domainCfg.Suffix, spec); len(aliases) > 0 {
-			options = append(options, pulumi.Aliases(aliases))
-		}
-		_, err = apigatewayv2.NewRoute(ctx, naming.ResourceName(cfg.Project, cfg.Stack, domainCfg.Suffix+"-route-"+routeResourceNameSuffix(spec.RouteKey)), args, options...)
+		_, err = apigatewayv2.NewRoute(ctx, naming.ResourceName(cfg.Project, cfg.Stack, domainCfg.Suffix+"-route-"+suffixes[i]), args, pulumi.Provider(providers.AWS))
 		if err != nil {
 			return nil, err
 		}
@@ -393,10 +325,50 @@ func buildHTTPAPIDomainConfigs(cfg config.StackConfig, truststore mtlsTruststore
 func httpAPICorsConfigForOrigins(origins []string) httpAPICorsConfig {
 	return httpAPICorsConfig{
 		AllowOrigins:     origins,
-		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
 		AllowHeaders:     []string{"Authorization", "Content-Type"},
 		AllowCredentials: false,
 	}
+}
+
+func ensureUniqueRouteResourceSuffixes(routes []routeSpec) []string {
+	bases := make([]string, len(routes))
+	counts := make(map[string]int)
+	for i, r := range routes {
+		bases[i] = routeResourceNameSuffix(r.RouteKey)
+		counts[bases[i]]++
+	}
+	colliding := make(map[string]bool)
+	for s, n := range counts {
+		if n > 1 {
+			colliding[s] = true
+		}
+	}
+	result := make([]string, len(routes))
+	used := make(map[string]bool)
+	disambiguator := make(map[string]int)
+	for i, r := range routes {
+		base := bases[i]
+		if colliding[base] {
+			for {
+				n := disambiguator[base]
+				disambiguator[base]++
+				h := fnv.New32a()
+				h.Write([]byte(r.RouteKey))
+				h.Write([]byte{byte(n), byte(n >> 8)})
+				candidate := fmt.Sprintf("%s-%x", base, h.Sum32())
+				if !used[candidate] {
+					result[i] = candidate
+					used[candidate] = true
+					break
+				}
+			}
+		} else {
+			result[i] = base
+			used[base] = true
+		}
+	}
+	return result
 }
 
 func apiDomainRecordArgs(cfg config.StackConfig, domain string, target pulumi.StringPtrInput) dns.RecordArgs {

--- a/infra/internal/services/apigateway_routes.go
+++ b/infra/internal/services/apigateway_routes.go
@@ -1,0 +1,210 @@
+package services
+
+func authorizedRoutes(authorizerName string, routeKeys ...string) []routeSpec {
+	routes := make([]routeSpec, len(routeKeys))
+	for i, key := range routeKeys {
+		routes[i] = routeSpec{RouteKey: key, AuthorizerName: authorizerName}
+	}
+	return routes
+}
+
+func preflightRoutes() []routeSpec {
+	return []routeSpec{
+		{RouteKey: "OPTIONS /"},
+		{RouteKey: "OPTIONS /{proxy+}"},
+	}
+}
+
+func buildAPIRouteSpecs() []routeSpec {
+	business := authorizedRoutes("LTBase",
+		"GET /api/ai/v1/notes",
+		"POST /api/ai/v1/notes",
+		"GET /api/ai/v1/notes/{note_id}",
+		"PUT /api/ai/v1/notes/{note_id}",
+		"DELETE /api/ai/v1/notes/{note_id}",
+		"GET /api/ai/v1/notes/{note_id}/model_sync",
+		"POST /api/ai/v1/notes/{note_id}/model_sync",
+
+		"POST /api/ai/v1/sessions",
+		"GET /api/ai/v1/sessions/{session_id}",
+		"GET /api/ai/v1/sessions/{session_id}/messages",
+		"POST /api/ai/v1/sessions/{session_id}/messages",
+		"POST /api/ai/v1/operations",
+
+		"POST /api/ai/v1/agent/sessions",
+		"GET /api/ai/v1/agent/sessions/{session_id}",
+		"DELETE /api/ai/v1/agent/sessions/{session_id}",
+		"GET /api/ai/v1/agent/sessions/{session_id}/turns",
+		"POST /api/ai/v1/agent/sessions/{session_id}/turns",
+		"GET /api/ai/v1/agent/sessions/{session_id}/turns/{turn_id}/citations",
+
+		"POST /api/ai/v1/intent-to-action/plans",
+		"POST /api/ai/v1/intent-to-action/executions",
+		"GET /api/ai/v1/intent-to-action/executions/{execution_id}",
+
+		"POST /api/ai/v1/governance/actions/execute",
+
+		"POST /api/ai/v1/compliance/decisions",
+
+		"GET /api/v1/deepping",
+		"GET /api/v1/schemas",
+		"GET /api/v1/tools",
+		"GET /api/v1/audit_records",
+		"GET /api/v1/search",
+		"POST /api/v1/advanced_query",
+		"GET /api/v1/{schema_name}",
+		"POST /api/v1/{schema_name}",
+		"DELETE /api/v1/{schema_name}",
+		"GET /api/v1/{schema_name}/{row_id}",
+		"PUT /api/v1/{schema_name}/{row_id}",
+		"DELETE /api/v1/{schema_name}/{row_id}",
+
+		"GET /api/ltflow/v1/tasks",
+		"GET /api/ltflow/v1/tasks/{task_id}",
+		"GET /api/ltflow/v1/instances",
+		"POST /api/ltflow/v1/instances",
+		"GET /api/ltflow/v1/instances/{instance_id}",
+		"POST /api/ltflow/v1/instances/{instance_id}/events",
+		"GET /api/ltflow/v1/instances/{instance_id}/history",
+
+		"POST /api/sys/v1/discovery/reachable",
+		"POST /api/sys/v1/discovery/paths",
+
+		"GET /api/sys/v1/ontology/object-types",
+		"GET /api/sys/v1/ontology/object-types/{type_name}",
+		"GET /api/sys/v1/ontology/link-types",
+		"GET /api/sys/v1/ontology/action-types",
+		"GET /api/sys/v1/ontology/objects/{type_name}/{row_id}",
+		"POST /api/sys/v1/ontology/objects/{type_name}/search",
+		"POST /api/sys/v1/ontology/objects/{type_name}/{row_id}/reachable",
+		"GET /api/sys/v1/ontology/objects/{type_name}/{row_id}/actions",
+		"GET /api/sys/v1/ontology/objects/{type_name}/{row_id}/provenance",
+
+		"GET /api/sys/v1/governance/entities/{entity}/capabilities",
+		"GET /api/sys/v1/governance/capabilities/{capability}",
+		"GET /api/sys/v1/governance/policies/{policy}/capabilities",
+		"GET /api/sys/v1/governance/claims",
+		"POST /api/sys/v1/governance/claims",
+		"POST /api/sys/v1/governance/claims/{claim_id}/approve",
+		"POST /api/sys/v1/governance/claims/{claim_id}/reject",
+		"GET /api/sys/v1/governance/events",
+		"POST /api/sys/v1/governance/evidence",
+		"GET /api/sys/v1/governance/evidence/{evidence_id}/gaps",
+		"GET /api/sys/v1/governance/evidence/{evidence_id}/expired",
+		"POST /api/sys/v1/governance/evidence/{evidence_id}/validate",
+		"POST /api/sys/v1/governance/monitoring/re-evaluate",
+
+		"GET /api/sys/v1/compliance/entities/{entity}",
+		"GET /api/sys/v1/compliance/capabilities/{capability}",
+		"GET /api/sys/v1/compliance/policies/{policy}",
+
+		"GET /api/v1/semantic/resources",
+		"GET /api/v1/semantic/resources/{resource_id}",
+		"GET /api/v1/semantic/lineage/{resource_id}",
+	)
+	return append(business, preflightRoutes()...)
+}
+
+func buildControlPlaneRouteSpecs() []routeSpec {
+	var business []routeSpec
+	for _, prefix := range []string{"/api/v1", "/api/control-plane/v1"} {
+		p := func(path string) string { return prefix + path }
+		business = append(business, authorizedRoutes("LTBase",
+			"GET "+p("/status"),
+			"GET "+p("/schema/status"),
+			"GET "+p("/workflows"),
+
+			"POST "+p("/repair/dry-run"),
+			"POST "+p("/repair/apply"),
+
+			"GET "+p("/catalogs/capabilities"),
+			"PUT "+p("/catalogs/capabilities"),
+			"GET "+p("/catalogs/action-templates"),
+			"PUT "+p("/catalogs/action-templates"),
+			"GET "+p("/catalogs/assistant-roles"),
+			"PUT "+p("/catalogs/assistant-roles"),
+
+			"GET "+p("/compliance-profile"),
+			"PUT "+p("/compliance-profile"),
+
+			"GET "+p("/auth-config"),
+			"GET "+p("/auth/config"),
+
+			"GET "+p("/referrals"),
+			"POST "+p("/referrals"),
+			"PATCH "+p("/referrals/{code}"),
+			"DELETE "+p("/referrals/{code}"),
+			"POST "+p("/referrals/{code}/disable"),
+
+			"GET "+p("/auth/referrals"),
+			"POST "+p("/auth/referrals"),
+			"PATCH "+p("/auth/referrals/{code}"),
+			"DELETE "+p("/auth/referrals/{code}"),
+			"POST "+p("/auth/referrals/{code}/disable"),
+
+			"GET "+p("/auth/users"),
+			"GET "+p("/auth/users/{user_id}"),
+			"PATCH "+p("/auth/users/{user_id}"),
+			"PUT "+p("/auth/users/{user_id}/roles/{role_id}"),
+			"DELETE "+p("/auth/users/{user_id}/roles/{role_id}"),
+
+			"GET "+p("/auth/roles"),
+			"POST "+p("/auth/roles"),
+			"GET "+p("/auth/roles/{role_id}"),
+			"PATCH "+p("/auth/roles/{role_id}"),
+			"DELETE "+p("/auth/roles/{role_id}"),
+
+			"GET "+p("/auth/policies"),
+			"POST "+p("/auth/policies"),
+			"GET "+p("/auth/policies/{policy_id}"),
+			"PATCH "+p("/auth/policies/{policy_id}"),
+			"DELETE "+p("/auth/policies/{policy_id}"),
+
+			"GET "+p("/auth/binding-policies"),
+			"POST "+p("/auth/binding-policies"),
+			"PATCH "+p("/auth/binding-policies/{policy_id}"),
+			"DELETE "+p("/auth/binding-policies/{policy_id}"),
+
+			"GET "+p("/auth/principals/{principal_type}/{principal_id}/policies"),
+			"PUT "+p("/auth/principals/{principal_type}/{principal_id}/policies/{policy_id}"),
+			"DELETE "+p("/auth/principals/{principal_type}/{principal_id}/policies/{policy_id}"),
+
+			"GET "+p("/org/units"),
+			"POST "+p("/org/units"),
+			"GET "+p("/org/units/{ou_id}"),
+			"PATCH "+p("/org/units/{ou_id}"),
+			"DELETE "+p("/org/units/{ou_id}"),
+			"GET "+p("/org/units/{ou_id}/users"),
+			"PUT "+p("/org/units/{ou_id}/users/{user_id}"),
+			"GET "+p("/org/units/{ou_id}/policies"),
+			"PUT "+p("/org/units/{ou_id}/policies/{policy_id}"),
+			"DELETE "+p("/org/units/{ou_id}/policies/{policy_id}"),
+
+			"GET "+p("/org/users/{user_id}/manager"),
+			"PUT "+p("/org/users/{user_id}/manager"),
+			"DELETE "+p("/org/users/{user_id}/manager"),
+			"GET "+p("/org/users/{user_id}/direct-reports"),
+			"GET "+p("/org/charts"),
+		)...)
+	}
+	return append(business, preflightRoutes()...)
+}
+
+func buildAuthRouteSpecs(providerCfg AuthProviderConfig) []routeSpec {
+	routes := []routeSpec{
+		{RouteKey: "GET /api/v1/auth/health"},
+		{RouteKey: "POST /api/v1/auth/refresh", AuthorizerName: "LTBaseRefresh"},
+		{RouteKey: "POST /api/v1/auth/revoke", AuthorizerName: "LTBase"},
+		{RouteKey: "GET /api/v1/auth/profile/{user_id}", AuthorizerName: "LTBase"},
+	}
+	for _, provider := range providerCfg.Providers {
+		if provider.EnableIDBinding {
+			routes = append(routes, routeSpec{RouteKey: "POST /api/v1/id_bindings/" + provider.Name, AuthorizerName: provider.Name})
+		}
+		if provider.EnableLogin {
+			routes = append(routes, routeSpec{RouteKey: "POST /api/v1/login/" + provider.Name, AuthorizerName: provider.Name})
+		}
+	}
+	routes = append(routes, preflightRoutes()...)
+	return routes
+}

--- a/infra/internal/services/apigateway_routes_test.go
+++ b/infra/internal/services/apigateway_routes_test.go
@@ -1,0 +1,299 @@
+package services
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAPIRouteSpecsHaveNoBusinessCatchAlls(t *testing.T) {
+	routes := buildAPIRouteSpecs()
+	for _, r := range routes {
+		if r.RouteKey == "OPTIONS /" || r.RouteKey == "OPTIONS /{proxy+}" {
+			continue
+		}
+		if strings.Contains(r.RouteKey, "ANY") || strings.Contains(r.RouteKey, "{proxy+}") {
+			t.Fatalf("route %q should not use ANY or {proxy+}", r.RouteKey)
+		}
+		if r.AuthorizerName != "LTBase" {
+			t.Fatalf("route %q authorizer = %q, want LTBase", r.RouteKey, r.AuthorizerName)
+		}
+	}
+}
+
+func TestAPIRouteSpecsIncludePreflight(t *testing.T) {
+	routes := buildAPIRouteSpecs()
+	foundOptionsRoot := false
+	foundOptionsProxy := false
+	for _, r := range routes {
+		if r.RouteKey == "OPTIONS /" {
+			foundOptionsRoot = true
+			if r.AuthorizerName != "" {
+				t.Fatal("OPTIONS / should have empty authorizer")
+			}
+		}
+		if r.RouteKey == "OPTIONS /{proxy+}" {
+			foundOptionsProxy = true
+			if r.AuthorizerName != "" {
+				t.Fatal("OPTIONS /{proxy+} should have empty authorizer")
+			}
+		}
+	}
+	if !foundOptionsRoot {
+		t.Fatal("missing OPTIONS / preflight route")
+	}
+	if !foundOptionsProxy {
+		t.Fatal("missing OPTIONS /{proxy+} preflight route")
+	}
+}
+
+func TestAPIRouteSpecsCoverKeyRoutes(t *testing.T) {
+	routes := buildAPIRouteSpecs()
+	routeSet := make(map[string]bool)
+	for _, r := range routes {
+		routeSet[r.RouteKey] = true
+	}
+	mustExist := []string{
+		"GET /api/ai/v1/notes",
+		"POST /api/ai/v1/notes",
+		"GET /api/ai/v1/notes/{note_id}",
+		"PUT /api/ai/v1/notes/{note_id}",
+		"DELETE /api/ai/v1/notes/{note_id}",
+		"GET /api/ai/v1/notes/{note_id}/model_sync",
+		"POST /api/ai/v1/notes/{note_id}/model_sync",
+		"POST /api/ai/v1/sessions",
+		"GET /api/ai/v1/sessions/{session_id}",
+		"POST /api/ai/v1/agent/sessions",
+		"POST /api/ai/v1/intent-to-action/plans",
+		"POST /api/ai/v1/governance/actions/execute",
+		"POST /api/ai/v1/compliance/decisions",
+		"GET /api/v1/deepping",
+		"GET /api/v1/semantic/resources",
+		"POST /api/sys/v1/discovery/reachable",
+		"GET /api/sys/v1/ontology/object-types",
+		"GET /api/sys/v1/governance/claims",
+		"POST /api/sys/v1/governance/evidence",
+		"GET /api/sys/v1/compliance/entities/{entity}",
+		"GET /api/ltflow/v1/tasks",
+		"POST /api/ltflow/v1/instances",
+		"OPTIONS /{proxy+}",
+	}
+	for _, key := range mustExist {
+		if !routeSet[key] {
+			t.Fatalf("missing route %q", key)
+		}
+	}
+}
+
+func TestControlPlaneRouteSpecsHaveNoBusinessCatchAlls(t *testing.T) {
+	routes := buildControlPlaneRouteSpecs()
+	for _, r := range routes {
+		if r.RouteKey == "OPTIONS /" || r.RouteKey == "OPTIONS /{proxy+}" {
+			continue
+		}
+		if strings.Contains(r.RouteKey, "ANY") || strings.Contains(r.RouteKey, "{proxy+}") {
+			t.Fatalf("route %q should not use ANY or {proxy+}", r.RouteKey)
+		}
+		if r.AuthorizerName != "LTBase" {
+			t.Fatalf("route %q authorizer = %q, want LTBase", r.RouteKey, r.AuthorizerName)
+		}
+	}
+}
+
+func TestControlPlaneRouteSpecsEveryRouteHasHTTPMethod(t *testing.T) {
+	routes := buildControlPlaneRouteSpecs()
+	for _, r := range routes {
+		if r.RouteKey == "OPTIONS /" || r.RouteKey == "OPTIONS /{proxy+}" {
+			continue
+		}
+		parts := strings.SplitN(r.RouteKey, " ", 2)
+		if len(parts) != 2 {
+			t.Fatalf("route %q missing HTTP method prefix", r.RouteKey)
+		}
+		method := strings.ToUpper(parts[0])
+		validMethods := map[string]bool{
+			"GET": true, "POST": true, "PUT": true,
+			"PATCH": true, "DELETE": true, "OPTIONS": true,
+		}
+		if !validMethods[method] {
+			t.Fatalf("route %q has invalid HTTP method %q", r.RouteKey, method)
+		}
+	}
+}
+
+func TestControlPlaneRouteSpecsCoverBothPrefixes(t *testing.T) {
+	routes := buildControlPlaneRouteSpecs()
+	routeSet := make(map[string]bool)
+	for _, r := range routes {
+		routeSet[r.RouteKey] = true
+	}
+	// Every key path must appear under both prefixes with some valid HTTP method.
+	keySuffixes := []string{
+		"/status", "/schema/status", "/workflows",
+		"/repair/dry-run", "/repair/apply",
+		"/catalogs/capabilities", "/catalogs/action-templates", "/catalogs/assistant-roles",
+		"/compliance-profile",
+		"/auth-config", "/auth/config",
+		"/referrals", "/referrals/{code}", "/referrals/{code}/disable",
+		"/auth/referrals", "/auth/referrals/{code}", "/auth/referrals/{code}/disable",
+		"/auth/users", "/auth/users/{user_id}", "/auth/users/{user_id}/roles/{role_id}",
+		"/auth/roles", "/auth/roles/{role_id}",
+		"/auth/policies", "/auth/policies/{policy_id}",
+		"/auth/binding-policies", "/auth/binding-policies/{policy_id}",
+		"/auth/principals/{principal_type}/{principal_id}/policies",
+		"/auth/principals/{principal_type}/{principal_id}/policies/{policy_id}",
+		"/org/units", "/org/units/{ou_id}", "/org/units/{ou_id}/users",
+		"/org/units/{ou_id}/users/{user_id}",
+		"/org/units/{ou_id}/policies", "/org/units/{ou_id}/policies/{policy_id}",
+		"/org/users/{user_id}/manager", "/org/users/{user_id}/direct-reports",
+		"/org/charts",
+	}
+	for _, suffix := range keySuffixes {
+		foundV1 := false
+		foundLegacy := false
+		for key := range routeSet {
+			if !strings.HasPrefix(key, "OPTIONS") {
+				if strings.HasSuffix(key, "/api/v1"+suffix) {
+					foundV1 = true
+				}
+				if strings.HasSuffix(key, "/api/control-plane/v1"+suffix) {
+					foundLegacy = true
+				}
+			}
+		}
+		if !foundV1 {
+			t.Fatalf("no route for suffix /api/v1%s", suffix)
+		}
+		if !foundLegacy {
+			t.Fatalf("no route for suffix /api/control-plane/v1%s", suffix)
+		}
+	}
+}
+
+func TestControlPlaneRouteSpecsIncludePreflight(t *testing.T) {
+	routes := buildControlPlaneRouteSpecs()
+	foundOptionsRoot := false
+	foundOptionsProxy := false
+	for _, r := range routes {
+		if r.RouteKey == "OPTIONS /" {
+			foundOptionsRoot = true
+			if r.AuthorizerName != "" {
+				t.Fatal("OPTIONS / should have empty authorizer")
+			}
+		}
+		if r.RouteKey == "OPTIONS /{proxy+}" {
+			foundOptionsProxy = true
+			if r.AuthorizerName != "" {
+				t.Fatal("OPTIONS /{proxy+} should have empty authorizer")
+			}
+		}
+	}
+	if !foundOptionsRoot {
+		t.Fatal("missing OPTIONS / preflight route")
+	}
+	if !foundOptionsProxy {
+		t.Fatal("missing OPTIONS /{proxy+} preflight route")
+	}
+}
+
+func TestAuthRouteSpecsIncludeRevokeAndProfile(t *testing.T) {
+	providerCfg := AuthProviderConfig{
+		Providers: []AuthProvider{
+			{Name: "firebase", Issuer: "https://issuer.example.com", Audiences: []string{"aud-1"}, EnableLogin: true, EnableIDBinding: true},
+			{Name: "apple", Issuer: "https://apple.example.com", Audiences: []string{"aud-2"}, EnableLogin: true, EnableIDBinding: false},
+		},
+	}
+	routes := buildAuthRouteSpecs(providerCfg)
+
+	check := func(wantKey, wantAuth string) {
+		t.Helper()
+		found := false
+		for _, r := range routes {
+			if r.RouteKey == wantKey {
+				found = true
+				if r.AuthorizerName != wantAuth {
+					t.Fatalf("route %q authorizer = %q, want %q", wantKey, r.AuthorizerName, wantAuth)
+				}
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("route %q not found in %d routes", wantKey, len(routes))
+		}
+	}
+
+	check("GET /api/v1/auth/health", "")
+	check("POST /api/v1/auth/refresh", "LTBaseRefresh")
+	check("POST /api/v1/auth/revoke", "LTBase")
+	check("GET /api/v1/auth/profile/{user_id}", "LTBase")
+	check("POST /api/v1/login/firebase", "firebase")
+	check("POST /api/v1/login/apple", "apple")
+	check("POST /api/v1/id_bindings/firebase", "firebase")
+	check("OPTIONS /", "")
+	check("OPTIONS /{proxy+}", "")
+}
+
+func TestAuthRouteSpecsNoBusinessCatchAlls(t *testing.T) {
+	providerCfg := AuthProviderConfig{
+		Providers: []AuthProvider{
+			{Name: "firebase", Issuer: "https://issuer.example.com", Audiences: []string{"aud-1"}, EnableLogin: true, EnableIDBinding: true},
+		},
+	}
+	routes := buildAuthRouteSpecs(providerCfg)
+	for _, r := range routes {
+		if r.RouteKey == "OPTIONS /" || r.RouteKey == "OPTIONS /{proxy+}" {
+			continue
+		}
+		if strings.Contains(r.RouteKey, "ANY") || strings.Contains(r.RouteKey, "{proxy+}") {
+			t.Fatalf("route %q should not use ANY or {proxy+}", r.RouteKey)
+		}
+	}
+}
+
+func TestRouteSuffixesAreUniqueForAllRouteBuilders(t *testing.T) {
+	providerCfg := AuthProviderConfig{
+		Providers: []AuthProvider{
+			{Name: "firebase", Issuer: "https://issuer.example.com", Audiences: []string{"aud-1"}, EnableLogin: true, EnableIDBinding: true},
+		},
+	}
+	allRoutes := append(buildAPIRouteSpecs(), buildControlPlaneRouteSpecs()...)
+	allRoutes = append(allRoutes, buildAuthRouteSpecs(providerCfg)...)
+
+	suffixes := ensureUniqueRouteResourceSuffixes(allRoutes)
+	seen := make(map[string]string) // suffix -> first routeKey
+	for i, s := range suffixes {
+		if prev, exists := seen[s]; exists {
+			t.Fatalf("suffix collision: %q used by both %q and %q", s, prev, allRoutes[i].RouteKey)
+		}
+		seen[s] = allRoutes[i].RouteKey
+	}
+	if len(suffixes) != len(allRoutes) {
+		t.Fatalf("suffix count = %d, want %d", len(suffixes), len(allRoutes))
+	}
+}
+
+func TestCORSConfigurationIncludesPatch(t *testing.T) {
+	config := httpAPICorsConfigForOrigins([]string{"https://example.com"})
+	methods := config.AllowMethods
+	hasPATCH := false
+	for _, m := range methods {
+		if m == "PATCH" {
+			hasPATCH = true
+			break
+		}
+	}
+	if !hasPATCH {
+		t.Fatalf("allow methods missing PATCH: %#v", methods)
+	}
+}
+
+func TestPreflightRoutesNoAuthorizer(t *testing.T) {
+	routes := preflightRoutes()
+	if len(routes) != 2 {
+		t.Fatalf("preflight route count = %d, want 2", len(routes))
+	}
+	for _, r := range routes {
+		if r.AuthorizerName != "" {
+			t.Fatalf("preflight route %q has authorizer %q, want empty", r.RouteKey, r.AuthorizerName)
+		}
+	}
+}

--- a/infra/internal/services/apigateway_routes_test.go
+++ b/infra/internal/services/apigateway_routes_test.go
@@ -249,26 +249,45 @@ func TestAuthRouteSpecsNoBusinessCatchAlls(t *testing.T) {
 	}
 }
 
+func assertUniqueRouteSuffixes(t *testing.T, routes []routeSpec) {
+	t.Helper()
+	suffixes := ensureUniqueRouteResourceSuffixes(routes)
+	seen := make(map[string]string) // suffix -> first routeKey
+	for i, s := range suffixes {
+		if prev, exists := seen[s]; exists {
+			t.Fatalf("suffix collision: %q used by both %q and %q", s, prev, routes[i].RouteKey)
+		}
+		seen[s] = routes[i].RouteKey
+	}
+	if len(suffixes) != len(routes) {
+		t.Fatalf("suffix count = %d, want %d", len(suffixes), len(routes))
+	}
+}
+
+func TestRouteSuffixesAreUniquePerBuilder(t *testing.T) {
+	providerCfg := AuthProviderConfig{
+		Providers: []AuthProvider{
+			{Name: "firebase", Issuer: "https://issuer.example.com", Audiences: []string{"aud-1"}, EnableLogin: true, EnableIDBinding: true},
+		},
+	}
+	// Each builder runs on its own API Gateway, so per-builder uniqueness is the
+	// production-relevant guarantee.
+	assertUniqueRouteSuffixes(t, buildAPIRouteSpecs())
+	assertUniqueRouteSuffixes(t, buildControlPlaneRouteSpecs())
+	assertUniqueRouteSuffixes(t, buildAuthRouteSpecs(providerCfg))
+}
+
 func TestRouteSuffixesAreUniqueForAllRouteBuilders(t *testing.T) {
 	providerCfg := AuthProviderConfig{
 		Providers: []AuthProvider{
 			{Name: "firebase", Issuer: "https://issuer.example.com", Audiences: []string{"aud-1"}, EnableLogin: true, EnableIDBinding: true},
 		},
 	}
+	// The merged set never occurs in production (the builders run on separate
+	// gateways); it is an intentional stress test of the dedup logic.
 	allRoutes := append(buildAPIRouteSpecs(), buildControlPlaneRouteSpecs()...)
 	allRoutes = append(allRoutes, buildAuthRouteSpecs(providerCfg)...)
-
-	suffixes := ensureUniqueRouteResourceSuffixes(allRoutes)
-	seen := make(map[string]string) // suffix -> first routeKey
-	for i, s := range suffixes {
-		if prev, exists := seen[s]; exists {
-			t.Fatalf("suffix collision: %q used by both %q and %q", s, prev, allRoutes[i].RouteKey)
-		}
-		seen[s] = allRoutes[i].RouteKey
-	}
-	if len(suffixes) != len(allRoutes) {
-		t.Fatalf("suffix count = %d, want %d", len(suffixes), len(allRoutes))
-	}
+	assertUniqueRouteSuffixes(t, allRoutes)
 }
 
 func TestCORSConfigurationIncludesPatch(t *testing.T) {

--- a/infra/internal/services/apigateway_test.go
+++ b/infra/internal/services/apigateway_test.go
@@ -9,43 +9,6 @@ import (
 	"lychee.technology/ltbase/infra/internal/dns"
 )
 
-func TestBuildAPIRouteSpecs(t *testing.T) {
-	routes := buildAPIRouteSpecs()
-	if len(routes) != 13 {
-		t.Fatalf("route count = %d, want 13", len(routes))
-	}
-	if routes[0].RouteKey != "GET /api/ai/v1/notes" {
-		t.Fatalf("first route = %q", routes[0].RouteKey)
-	}
-	wantRoutes := map[string]bool{
-		"GET /api/ai/v1/notes/{note_id}/model_sync":  false,
-		"POST /api/ai/v1/notes/{note_id}/model_sync": false,
-	}
-	for _, route := range routes {
-		if route.AuthorizerName != "LTBase" {
-			t.Fatalf("route %q authorizer = %q, want LTBase", route.RouteKey, route.AuthorizerName)
-		}
-		if _, ok := wantRoutes[route.RouteKey]; ok {
-			wantRoutes[route.RouteKey] = true
-		}
-	}
-	for routeKey, found := range wantRoutes {
-		if !found {
-			t.Fatalf("missing API route %q", routeKey)
-		}
-	}
-}
-
-func TestBuildControlPlaneRouteSpecs(t *testing.T) {
-	routes := buildControlPlaneRouteSpecs()
-	if len(routes) != 2 {
-		t.Fatalf("route count = %d, want 2", len(routes))
-	}
-	if routes[0].RouteKey != "ANY /" || routes[1].RouteKey != "ANY /{proxy+}" {
-		t.Fatalf("unexpected control routes: %#v", routes)
-	}
-}
-
 func TestBuildAuthProviderAuthorizerSpecs(t *testing.T) {
 	providerCfg := AuthProviderConfig{
 		Providers: []AuthProvider{
@@ -67,57 +30,10 @@ func TestBuildAuthProviderAuthorizerSpecs(t *testing.T) {
 	}
 }
 
-func TestBuildAuthRouteSpecs(t *testing.T) {
-	providerCfg := AuthProviderConfig{
-		Providers: []AuthProvider{
-			{Name: "firebase", Issuer: "https://issuer.example.com", Audiences: []string{"aud-1"}, EnableLogin: true, EnableIDBinding: true},
-			{Name: "apple", Issuer: "https://apple.example.com", Audiences: []string{"aud-2"}, EnableLogin: true, EnableIDBinding: false},
-		},
-	}
-	routes := buildAuthRouteSpecs(providerCfg)
-	if len(routes) != 5 {
-		t.Fatalf("route count = %d, want 5", len(routes))
-	}
-	if routes[0].RouteKey != "GET /api/v1/auth/health" || routes[0].AuthorizerName != "" {
-		t.Fatalf("unexpected health route: %#v", routes[0])
-	}
-	if routes[1].RouteKey != "POST /api/v1/auth/refresh" || routes[1].AuthorizerName != "LTBaseRefresh" {
-		t.Fatalf("unexpected refresh route: %#v", routes[1])
-	}
-	if routes[4].RouteKey != "POST /api/v1/login/apple" {
-		t.Fatalf("unexpected final route: %#v", routes[4])
-	}
-}
-
 func TestRouteResourceNameIsStableFromRouteKey(t *testing.T) {
 	got := routeResourceNameSuffix("POST /api/v1/id_bindings/firebase")
 	if got != "post-api-v1-id-bindings-firebase" {
 		t.Fatalf("routeResourceNameSuffix() = %q", got)
-	}
-}
-
-func TestControlRouteAliases(t *testing.T) {
-	cfg := config.StackConfig{Project: "ltbase-infra", Stack: "devo"}
-	tests := []struct {
-		name     string
-		suffix   string
-		routeKey string
-		want     string
-	}{
-		{name: "control root", suffix: "control", routeKey: "ANY /", want: "ltbase-infra-devo-control-root"},
-		{name: "control proxy", suffix: "control", routeKey: "ANY /{proxy+}", want: "ltbase-infra-devo-control-route"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := legacyRouteAliasName(cfg, tt.suffix, routeSpec{RouteKey: tt.routeKey}); got != tt.want {
-				t.Fatalf("legacyRouteAliasName() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-
-	if got := legacyRouteAliasName(cfg, "api", routeSpec{RouteKey: "ANY /"}); got != "" {
-		t.Fatalf("non-control alias = %q, want empty", got)
 	}
 }
 
@@ -218,6 +134,16 @@ func TestHTTPAPICORSConfigurationUsesConfiguredOrigins(t *testing.T) {
 	}
 	if len(config.AllowMethods) == 0 {
 		t.Fatal("allow methods should not be empty")
+	}
+	hasPATCH := false
+	for _, m := range config.AllowMethods {
+		if m == "PATCH" {
+			hasPATCH = true
+			break
+		}
+	}
+	if !hasPATCH {
+		t.Fatalf("allow methods missing PATCH: %#v", config.AllowMethods)
 	}
 	if len(config.AllowHeaders) == 0 {
 		t.Fatal("allow headers should not be empty")


### PR DESCRIPTION
Closes #99

## What changed

- Replace `buildAPIRouteSpecs` with explicit Data Plane routes covering notes, Forma CRUD, agent sessions, LTFlow, intent-to-action, discovery, ontology, governance, compliance, semantic resources
- Replace `buildControlPlaneRouteSpecs` with explicit Control Plane routes covering both `/api/v1/...` and `/api/control-plane/v1/...` prefixes
- Expand `buildAuthRouteSpecs` with `POST /api/v1/auth/revoke`, `GET /api/v1/auth/profile/{user_id}`, and preflight routes
- Remove `ANY /` and `ANY /{proxy+}` business catch-all routes; retain only `OPTIONS /` and `OPTIONS /{proxy+}` as unauthenticated preflight
- Add `ensureUniqueRouteResourceSuffixes` to prevent Pulumi resource name collisions (e.g. `auth-config` vs `auth/config`)
- Remove legacy alias machinery (`legacyRouteAliasName`, `routeAliases`)
- Add `PATCH` to CORS allowed methods
- New tests lock in route table, authorizer assignment, preflight constraints, and suffix uniqueness

## Related

- `ltbase.api` AGENTS.md update: Lychee-Technology/ltbase.api#397