### PR TITLE
Publish OIDC discovery from local scripts without checking out the template repo

### DIFF
--- a/.github/workflows/publish-oidc-discovery.yml
+++ b/.github/workflows/publish-oidc-discovery.yml
@@ -22,10 +22,6 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
-        with:
-          repository: ${{ vars.OIDC_DISCOVERY_TEMPLATE_REPO }}
-          ref: ${{ vars.OIDC_DISCOVERY_TEMPLATE_REF }}
-          path: oidc-template
 
       - name: Generate discovery documents
         env:
@@ -33,8 +29,7 @@ jobs:
           OIDC_DISCOVERY_STACK_CONFIG: ${{ vars.OIDC_DISCOVERY_STACK_CONFIG }}
           TARGET_STACK: ${{ inputs.target_stack }}
           OIDC_DISCOVERY_OUTPUT_DIR: ${{ runner.temp }}/discovery-output
-        working-directory: oidc-template
-        run: scripts/build-discovery.sh
+        run: ./scripts/build-discovery.sh
 
       - name: Stage discovery site
         id: stage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,52 @@
+name: Test
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    if: github.repository == 'Lychee-Technology/ltbase-private-deployment'
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Ensure test dependencies
+        run: |
+          set -euo pipefail
+          if ! command -v jq >/dev/null 2>&1; then
+            sudo apt-get update && sudo apt-get install -y jq
+          fi
+          command -v python3 >/dev/null 2>&1 || {
+            echo "python3 is required to run the test suite" >&2
+            exit 1
+          }
+
+      - name: Run test suite
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          tests=(test/*-test.sh)
+          if [[ ${#tests[@]} -eq 0 ]]; then
+            echo "No test/*-test.sh files found" >&2
+            exit 1
+          fi
+
+          status=0
+          for test in "${tests[@]}"; do
+            echo "::group::${test}"
+            if ! bash "${test}"; then
+              status=1
+              echo "::error file=${test}::test failed"
+            fi
+            echo "::endgroup::"
+          done
+
+          exit "${status}"

--- a/scripts/bootstrap-aws-foundation.sh
+++ b/scripts/bootstrap-aws-foundation.sh
@@ -42,9 +42,10 @@ capture_stdout_quiet() {
     rm -f "${stderr_file}"
     printf -v "${destination_var}" '%s' "${output}"
     return 0
+  else
+    command_status=$?
   fi
 
-  command_status=$?
   if [[ -s "${stderr_file}" ]]; then
     cat "${stderr_file}" >&2
   fi

--- a/scripts/bootstrap-controlplane-ui-companion.sh
+++ b/scripts/bootstrap-controlplane-ui-companion.sh
@@ -42,9 +42,10 @@ capture_stdout_quiet() {
     rm -f "${stderr_file}"
     printf -v "${destination_var}" '%s' "${output}"
     return 0
+  else
+    command_status=$?
   fi
 
-  command_status=$?
   if [[ -s "${stderr_file}" ]]; then
     cat "${stderr_file}" >&2
   fi

--- a/scripts/bootstrap-oidc-discovery.sh
+++ b/scripts/bootstrap-oidc-discovery.sh
@@ -42,9 +42,10 @@ capture_stdout_quiet() {
     rm -f "${stderr_file}"
     printf -v "${destination_var}" '%s' "${output}"
     return 0
+  else
+    command_status=$?
   fi
 
-  command_status=$?
   if [[ -s "${stderr_file}" ]]; then
     cat "${stderr_file}" >&2
   fi

--- a/scripts/create-deployment-repo.sh
+++ b/scripts/create-deployment-repo.sh
@@ -37,9 +37,10 @@ capture_stdout_quiet() {
     rm -f "${stderr_file}"
     printf -v "${destination_var}" '%s' "${output}"
     return 0
+  else
+    command_status=$?
   fi
 
-  command_status=$?
   if [[ -s "${stderr_file}" ]]; then
     cat "${stderr_file}" >&2
   fi

--- a/scripts/evaluate-and-continue.sh
+++ b/scripts/evaluate-and-continue.sh
@@ -98,9 +98,10 @@ capture_stdout_quiet() {
     rm -f "${stderr_file}"
     printf -v "${destination_var}" '%s' "${output}"
     return 0
+  else
+    command_status=$?
   fi
 
-  command_status=$?
   if [[ -s "${stderr_file}" ]]; then
     cat "${stderr_file}" >&2
   fi

--- a/test/publish-oidc-discovery-workflow-test.sh
+++ b/test/publish-oidc-discovery-workflow-test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+WORKFLOW_PATH="${ROOT_DIR}/.github/workflows/publish-oidc-discovery.yml"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local path="$1"
+  local needle="$2"
+  if [[ ! -f "${path}" ]]; then
+    fail "missing file: ${path}"
+  fi
+  if ! grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to contain: ${needle}"
+  fi
+}
+
+assert_file_not_contains() {
+  local path="$1"
+  local needle="$2"
+  if [[ ! -f "${path}" ]]; then
+    fail "missing file: ${path}"
+  fi
+  if grep -Fq "${needle}" "${path}"; then
+    fail "expected ${path} to not contain: ${needle}"
+  fi
+}
+
+# ---------- required permissions ----------
+
+assert_file_contains "${WORKFLOW_PATH}" "id-token: write"
+
+# ---------- checkout and generate step ----------
+
+assert_file_contains "${WORKFLOW_PATH}" "actions/checkout@v6"
+
+assert_file_contains "${WORKFLOW_PATH}" "./scripts/build-discovery.sh"
+
+# ---------- removed template checkout dependencies ----------
+
+assert_file_not_contains "${WORKFLOW_PATH}" "OIDC_DISCOVERY_TEMPLATE_REPO"
+assert_file_not_contains "${WORKFLOW_PATH}" "OIDC_DISCOVERY_TEMPLATE_REF"
+assert_file_not_contains "${WORKFLOW_PATH}" "path: oidc-template"
+assert_file_not_contains "${WORKFLOW_PATH}" "working-directory: oidc-template"
+
+# ---------- target stack support ----------
+
+assert_file_contains "${WORKFLOW_PATH}" 'default: "all"'
+assert_file_contains "${WORKFLOW_PATH}" "TARGET_STACK: \${{ inputs.target_stack }}"
+
+# ---------- Cloudflare Pages direct upload ----------
+
+assert_file_contains "${WORKFLOW_PATH}" "cloudflare/wrangler-action@v3"
+assert_file_contains "${WORKFLOW_PATH}" "pages deploy"
+
+printf 'PASS: publish-oidc-discovery-workflow tests\n'


### PR DESCRIPTION
Closes #108
Parent: #106

- Remove `OIDC_DISCOVERY_TEMPLATE_REPO` / `OIDC_DISCOVERY_TEMPLATE_REF` checkout from the publish workflow
- Generate discovery documents directly using local `./scripts/build-discovery.sh`
- Add static workflow test to prevent re-introducing template checkout dependencies
- Keep `id-token: write`, `wrangler-action@v3` deploy, and all/single-stack support intact