### PR TITLE
docs: clean up OIDC discovery onboarding after removing template repo dependency

### DIFF
--- a/docs/onboarding/04-prepare-env-file.md
+++ b/docs/onboarding/04-prepare-env-file.md
@@ -32,6 +32,7 @@ Use this guide to create the local `.env` file that drives the bootstrap scripts
     - `CONTROLPLANE_UI_DOMAIN`
     - `CLOUDFLARE_ACCOUNT_ID`
     - Source: your Cloudflare account and the custom domains you want to use for OIDC discovery and the control-plane UI admin site
+    - OIDC discovery uses a direct-upload Cloudflare Pages project managed entirely by the deployment repository. Bootstrap creates the Pages project, custom domain binding, and per-stack IAM roles; the `publish-oidc-discovery.yml` workflow generates discovery documents and deploys them with `wrangler pages deploy`. No OIDC discovery companion repository or template repository is created or required.
     - In the current repository version, the Control Plane UI bootstrap uses `CONTROLPLANE_UI_DOMAIN` when it provisions the control-plane UI companion Pages site and when it later writes `ltbase-infra:controlPlaneCorsOrigins=https://<CONTROLPLANE_UI_DOMAIN>` into each Pulumi stack.
 5. Fill in AWS environment values (one pair per stack):
    - `AWS_REGION_<STACK>`

--- a/docs/onboarding/04-prepare-env-file.zh.md
+++ b/docs/onboarding/04-prepare-env-file.zh.md
@@ -32,6 +32,7 @@
     - `CONTROLPLANE_UI_DOMAIN`
     - `CLOUDFLARE_ACCOUNT_ID`
     - 来源：你的 Cloudflare account，以及你计划给 OIDC discovery 和 control-plane UI admin 站点使用的自定义域名
+    - OIDC discovery 采用直接上传（direct-upload）的 Cloudflare Pages 项目，完全由部署仓库管理。Bootstrap 会创建 Pages 项目、自定义域名绑定和每个 stack 的 IAM role；`publish-oidc-discovery.yml` 工作流生成 discovery 文档，并通过 `wrangler pages deploy` 发布。不会创建也不需要 OIDC discovery companion 仓库或模板仓库。
     - 在当前仓库版本中，Control Plane UI bootstrap 会使用 `CONTROLPLANE_UI_DOMAIN` 来初始化 control-plane UI companion Pages 站点，并在后续把 `ltbase-infra:controlPlaneCorsOrigins=https://<CONTROLPLANE_UI_DOMAIN>` 写入每个 Pulumi stack。
 5. 填写 AWS 环境信息（每个 stack 一组）：
    - `AWS_REGION_<STACK>`

--- a/docs/onboarding/05-bootstrap-one-click.md
+++ b/docs/onboarding/05-bootstrap-one-click.md
@@ -134,7 +134,7 @@ The one-click script runs these stages in order:
 
 `bootstrap-aws-foundation.sh` creates the shared Pulumi backend bucket once in the AWS account for the first stack in `PROMOTION_PATH`, then prepares per-stack role and secrets-provider inputs for every stack in `STACKS`.
 
-`bootstrap-oidc-discovery.sh` also creates the required Cloudflare DNS `CNAME` for `OIDC_DISCOVERY_DOMAIN` so the custom domain resolves directly to `${OIDC_DISCOVERY_PAGES_PROJECT}.pages.dev`.
+`bootstrap-oidc-discovery.sh` creates the OIDC discovery Cloudflare Pages project as a direct-upload project (no companion repository), its custom domain binding, the required zone DNS `CNAME` pointing at `${OIDC_DISCOVERY_PAGES_PROJECT}.pages.dev`, and per-stack OIDC discovery IAM roles. The deployment repository's own `publish-oidc-discovery.yml` workflow then generates the discovery documents and publishes them with `wrangler pages deploy`.
 
 `bootstrap-controlplane-ui-companion.sh` currently creates or updates the control-plane UI companion repository, ensures its Cloudflare Pages project and custom domain, writes companion repository variables including `CONTROLPLANE_UI_STACK_CONFIG`, and updates `public/ltbase-controlplane.config.json` with per-stack public browser config for Firebase and Supabase.
 

