### PR TITLE
feat: inline OIDC discovery generation scripts into deployment template

### DIFF
--- a/scripts/build-discovery.sh
+++ b/scripts/build-discovery.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Required environment variables:
+#   OIDC_DISCOVERY_DOMAIN        – custom domain for discovery documents
+#   OIDC_DISCOVERY_STACK_CONFIG  – JSON mapping stack name -> {aws_region, aws_role_arn, kms_auth_key_alias}
+#   OIDC_DISCOVERY_OUTPUT_DIR    – directory to write generated files into
+# Optional:
+#   TARGET_STACK                 – "all" (default) or a specific stack name
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GENERATE_JWKS="${SCRIPT_DIR}/generate-jwks.py"
+
+fail() {
+  printf '::error::%s\n' "$1" >&2
+  exit 1
+}
+
+# --- validate required vars ---
+
+[[ -n "${OIDC_DISCOVERY_DOMAIN:-}" ]]       || fail "OIDC_DISCOVERY_DOMAIN is not set"
+[[ -n "${OIDC_DISCOVERY_STACK_CONFIG:-}" ]] || fail "OIDC_DISCOVERY_STACK_CONFIG is not set"
+[[ -n "${OIDC_DISCOVERY_OUTPUT_DIR:-}" ]]   || fail "OIDC_DISCOVERY_OUTPUT_DIR is not set"
+
+if ! echo "${OIDC_DISCOVERY_STACK_CONFIG}" | jq -e 'type == "object"' >/dev/null 2>&1; then
+  fail "OIDC_DISCOVERY_STACK_CONFIG must be a valid JSON object"
+fi
+
+TARGET_STACK="${TARGET_STACK:-all}"
+
+# --- determine stacks ---
+
+if [[ "${TARGET_STACK}" == "all" ]]; then
+  stacks=()
+  while IFS= read -r line; do
+    [[ -n "${line}" ]] || continue
+    stacks+=("${line}")
+  done < <(echo "${OIDC_DISCOVERY_STACK_CONFIG}" | jq -r 'keys[]')
+else
+  if ! echo "${OIDC_DISCOVERY_STACK_CONFIG}" | jq -e --arg s "${TARGET_STACK}" '.[$s]' >/dev/null 2>&1; then
+    fail "Stack '${TARGET_STACK}' not found in OIDC_DISCOVERY_STACK_CONFIG"
+  fi
+  stacks=("${TARGET_STACK}")
+fi
+
+for stack in "${stacks[@]}"; do
+  if [[ ! "${stack}" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+    fail "Invalid stack name '${stack}' in OIDC_DISCOVERY_STACK_CONFIG"
+  fi
+done
+
+# --- generate per-stack documents ---
+#
+# This script is generation-only: it writes the configured stacks into a fresh
+# output dir. Reconciling repo state (pruning stacks that are no longer
+# configured) is the publishing workflow's responsibility, since only the
+# workflow has the committed repo to compare against.
+
+mkdir -p "${OIDC_DISCOVERY_OUTPUT_DIR}"
+
+current_stack_manifest="$(mktemp)"
+trap 'rm -f "${current_stack_manifest}"' EXIT
+
+for stack in "${stacks[@]}"; do
+  echo "::group::${stack}"
+
+  aws_region=$(echo "${OIDC_DISCOVERY_STACK_CONFIG}" | jq -r --arg s "${stack}" '.[$s].aws_region')
+  aws_role_arn=$(echo "${OIDC_DISCOVERY_STACK_CONFIG}" | jq -r --arg s "${stack}" '.[$s].aws_role_arn')
+  kms_alias=$(echo "${OIDC_DISCOVERY_STACK_CONFIG}" | jq -r --arg s "${stack}" '.[$s].kms_auth_key_alias')
+
+  # Obtain a fresh GitHub OIDC token and assume the stack IAM role.
+  oidc_token_response=$(curl -sS -f \
+    -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+    "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com") || fail "Failed to obtain GitHub OIDC token"
+
+  oidc_token=$(echo "${oidc_token_response}" | jq -r '.value')
+  if [[ -z "${oidc_token}" || "${oidc_token}" == "null" ]]; then
+    fail "GitHub OIDC token value is empty"
+  fi
+
+  creds=$(AWS_DEFAULT_REGION="${aws_region}" aws sts assume-role-with-web-identity \
+    --role-arn "${aws_role_arn}" \
+    --role-session-name "oidc-discovery-${stack}" \
+    --web-identity-token "${oidc_token}" \
+    --duration-seconds 900 \
+    --output json) || fail "Failed to assume role ${aws_role_arn}"
+
+  # Split assignment from export so set -e catches a failed jq.
+  AWS_ACCESS_KEY_ID=$(echo "${creds}" | jq -r '.Credentials.AccessKeyId'); export AWS_ACCESS_KEY_ID
+  AWS_SECRET_ACCESS_KEY=$(echo "${creds}" | jq -r '.Credentials.SecretAccessKey'); export AWS_SECRET_ACCESS_KEY
+  AWS_SESSION_TOKEN=$(echo "${creds}" | jq -r '.Credentials.SessionToken'); export AWS_SESSION_TOKEN
+  export AWS_DEFAULT_REGION="${aws_region}"
+
+  # Fetch the RSA public key from KMS.
+  public_key_json=$(aws kms get-public-key --key-id "${kms_alias}" --output json) || fail "Failed to get KMS public key for ${kms_alias}"
+  public_key_b64=$(echo "${public_key_json}" | jq -r '.PublicKey')
+  key_id=$(echo "${public_key_json}" | jq -r '.KeyId')
+
+  # Generate JWKS.
+  mkdir -p "${OIDC_DISCOVERY_OUTPUT_DIR}/${stack}/.well-known"
+  python3 "${GENERATE_JWKS}" \
+    --public-key-b64 "${public_key_b64}" \
+    --key-id "${key_id}" \
+    > "${OIDC_DISCOVERY_OUTPUT_DIR}/${stack}/.well-known/jwks.json"
+
+  # Generate openid-configuration.
+  python3 -c "
+import json, sys
+domain = sys.argv[1]
+stack = sys.argv[2]
+print(json.dumps({
+    'issuer': f'https://{domain}/{stack}',
+    'jwks_uri': f'https://{domain}/{stack}/.well-known/jwks.json',
+    'response_types_supported': ['id_token'],
+    'subject_types_supported': ['public'],
+    'id_token_signing_alg_values_supported': ['RS256'],
+}, indent=2))" "${OIDC_DISCOVERY_DOMAIN}" "${stack}" \
+    > "${OIDC_DISCOVERY_OUTPUT_DIR}/${stack}/.well-known/openid-configuration"
+
+  echo "Published: ${stack}/.well-known/jwks.json"
+  echo "Published: ${stack}/.well-known/openid-configuration"
+
+  printf '%s\n' "${stack}" >> "${current_stack_manifest}"
+
+  # Clear per-stack credentials.
+  unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_DEFAULT_REGION
+
+  echo "::endgroup::"
+done
+
+# --- generate _headers ---
+
+headers_file="${OIDC_DISCOVERY_OUTPUT_DIR}/_headers"
+: > "${headers_file}"
+
+while IFS= read -r stack; do
+  [[ -n "${stack}" ]] || continue
+  printf '/%s/.well-known/openid-configuration\n  Content-Type: application/json; charset=utf-8\n\n/%s/.well-known/jwks.json\n  Content-Type: application/json; charset=utf-8\n\n' \
+    "${stack}" "${stack}" >> "${headers_file}"
+done < "${current_stack_manifest}"

--- a/scripts/build-discovery.sh
+++ b/scripts/build-discovery.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 GENERATE_JWKS="${SCRIPT_DIR}/generate-jwks.py"
 
 fail() {
-  printf '::error::%s\n' "$1" >&2
+  printf '%s\n' "$1" >&2
   exit 1
 }
 
@@ -62,11 +62,20 @@ current_stack_manifest="$(mktemp)"
 trap 'rm -f "${current_stack_manifest}"' EXIT
 
 for stack in "${stacks[@]}"; do
-  echo "::group::${stack}"
+  echo "Generating discovery documents for ${stack}"
 
   aws_region=$(echo "${OIDC_DISCOVERY_STACK_CONFIG}" | jq -r --arg s "${stack}" '.[$s].aws_region')
   aws_role_arn=$(echo "${OIDC_DISCOVERY_STACK_CONFIG}" | jq -r --arg s "${stack}" '.[$s].aws_role_arn')
   kms_alias=$(echo "${OIDC_DISCOVERY_STACK_CONFIG}" | jq -r --arg s "${stack}" '.[$s].kms_auth_key_alias')
+
+  # Each missing JSON key yields the literal string "null" from jq -r; reject it
+  # before it flows into AWS calls as a bogus --role-arn / --key-id argument.
+  [[ -n "${aws_region}" && "${aws_region}" != "null" ]] \
+    || fail "Stack '${stack}' is missing required field 'aws_region' in OIDC_DISCOVERY_STACK_CONFIG"
+  [[ -n "${aws_role_arn}" && "${aws_role_arn}" != "null" ]] \
+    || fail "Stack '${stack}' is missing required field 'aws_role_arn' in OIDC_DISCOVERY_STACK_CONFIG"
+  [[ -n "${kms_alias}" && "${kms_alias}" != "null" ]] \
+    || fail "Stack '${stack}' is missing required field 'kms_auth_key_alias' in OIDC_DISCOVERY_STACK_CONFIG"
 
   # Obtain a fresh GitHub OIDC token and assume the stack IAM role.
   oidc_token_response=$(curl -sS -f \
@@ -96,6 +105,13 @@ for stack in "${stacks[@]}"; do
   public_key_b64=$(echo "${public_key_json}" | jq -r '.PublicKey')
   key_id=$(echo "${public_key_json}" | jq -r '.KeyId')
 
+  if [[ -z "${public_key_b64}" || "${public_key_b64}" == "null" ]]; then
+    fail "KMS get-public-key returned no PublicKey for ${kms_alias}"
+  fi
+  if [[ -z "${key_id}" || "${key_id}" == "null" ]]; then
+    fail "KMS get-public-key returned no KeyId for ${kms_alias}"
+  fi
+
   # Generate JWKS.
   mkdir -p "${OIDC_DISCOVERY_OUTPUT_DIR}/${stack}/.well-known"
   python3 "${GENERATE_JWKS}" \
@@ -124,8 +140,6 @@ print(json.dumps({
 
   # Clear per-stack credentials.
   unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_DEFAULT_REGION
-
-  echo "::endgroup::"
 done
 
 # --- generate _headers ---

--- a/scripts/generate-jwks.py
+++ b/scripts/generate-jwks.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Convert a DER-encoded RSA public key to a JWKS document (RFC 7517).
+
+Zero external dependencies — uses only Python 3 stdlib.
+Parses the fixed ASN.1 DER layout of SubjectPublicKeyInfo for RSA keys.
+"""
+
+import argparse
+import base64
+import json
+import re
+import sys
+
+_KMS_ARN_RE = re.compile(r"^arn:aws:kms:[^:]+:\d+:key/(.+)$")
+
+
+def extract_kms_key_id(key_id):
+    """Extract the key UUID from a KMS key ARN, or return as-is if not an ARN."""
+    m = _KMS_ARN_RE.match(key_id)
+    return m.group(1) if m else key_id
+
+
+def _read_der_length(data, offset):
+    """Read a DER length field. Returns (length, new_offset)."""
+    first = data[offset]
+    if first < 0x80:
+        return first, offset + 1
+    num_bytes = first & 0x7F
+    length = 0
+    for i in range(num_bytes):
+        length = (length << 8) | data[offset + 1 + i]
+    return length, offset + 1 + num_bytes
+
+
+def _read_der_element(data, offset, expected_tag):
+    """Read a DER element with the expected tag. Returns (content, new_offset)."""
+    if offset >= len(data):
+        raise ValueError(f"unexpected end of data at offset {offset}")
+    if data[offset] != expected_tag:
+        raise ValueError(
+            f"expected tag 0x{expected_tag:02x} at offset {offset}, "
+            f"got 0x{data[offset]:02x}"
+        )
+    length, value_offset = _read_der_length(data, offset + 1)
+    end = value_offset + length
+    if end > len(data):
+        raise ValueError(f"element at offset {offset} extends past end of data")
+    return data[value_offset:end], end
+
+
+TAG_SEQUENCE = 0x30
+TAG_BIT_STRING = 0x03
+TAG_INTEGER = 0x02
+
+
+def parse_rsa_public_key_der(der_bytes):
+    """Extract (modulus_bytes, exponent_bytes) from DER-encoded SubjectPublicKeyInfo.
+
+    The DER structure for RSA is:
+        SEQUENCE {
+            SEQUENCE { OID rsaEncryption, NULL }
+            BIT STRING {
+                SEQUENCE {
+                    INTEGER modulus
+                    INTEGER exponent
+                }
+            }
+        }
+    """
+    outer, _ = _read_der_element(der_bytes, 0, TAG_SEQUENCE)
+    pos = 0
+
+    # Skip algorithm identifier SEQUENCE
+    _, pos = _read_der_element(outer, pos, TAG_SEQUENCE)
+
+    # BIT STRING wrapping the RSA public key
+    bit_string, _ = _read_der_element(outer, pos, TAG_BIT_STRING)
+    if bit_string[0] != 0:
+        raise ValueError("unexpected unused bits in BIT STRING")
+    inner = bit_string[1:]
+
+    # Inner SEQUENCE: modulus + exponent
+    rsa_seq, _ = _read_der_element(inner, 0, TAG_SEQUENCE)
+    pos = 0
+    n_bytes, pos = _read_der_element(rsa_seq, pos, TAG_INTEGER)
+    e_bytes, _ = _read_der_element(rsa_seq, pos, TAG_INTEGER)
+
+    # Strip DER INTEGER leading-zero padding (sign byte)
+    if len(n_bytes) > 1 and n_bytes[0] == 0:
+        n_bytes = n_bytes[1:]
+    if len(e_bytes) > 1 and e_bytes[0] == 0:
+        e_bytes = e_bytes[1:]
+
+    return bytes(n_bytes), bytes(e_bytes)
+
+
+def base64url_encode(data):
+    """Base64url encode without padding (RFC 7515 section 2)."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate JWKS from a DER-encoded RSA public key"
+    )
+    parser.add_argument(
+        "--public-key-b64",
+        required=True,
+        help="Base64-encoded DER SubjectPublicKeyInfo",
+    )
+    parser.add_argument(
+        "--key-id",
+        required=True,
+        help="Key identifier (typically a KMS key ARN)",
+    )
+    args = parser.parse_args()
+
+    der_bytes = base64.b64decode(args.public_key_b64)
+    n_bytes, e_bytes = parse_rsa_public_key_der(der_bytes)
+
+    jwks = {
+        "keys": [
+            {
+                "kty": "RSA",
+                "alg": "RS256",
+                "use": "sig",
+                "kid": extract_kms_key_id(args.key_id),
+                "n": base64url_encode(n_bytes),
+                "e": base64url_encode(e_bytes),
+            }
+        ]
+    }
+    json.dump(jwks, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/build-discovery-test.sh
+++ b/test/build-discovery-test.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_SCRIPT="${SCRIPT_DIR}/scripts/build-discovery.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_dir_contains() {
+  local dir="$1"
+  local path="$2"
+  if [[ ! -e "${dir}/${path}" ]]; then
+    fail "expected ${dir}/${path} to exist"
+  fi
+}
+
+assert_dir_not_contains() {
+  local dir="$1"
+  local path="$2"
+  if [[ -e "${dir}/${path}" ]]; then
+    fail "expected ${dir}/${path} to not exist"
+  fi
+}
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+fake_bin="${temp_dir}/bin"
+mkdir -p "${fake_bin}"
+
+# --- fake KMS public key (DER-encoded RSA, generated below) ---
+kms_public_key_b64="$(python3 -c '
+import base64, struct
+
+# Build a minimal valid DER RSA SubjectPublicKeyInfo by hand.
+# SPKI ::= SEQUENCE { AlgorithmIdentifier, BIT STRING { SEQUENCE { INTEGER n, INTEGER e } } }
+def der_length(length):
+    if length < 0x80:
+        return bytes([length])
+    elif length < 0x100:
+        return bytes([0x81, length])
+    else:
+        return bytes([0x82, (length >> 8) & 0xFF, length & 0xFF])
+
+# RSA OID 1.2.840.113549.1.1.1 = 2A 86 48 86 F7 0D 01 01 01
+rsa_oid = bytes([0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x01, 0x01])
+# AlgorithmIdentifier ::= SEQUENCE { OID rsaEncryption, NULL }
+null_bytes = bytes([0x05, 0x00])
+algo_id_inner = rsa_oid + null_bytes
+algo_id = b"\x30" + der_length(len(algo_id_inner)) + algo_id_inner
+
+# RSA public key ::= SEQUENCE { INTEGER modulus, INTEGER exponent }
+modulus = bytes(range(256))     # 256-byte fake modulus
+exponent = b"\x01\x00\x01"       # 65537
+
+def der_integer(value):
+    if value[0] & 0x80:
+        value = b"\x00" + value
+    return b"\x02" + der_length(len(value)) + value
+
+rsa_key_inner = der_integer(modulus) + der_integer(exponent)
+rsa_key = b"\x30" + der_length(len(rsa_key_inner)) + rsa_key_inner
+
+# BIT STRING wrapping RSA key (with 0 unused bits header)
+bit_string = b"\x03" + der_length(len(rsa_key) + 1) + b"\x00" + rsa_key
+
+# Full SPKI
+spki_inner = algo_id + bit_string
+spki = b"\x30" + der_length(len(spki_inner)) + spki_inner
+
+print(base64.b64encode(spki).decode())
+')"
+
+# --- fake aws ---
+cat >"${fake_bin}/aws" <<'AWSEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-} ${2:-}" == "kms get-public-key" ]]; then
+  printf '{"KeyId":"arn:aws:kms:us-east-1:123456789012:key/test-key-00001","PublicKey":"%s"}\n' "${KMS_PUBLIC_KEY_B64:-}"
+  exit 0
+fi
+if [[ "${1:-} ${2:-}" == "sts assume-role-with-web-identity" ]]; then
+  cat <<'EOF'
+{"Credentials":{"AccessKeyId":"AKIAIOSFODNN7EXAMPLE","SecretAccessKey":"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY","SessionToken":"FQoGZXIvYXdzE..."}}
+EOF
+  exit 0
+fi
+printf 'aws unexpected: %s\n' "$*" >&2
+exit 1
+AWSEOF
+chmod +x "${fake_bin}/aws"
+
+# --- fake curl ---
+cat >"${fake_bin}/curl" <<'CURLEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{"value":"fake-oidc-token"}\n'
+exit 0
+CURLEOF
+chmod +x "${fake_bin}/curl"
+
+# --- test stack config ---
+stack_config='{"devo":{"aws_region":"us-east-1","aws_role_arn":"arn:aws:iam::123456789012:role/ltbase-oidc-devo","kms_auth_key_alias":"alias/ltbase-devo-auth"},"prod":{"aws_region":"us-west-2","aws_role_arn":"arn:aws:iam::210987654321:role/ltbase-oidc-prod","kms_auth_key_alias":"alias/ltbase-prod-auth"}}'
+
+run_build() {
+  local output_dir="$1"
+  local target_stack="${2:-all}"
+  local domain="${3:-oidc.example.com}"
+
+  PATH="${fake_bin}:$PATH" \
+    KMS_PUBLIC_KEY_B64="${kms_public_key_b64}" \
+    OIDC_DISCOVERY_DOMAIN="${domain}" \
+    OIDC_DISCOVERY_STACK_CONFIG="${stack_config}" \
+    OIDC_DISCOVERY_OUTPUT_DIR="${output_dir}" \
+    TARGET_STACK="${target_stack}" \
+    ACTIONS_ID_TOKEN_REQUEST_TOKEN="fake-github-token" \
+    ACTIONS_ID_TOKEN_REQUEST_URL="https://pipelines.actions.githubusercontent.com/abcdef/" \
+    "${BUILD_SCRIPT}" >/dev/null 2>&1
+}
+
+# ---------- Test 1: all stacks ----------
+
+output_dir="${temp_dir}/all-stacks"
+mkdir -p "${output_dir}"
+if ! run_build "${output_dir}" "all"; then
+  fail "expected build with all stacks to succeed"
+fi
+
+for stack in devo prod; do
+  assert_dir_contains "${output_dir}" "${stack}/.well-known/jwks.json"
+  assert_dir_contains "${output_dir}" "${stack}/.well-known/openid-configuration"
+done
+
+assert_dir_contains "${output_dir}" "_headers"
+
+# ---------- Test 2: single stack ----------
+
+output_dir="${temp_dir}/single-stack"
+mkdir -p "${output_dir}"
+if ! run_build "${output_dir}" "devo"; then
+  fail "expected build with single stack to succeed"
+fi
+
+assert_dir_contains "${output_dir}" "devo/.well-known/jwks.json"
+assert_dir_contains "${output_dir}" "devo/.well-known/openid-configuration"
+assert_dir_not_contains "${output_dir}" "prod"
+
+# ---------- Test 3: generation-only (does not prune unrelated content) ----------
+# The script is generation-only; pruning stale stacks is the workflow's job.
+# A pre-existing dir not in the config must be left untouched.
+
+output_dir="${temp_dir}/generation-only"
+mkdir -p "${output_dir}"
+mkdir -p "${output_dir}/stale/.well-known"
+: > "${output_dir}/stale/.well-known/jwks.json"
+: > "${output_dir}/stale/.well-known/openid-configuration"
+
+if ! run_build "${output_dir}" "all"; then
+  fail "expected build to succeed"
+fi
+
+assert_dir_contains "${output_dir}" "stale/.well-known/jwks.json"
+assert_dir_contains "${output_dir}" "devo/.well-known/jwks.json"
+assert_dir_contains "${output_dir}" "prod/.well-known/jwks.json"
+
+# ---------- Test 4: missing required env vars ----------
+
+if OIDC_DISCOVERY_OUTPUT_DIR="${temp_dir}/no-domain" \
+   KMS_PUBLIC_KEY_B64="${kms_public_key_b64}" \
+   PATH="${fake_bin}:$PATH" \
+   "${BUILD_SCRIPT}" 2>/dev/null; then
+  fail "expected failure when OIDC_DISCOVERY_DOMAIN is missing"
+fi
+
+# ---------- Test 5: invalid JSON config ----------
+
+output_dir="${temp_dir}/bad-config"
+mkdir -p "${output_dir}"
+if KMS_PUBLIC_KEY_B64="${kms_public_key_b64}" \
+   OIDC_DISCOVERY_DOMAIN="oidc.example.com" \
+   OIDC_DISCOVERY_STACK_CONFIG="not-json" \
+   OIDC_DISCOVERY_OUTPUT_DIR="${output_dir}" \
+   ACTIONS_ID_TOKEN_REQUEST_TOKEN="fake-github-token" \
+   ACTIONS_ID_TOKEN_REQUEST_URL="https://pipelines.actions.githubusercontent.com/abcdef/" \
+   PATH="${fake_bin}:$PATH" \
+   "${BUILD_SCRIPT}" 2>/dev/null; then
+  fail "expected failure with invalid JSON config"
+fi
+
+# ---------- Test 6: unknown target stack ----------
+
+output_dir="${temp_dir}/bad-target"
+mkdir -p "${output_dir}"
+if KMS_PUBLIC_KEY_B64="${kms_public_key_b64}" \
+   OIDC_DISCOVERY_DOMAIN="oidc.example.com" \
+   OIDC_DISCOVERY_STACK_CONFIG="${stack_config}" \
+   OIDC_DISCOVERY_OUTPUT_DIR="${output_dir}" \
+   TARGET_STACK="nonexistent" \
+   ACTIONS_ID_TOKEN_REQUEST_TOKEN="fake-github-token" \
+   ACTIONS_ID_TOKEN_REQUEST_URL="https://pipelines.actions.githubusercontent.com/abcdef/" \
+   PATH="${fake_bin}:$PATH" \
+   "${BUILD_SCRIPT}" 2>/dev/null; then
+  fail "expected failure with unknown target stack"
+fi
+
+# ---------- Test 7: openid-configuration content ----------
+
+output_dir="${temp_dir}/config-content"
+mkdir -p "${output_dir}"
+run_build "${output_dir}" "devo" "oidc.example.com"
+
+openid_config="${output_dir}/devo/.well-known/openid-configuration"
+actual_issuer="$(python3 -c "import json; print(json.load(open('${openid_config}'))['issuer'])")"
+expected_issuer="https://oidc.example.com/devo"
+if [[ "${actual_issuer}" != "${expected_issuer}" ]]; then
+  fail "expected issuer ${expected_issuer}, got ${actual_issuer}"
+fi
+
+# ---------- Test 8: _headers content ----------
+
+output_dir="${temp_dir}/headers-content"
+mkdir -p "${output_dir}"
+run_build "${output_dir}" "devo" "oidc.example.com"
+
+if ! grep -q '/devo/.well-known/openid-configuration' "${output_dir}/_headers"; then
+  fail "missing devo openid-configuration header entry"
+fi
+if ! grep -q 'Content-Type: application/json' "${output_dir}/_headers"; then
+  fail "missing Content-Type header in _headers"
+fi
+
+printf 'PASS: build-discovery tests\n'

--- a/test/build-discovery-test.sh
+++ b/test/build-discovery-test.sh
@@ -207,6 +207,40 @@ if KMS_PUBLIC_KEY_B64="${kms_public_key_b64}" \
   fail "expected failure with unknown target stack"
 fi
 
+# ---------- Test 6b: stack config missing a required inner field ----------
+
+output_dir="${temp_dir}/missing-field"
+mkdir -p "${output_dir}"
+missing_field_config='{"devo":{"aws_region":"us-east-1","kms_auth_key_alias":"alias/ltbase-devo-auth"}}'
+if KMS_PUBLIC_KEY_B64="${kms_public_key_b64}" \
+   OIDC_DISCOVERY_DOMAIN="oidc.example.com" \
+   OIDC_DISCOVERY_STACK_CONFIG="${missing_field_config}" \
+   OIDC_DISCOVERY_OUTPUT_DIR="${output_dir}" \
+   ACTIONS_ID_TOKEN_REQUEST_TOKEN="fake-github-token" \
+   ACTIONS_ID_TOKEN_REQUEST_URL="https://pipelines.actions.githubusercontent.com/abcdef/" \
+   PATH="${fake_bin}:$PATH" \
+   "${BUILD_SCRIPT}" 2>/dev/null; then
+  fail "expected failure when a stack config entry omits a required field"
+fi
+
+# ---------- Test 6c: empty KMS public key ----------
+# The fake aws echoes KMS_PUBLIC_KEY_B64 into PublicKey; an empty value must be
+# rejected rather than passed on to generate-jwks.py.
+
+output_dir="${temp_dir}/empty-kms-key"
+mkdir -p "${output_dir}"
+if KMS_PUBLIC_KEY_B64="" \
+   OIDC_DISCOVERY_DOMAIN="oidc.example.com" \
+   OIDC_DISCOVERY_STACK_CONFIG="${stack_config}" \
+   OIDC_DISCOVERY_OUTPUT_DIR="${output_dir}" \
+   TARGET_STACK="devo" \
+   ACTIONS_ID_TOKEN_REQUEST_TOKEN="fake-github-token" \
+   ACTIONS_ID_TOKEN_REQUEST_URL="https://pipelines.actions.githubusercontent.com/abcdef/" \
+   PATH="${fake_bin}:$PATH" \
+   "${BUILD_SCRIPT}" 2>/dev/null; then
+  fail "expected failure when KMS returns an empty PublicKey"
+fi
+
 # ---------- Test 7: openid-configuration content ----------
 
 output_dir="${temp_dir}/config-content"

--- a/test/generate-jwks-test.sh
+++ b/test/generate-jwks-test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+GENERATE_SCRIPT="${SCRIPT_DIR}/scripts/generate-jwks.py"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+temp_dir="$(mktemp -d)"
+trap 'rm -rf "${temp_dir}"' EXIT
+
+# --- Setup: generate a test RSA key pair with openssl ---
+
+openssl genrsa -out "${temp_dir}/private.pem" 2048 2>/dev/null
+openssl rsa -in "${temp_dir}/private.pem" -pubout -outform DER \
+  -out "${temp_dir}/public.der" 2>/dev/null
+
+# Extract expected modulus (uppercase hex, no prefix) via openssl
+expected_modulus_hex="$(openssl rsa -in "${temp_dir}/private.pem" \
+  -pubout -outform DER 2>/dev/null \
+  | openssl rsa -pubin -inform DER -modulus -noout 2>/dev/null \
+  | sed 's/Modulus=//')"
+
+# Base64-encode the DER key (single line, portable across macOS/Linux)
+public_key_b64="$(base64 < "${temp_dir}/public.der" | tr -d '\n')"
+
+test_key_id="arn:aws:kms:us-west-2:123456789012:key/test-key-id-00001"
+
+# --- Test 1: output is valid JSON ---
+
+if ! output="$(python3 "${GENERATE_SCRIPT}" \
+    --public-key-b64 "${public_key_b64}" \
+    --key-id "${test_key_id}" 2>&1)"; then
+  fail "generate-jwks.py exited non-zero: ${output}"
+fi
+
+if ! printf '%s' "${output}" | python3 -m json.tool >/dev/null 2>&1; then
+  fail "output is not valid JSON: ${output}"
+fi
+
+# --- Test 2: required JWKS fields present with correct values ---
+
+expected_kid="${test_key_id##*/key/}"
+
+if ! python3 - "${expected_kid}" "${expected_modulus_hex}" <<'PYEOF' <<<"${output}"
+import json, sys, base64
+
+jwks = json.load(sys.stdin)
+expected_kid = sys.argv[1]
+expected_hex = sys.argv[2]
+
+assert "keys" in jwks, "missing 'keys'"
+assert len(jwks["keys"]) == 1, f"expected 1 key, got {len(jwks['keys'])}"
+
+k = jwks["keys"][0]
+
+assert k["kty"] == "RSA", f"kty={k['kty']}"
+assert k["alg"] == "RS256", f"alg={k['alg']}"
+assert k["use"] == "sig", f"use={k['use']}"
+assert k["kid"] == expected_kid, f"kid={k['kid']}"
+
+for field in ("n", "e"):
+    v = k[field]
+    assert "=" not in v, f"{field} has base64 padding"
+    assert "+" not in v, f"{field} has + (not url-safe)"
+    assert "/" not in v, f"{field} has / (not url-safe)"
+
+# Round-trip: decode n and verify modulus matches openssl output
+n_padded = k["n"] + "=" * (-len(k["n"]) % 4)
+n_bytes = base64.urlsafe_b64decode(n_padded)
+n_hex = n_bytes.hex().upper()
+assert n_hex == expected_hex.upper(), (
+    f"modulus mismatch:\n  got:      {n_hex[:40]}...\n  expected: {expected_hex[:40]}..."
+)
+PYEOF
+then
+  fail "field validation failed"
+fi
+
+# --- Test 3: different key produces different output ---
+
+openssl genrsa -out "${temp_dir}/private2.pem" 2048 2>/dev/null
+openssl rsa -in "${temp_dir}/private2.pem" -pubout -outform DER \
+  -out "${temp_dir}/public2.der" 2>/dev/null
+public_key_b64_2="$(base64 < "${temp_dir}/public2.der" | tr -d '\n')"
+
+output2="$(python3 "${GENERATE_SCRIPT}" \
+  --public-key-b64 "${public_key_b64_2}" \
+  --key-id "other-key-id")"
+
+n1="$(printf '%s' "${output}" | python3 -c "import json,sys; print(json.load(sys.stdin)['keys'][0]['n'])")"
+n2="$(printf '%s' "${output2}" | python3 -c "import json,sys; print(json.load(sys.stdin)['keys'][0]['n'])")"
+
+if [[ "${n1}" == "${n2}" ]]; then
+  fail "two different keys produced the same modulus"
+fi
+
+printf 'PASS: generate-jwks tests\n'


### PR DESCRIPTION
## Summary

Add `build-discovery.sh`, `generate-jwks.py`, and tests into the deployment template so generated deployment repositories can produce OIDC discovery documents without depending on the external `ltbase-oidc-discovery-template` checkout.

## Changes

- **`scripts/build-discovery.sh`** — per-stack OIDC discovery generation via GitHub Actions OIDC → AWS STS → KMS get-public-key. Produces `openid-configuration`, `jwks.json`, and Cloudflare Pages `_headers`.
- **`scripts/generate-jwks.py`** — stdlib-only DER RSA public key → RFC 7517 JWKS converter, uses KMS key UUID as `kid`.
- **`test/build-discovery-test.sh`** — 8 scenarios: all-stack, single-stack, generation-only (no prune), missing env, invalid config, unknown stack, openid config content, _headers content.
- **`test/generate-jwks-test.sh`** — 3 scenarios: valid JSON, required JWKS fields + base64url + modulus round-trip, different keys produce different output.

## Review follow-up

The two scripts were initially inlined byte-identical from `ltbase-oidc-discovery-template`. A review of this PR surfaced robustness/house-style issues that shipped verbatim from upstream, fixed here in a follow-up commit (`build-discovery.sh` only). This **intentionally diverges** from upstream; the standalone template repo is left untouched pending its deprecation (Lychee-Technology/ltbase-oidc-discovery-template#4).

- Validate per-stack config fields (`aws_region`, `aws_role_arn`, `kms_auth_key_alias`) before use — a missing JSON key yielded the literal `null` from `jq -r`, which previously flowed into AWS calls as a bogus `--role-arn` / `--key-id`.
- Guard the `kms get-public-key` output (`PublicKey`, `KeyId`) for empty/null, matching the existing GitHub OIDC token check, so an unexpected KMS response fails with a clear message instead of a cryptic downstream JWKS parse error.
- Replace GitHub Actions `::error::`/`::group::`/`::endgroup::` annotations with plain stderr/stdout to match the house style used by every other script in `scripts/`.
- Added tests for the missing-field and empty-KMS-key failure paths.

## Scope

This PR only adds the local generation scripts and tests. It does not:
- Update `publish-oidc-discovery.yml` to use local scripts (→ #108)
- Remove `OIDC_DISCOVERY_TEMPLATE_REPO/REF` from bootstrap (→ #109)
- Clean up onboarding docs (→ #110)

Closes #107
Part of #106