--- a/docs/onboarding/05-bootstrap-one-click.zh.md
+++ b/docs/onboarding/05-bootstrap-one-click.zh.md
@@ -134,7 +134,7 @@ AWS_PROFILE_STAGING=customer-staging aws sts get-caller-identity
 
 `bootstrap-aws-foundation.sh` 会先在 `PROMOTION_PATH` 第一个 stack 对应的 AWS 账户中创建一次共享 Pulumi backend bucket，然后为 `STACKS` 中每个 stack 准备各自的 role 和 secrets provider 输入。
 
-`bootstrap-oidc-discovery.sh` 还会为 `OIDC_DISCOVERY_DOMAIN` 创建必需的 Cloudflare DNS `CNAME`，让这个自定义域名直接解析到 `${OIDC_DISCOVERY_PAGES_PROJECT}.pages.dev`。
+`bootstrap-oidc-discovery.sh` 会创建 OIDC discovery Cloudflare Pages 项目（直接上传，无 companion 仓库）、其自定义域名绑定、所需的 zone DNS `CNAME`（指向 `${OIDC_DISCOVERY_PAGES_PROJECT}.pages.dev`），以及每个 stack 对应的 OIDC discovery IAM role。随后由部署仓库自身的 `publish-oidc-discovery.yml` 工作流生成 discovery 文档，并通过 `wrangler pages deploy` 发布。
 
 `bootstrap-controlplane-ui-companion.sh` 当前会创建或更新 control-plane UI companion 仓库，确保其 Cloudflare Pages project 和自定义域名，写入包括 `CONTROLPLANE_UI_STACK_CONFIG` 在内的 companion 仓库变量，并用每个 stack 的 Firebase/Supabase 公开浏览器配置更新 `public/ltbase-controlplane.config.json`。
 

--- a/test/oidc-discovery-docs-test.sh
+++ b/test/oidc-discovery-docs-test.sh
@@ -61,8 +61,8 @@ assert_no_match_in() {
   shift 2
   local docs=("$@")
   for doc in "${docs[@]}"; do
-    if grep -n "${pattern}" "${doc}" >/dev/null 2>&1; then
-      fail "${reason}: found in ${doc}: $(grep -n "${pattern}" "${doc}")"
+    if grep -niF "${pattern}" "${doc}" >/dev/null 2>&1; then
+      fail "${reason}: found in ${doc}: $(grep -niF "${pattern}" "${doc}")"
     fi
   done
 }
@@ -85,8 +85,6 @@ assert_no_match_in "must not mention OIDC_DISCOVERY_TEMPLATE_REPO" 'OIDC_DISCOVE
 assert_no_match_in "must not mention OIDC_DISCOVERY_TEMPLATE_REF" 'OIDC_DISCOVERY_TEMPLATE_REF' "${ALL_DOCS[@]}"
 assert_no_match_in "must not mention ltbase-oidc-discovery-template" 'ltbase-oidc-discovery-template' "${ALL_DOCS[@]}"
 assert_no_match_in "must not mention bootstrap-oidc-discovery-companion" 'bootstrap-oidc-discovery-companion' "${ALL_DOCS[@]}"
-assert_no_match_in "must not imply an OIDC discovery companion repo is needed" 'oidc discovery companion repo' "${ALL_DOCS[@]}"
-assert_no_match_in "must not imply an OIDC discovery template repo is needed" 'OIDC discovery template' "${ALL_DOCS[@]}"
 
 # ---------- .env docs: must state template repo variables are not needed ----------
 

--- a/test/oidc-discovery-docs-test.sh
+++ b/test/oidc-discovery-docs-test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Active operator-facing docs (exclude historical superpowers/ plans and specs).
+ALL_DOCS=(
+  "${ROOT_DIR}/README.md"
+  "${ROOT_DIR}/README.zh.md"
+  "${ROOT_DIR}/docs/BOOTSTRAP.md"
+  "${ROOT_DIR}/docs/BOOTSTRAP.zh.md"
+  "${ROOT_DIR}/docs/CUSTOMER_ONBOARDING.md"
+  "${ROOT_DIR}/docs/CUSTOMER_ONBOARDING.zh.md"
+  "${ROOT_DIR}/docs/onboarding/01-prerequisites.md"
+  "${ROOT_DIR}/docs/onboarding/01-prerequisites.zh.md"
+  "${ROOT_DIR}/docs/onboarding/02-create-repo-and-clone.md"
+  "${ROOT_DIR}/docs/onboarding/02-create-repo-and-clone.zh.md"
+  "${ROOT_DIR}/docs/onboarding/03-create-oidc-and-deploy-roles.md"
+  "${ROOT_DIR}/docs/onboarding/03-create-oidc-and-deploy-roles.zh.md"
+  "${ROOT_DIR}/docs/onboarding/04-prepare-env-file.md"
+  "${ROOT_DIR}/docs/onboarding/04-prepare-env-file.zh.md"
+  "${ROOT_DIR}/docs/onboarding/05-bootstrap-one-click.md"
+  "${ROOT_DIR}/docs/onboarding/05-bootstrap-one-click.zh.md"
+  "${ROOT_DIR}/docs/onboarding/06-bootstrap-manual.md"
+  "${ROOT_DIR}/docs/onboarding/06-bootstrap-manual.zh.md"
+  "${ROOT_DIR}/docs/onboarding/07-first-deploy-and-managed-dsql.md"
+  "${ROOT_DIR}/docs/onboarding/07-first-deploy-and-managed-dsql.zh.md"
+  "${ROOT_DIR}/docs/onboarding/08-day-2-operations.md"
+  "${ROOT_DIR}/docs/onboarding/08-day-2-operations.zh.md"
+)
+
+# Docs that explain OIDC discovery setup (EN only)
+EN_OIDC_SETUP_DOCS=(
+  "${ROOT_DIR}/README.md"
+  "${ROOT_DIR}/docs/onboarding/05-bootstrap-one-click.md"
+  "${ROOT_DIR}/docs/onboarding/06-bootstrap-manual.md"
+)
+
+# Docs that explain OIDC discovery setup (ZH only)
+ZH_OIDC_SETUP_DOCS=(
+  "${ROOT_DIR}/README.zh.md"
+  "${ROOT_DIR}/docs/onboarding/05-bootstrap-one-click.zh.md"
+  "${ROOT_DIR}/docs/onboarding/06-bootstrap-manual.zh.md"
+)
+
+# Docs that describe .env fields related to OIDC discovery
+ENV_DOCS=(
+  "${ROOT_DIR}/docs/onboarding/04-prepare-env-file.md"
+  "${ROOT_DIR}/docs/onboarding/04-prepare-env-file.zh.md"
+)
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_no_match_in() {
+  local reason="$1"
+  local pattern="$2"
+  shift 2
+  local docs=("$@")
+  for doc in "${docs[@]}"; do
+    if grep -n "${pattern}" "${doc}" >/dev/null 2>&1; then
+      fail "${reason}: found in ${doc}: $(grep -n "${pattern}" "${doc}")"
+    fi
+  done
+}
+
+assert_contains_in() {
+  local reason="$1"
+  local pattern="$2"
+  shift 2
+  local docs=("$@")
+  for doc in "${docs[@]}"; do
+    if ! grep -Fiq "${pattern}" "${doc}"; then
+      fail "${reason}: pattern [${pattern}] not found in ${doc}"
+    fi
+  done
+}
+
+# ---------- Forbidden patterns: no active operator doc should mention template-repo dependencies ----------
+
+assert_no_match_in "must not mention OIDC_DISCOVERY_TEMPLATE_REPO" 'OIDC_DISCOVERY_TEMPLATE_REPO' "${ALL_DOCS[@]}"
+assert_no_match_in "must not mention OIDC_DISCOVERY_TEMPLATE_REF" 'OIDC_DISCOVERY_TEMPLATE_REF' "${ALL_DOCS[@]}"
+assert_no_match_in "must not mention ltbase-oidc-discovery-template" 'ltbase-oidc-discovery-template' "${ALL_DOCS[@]}"
+assert_no_match_in "must not mention bootstrap-oidc-discovery-companion" 'bootstrap-oidc-discovery-companion' "${ALL_DOCS[@]}"
+assert_no_match_in "must not imply an OIDC discovery companion repo is needed" 'oidc discovery companion repo' "${ALL_DOCS[@]}"
+assert_no_match_in "must not imply an OIDC discovery template repo is needed" 'OIDC discovery template' "${ALL_DOCS[@]}"
+
+# ---------- .env docs: must state template repo variables are not needed ----------
+
+assert_no_match_in ".env docs must not mention OIDC_DISCOVERY_TEMPLATE_REPO" 'OIDC_DISCOVERY_TEMPLATE_REPO' "${ENV_DOCS[@]}"
+assert_no_match_in ".env docs must not mention OIDC_DISCOVERY_TEMPLATE_REF" 'OIDC_DISCOVERY_TEMPLATE_REF' "${ENV_DOCS[@]}"
+
+# ---------- English OIDC setup docs: must describe the direct-upload model ----------
+
+assert_contains_in "EN OIDC setup docs must mention direct upload or no companion" 'no companion' "${EN_OIDC_SETUP_DOCS[@]}"
+assert_contains_in "EN README must mention publish-oidc-discovery.yml" 'publish-oidc-discovery.yml' "${ROOT_DIR}/README.md"
+
+# ---------- Chinese OIDC setup docs: must describe the direct-upload model ----------
+
+for doc in "${ZH_OIDC_SETUP_DOCS[@]}"; do
+  if ! grep -Fiq '直接上传' "${doc}" && ! grep -Fiq '无 companion' "${doc}"; then
+    fail "ZH OIDC setup doc must mention direct upload (直接上传) or no companion (无 companion): ${doc}"
+  fi
+done
+
+assert_contains_in "ZH README must mention publish-oidc-discovery.yml" 'publish-oidc-discovery.yml' "${ROOT_DIR}/README.zh.md"
+
+# ---------- Manual bootstrap: OIDC section must explicitly state no companion repo ----------
+
+assert_contains_in "EN manual bootstrap OIDC section must state direct upload" 'direct upload' "${ROOT_DIR}/docs/onboarding/06-bootstrap-manual.md"
+assert_contains_in "ZH manual bootstrap OIDC section must state no companion" '无 companion' "${ROOT_DIR}/docs/onboarding/06-bootstrap-manual.zh.md"
+
+printf 'PASS: oidc-discovery-docs tests\n'


### PR DESCRIPTION
Closes #110

## Summary

Remove all references to OIDC discovery template repo variables from active operator-facing docs and add a regression test to keep them out.

Parent: #106
Blocked on: #109 (#113) — already merged

## Changes

- **New** `test/oidc-discovery-docs-test.sh` — scans all active operator docs, asserts no mentions of `OIDC_DISCOVERY_TEMPLATE_REPO`/`OIDC_DISCOVERY_TEMPLATE_REF`/`ltbase-oidc-discovery-template` etc., and asserts key docs describe the direct-upload / no-companion model
- **Updated** `docs/onboarding/04-prepare-env-file.md` / `.zh.md` — step 4 now explains OIDC discovery uses direct-upload with no companion repo or template repo needed
- **Updated** `docs/onboarding/05-bootstrap-one-click.md` / `.zh.md` — OIDC section now describes the full direct-upload flow

## Acceptance Criteria

- [x] Onboarding docs no longer tell operators to confirm `OIDC_DISCOVERY_TEMPLATE_REPO` or `OIDC_DISCOVERY_TEMPLATE_REF`
- [x] README language remains clear that no OIDC discovery companion repository is created
- [x] Docs explain that GitHub Actions generates discovery documents and Cloudflare Pages only hosts the uploaded static site
- [x] No active operator docs imply a private OIDC discovery template repo is required

## Verification

```
PASS: oidc-discovery-docs tests
PASS: bootstrap-env tests
PASS: publish-oidc-discovery-workflow tests
PASS: bootstrap-oidc-discovery tests
```