### PR TITLE
docs: add per-workflow GitHub Actions reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Main entrypoint — **new users start here**:
 Quick reference:
 
 - [`docs/BOOTSTRAP.md`](docs/BOOTSTRAP.md) — quick bootstrap checklist
+- [`docs/GITHUB_ACTIONS.md`](docs/GITHUB_ACTIONS.md) — per-workflow GitHub Actions reference (what each workflow does, when to use it, inputs and examples)
 
 Detailed reference (read as needed):
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -52,6 +52,7 @@ onboarding 文档支持通用多 stack 拓扑。文中出现 `devo`、`prod` 等
 快速参考：
 
 - [`docs/BOOTSTRAP.zh.md`](docs/BOOTSTRAP.zh.md) — 快速 bootstrap 清单
+- [`docs/GITHUB_ACTIONS.zh.md`](docs/GITHUB_ACTIONS.zh.md) — 逐个工作流的 GitHub Actions 参考（每个工作流做什么、何时用、参数与示例）
 
 深入参考（按需阅读）：
 

--- a/docs/BOOTSTRAP.md
+++ b/docs/BOOTSTRAP.md
@@ -94,11 +94,15 @@ source dist/foundation.env
 gh workflow run preview.yml -f target_stack=devo --ref main
 ```
 
+For full inputs and examples, see [`GITHUB_ACTIONS.md`](GITHUB_ACTIONS.md#previewyml--preview-ltbase-blueprint).
+
 ### 8. Rollout
 
 ```bash
 gh workflow run rollout.yml -f release_id=v1.0.23 --ref main
 ```
+
+For full inputs and examples, see [`GITHUB_ACTIONS.md`](GITHUB_ACTIONS.md#rolloutyml--rollout-ltbase-release).
 
 ### 9. Publish OIDC Discovery (must be after that stack's first rollout)
 
@@ -111,6 +115,8 @@ gh workflow run publish-oidc-discovery.yml -f target_stack=devo --ref main
 # Refresh all stacks once they have all completed their first rollout
 gh workflow run publish-oidc-discovery.yml -f target_stack=all --ref main
 ```
+
+For full inputs and examples, see [`GITHUB_ACTIONS.md`](GITHUB_ACTIONS.md#publish-oidc-discoveryyml--publish-oidc-discovery-documents).
 
 ### 10. Verify
 

--- a/docs/BOOTSTRAP.zh.md
+++ b/docs/BOOTSTRAP.zh.md
@@ -94,11 +94,15 @@ source dist/foundation.env
 gh workflow run preview.yml -f target_stack=devo --ref main
 ```
 
+完整参数与示例见 [`GITHUB_ACTIONS.zh.md`](GITHUB_ACTIONS.zh.md#previewyml--preview-ltbase-blueprint)。
+
 ### 8. Rollout
 
 ```bash
 gh workflow run rollout.yml -f release_id=v1.0.23 --ref main
 ```
+
+完整参数与示例见 [`GITHUB_ACTIONS.zh.md`](GITHUB_ACTIONS.zh.md#rolloutyml--rollout-ltbase-release)。
 
 ### 9. 发布 OIDC Discovery（必须在对应 stack 首次 rollout 之后）
 
@@ -111,6 +115,8 @@ gh workflow run publish-oidc-discovery.yml -f target_stack=devo --ref main
 # 全部 stack 都完成首次 rollout 后可一次性刷新
 gh workflow run publish-oidc-discovery.yml -f target_stack=all --ref main
 ```
+
+完整参数与示例见 [`GITHUB_ACTIONS.zh.md`](GITHUB_ACTIONS.zh.md#publish-oidc-discoveryyml--publish-oidc-discovery-documents)。
 
 ### 10. 验证
 

--- a/docs/CUSTOMER_ONBOARDING.md
+++ b/docs/CUSTOMER_ONBOARDING.md
@@ -1118,4 +1118,5 @@ pulumi stack output --stack "org/customer-ltbase/prod" -C infra
 | [onboarding/06-bootstrap-manual.md](onboarding/06-bootstrap-manual.md) | Manual bootstrap details |
 | [onboarding/07-first-deploy-and-managed-dsql.md](onboarding/07-first-deploy-and-managed-dsql.md) | First deploy and DSQL handling |
 | [onboarding/08-day-2-operations.md](onboarding/08-day-2-operations.md) | Day-2 operations details |
+| [GITHUB_ACTIONS.md](GITHUB_ACTIONS.md) | Per-workflow GitHub Actions reference |
 | [CONTROLPLANE_UI_DEPLOYMENT_CHECKLIST.md](CONTROLPLANE_UI_DEPLOYMENT_CHECKLIST.md) | Control Plane UI deployment checklist |

--- a/docs/CUSTOMER_ONBOARDING.zh.md
+++ b/docs/CUSTOMER_ONBOARDING.zh.md
@@ -1117,4 +1117,5 @@ pulumi stack output --stack "org/customer-ltbase/prod" -C infra
 | [onboarding/06-bootstrap-manual.zh.md](onboarding/06-bootstrap-manual.zh.md) | 手动 bootstrap 详细说明 |
 | [onboarding/07-first-deploy-and-managed-dsql.zh.md](onboarding/07-first-deploy-and-managed-dsql.zh.md) | 首次部署和 DSQL 处理 |
 | [onboarding/08-day-2-operations.zh.md](onboarding/08-day-2-operations.zh.md) | 日常运维详细说明 |
+| [GITHUB_ACTIONS.zh.md](GITHUB_ACTIONS.zh.md) | 逐个工作流的 GitHub Actions 参考 |
 | [CONTROLPLANE_UI_DEPLOYMENT_CHECKLIST.md](CONTROLPLANE_UI_DEPLOYMENT_CHECKLIST.md) | Control Plane UI 部署检查清单 |

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -1,0 +1,325 @@
+> **中文版：[GITHUB_ACTIONS.zh.md](GITHUB_ACTIONS.zh.md)**
+
+# GitHub Actions Reference
+
+This document describes every GitHub Actions workflow shipped in `.github/workflows/` of this deployment repository: what each one does, when you should run it, which inputs it accepts (with examples), and which GitHub Variables and Secrets it depends on.
+
+For the end-to-end deployment story, read [`CUSTOMER_ONBOARDING.md`](CUSTOMER_ONBOARDING.md) first. This page is a per-workflow reference you can return to when you need the exact inputs.
+
+## How to Read This Page
+
+- **Trigger** — how the workflow starts (`workflow_dispatch` = manual "Run workflow" button or `gh workflow run`, `workflow_call` = called by another workflow, `push`/`pull_request` = automatic).
+- **Inputs** — parameters you supply when dispatching. Every input example is also shown as a `gh workflow run` command.
+- **Config used** — the GitHub repository Variables (`vars.*`) and Secrets (`secrets.*`) the workflow reads. Bootstrap scripts write most of these automatically; see [`onboarding/04-prepare-env-file.md`](onboarding/04-prepare-env-file.md).
+- Run all `gh workflow run` commands with `--ref main`. Several OIDC roles trust only the default branch, so dispatching from another branch will fail AWS role assumption.
+
+## Workflow Map
+
+| Workflow | Name in GitHub UI | Primary use | You run it? |
+|----------|-------------------|-------------|-------------|
+| [`preview.yml`](#previewyml--preview-ltbase-blueprint) | Preview LTBase Blueprint | Validate config + Pulumi diff before deploying | Yes |
+| [`rollout.yml`](#rolloutyml--rollout-ltbase-release) | Rollout LTBase Release | Deploy a release across the whole promotion path | Yes (main entrypoint) |
+| [`deploy-devo.yml`](#deploy-devoyml--deploy-ltbase-start-stack) | Deploy LTBase Start Stack | Deploy only the first stack, then stop | Yes (occasionally) |
+| [`promote-prod.yml`](#promote-prodyml--promote-ltbase-between-stacks) | Promote LTBase Between Stacks | Manually run one adjacent promotion hop | Yes (recovery) |
+| [`rollout-hop.yml`](#rollout-hopyml--rollout-ltbase-promotion-hop) | Rollout LTBase Promotion Hop | Reusable single-hop engine used by the above | Rarely, directly |
+| [`publish-oidc-discovery.yml`](#publish-oidc-discoveryyml--publish-oidc-discovery-documents) | Publish OIDC Discovery Documents | Publish OIDC discovery site after first rollout | Yes |
+| [`build-infra-binary.yml`](#build-infra-binaryyml--build-infra-binary) | Build Infra Binary | Publish prebuilt infra binaries (upstream only) | No |
+| [`test.yml`](#testyml--test) | Test | Run the repo test suite (upstream only) | No |
+
+---
+
+## `preview.yml` — Preview LTBase Blueprint
+
+**What it does.** Validates the target stack before any deployment. It checks that `infra/Pulumi.<stack>.yaml` contains the required `ltbase-infra:*` config keys, dry-run-validates your `customer-owned/schemas/*.json` against the stack schema bucket (nothing is uploaded), runs the shared `preview-stack.yml` reusable workflow to produce a Pulumi diff, and finally audits Cloudflare/API Gateway mTLS posture.
+
+**When to use it.**
+- Before the first rollout of a stack.
+- Any time you change stack configuration, the release selection, or other deployment inputs. Preview first, then rollout.
+- To confirm a Pulumi diff is within the scope you expect.
+
+**When not to use it.**
+- To deploy. Preview is infra-only: it does not run `pulumi up`, does not publish the Control Plane UI, and does not upload schemas.
+- To preview a later stack. Manual preview only supports the first stack in `PROMOTION_PATH`; any other value fails fast.
+
+**Trigger.** `workflow_dispatch` (manual).
+
+**Inputs.**
+
+| Input | Required | Type | Default | Description |
+|-------|----------|------|---------|-------------|
+| `target_stack` | No | string | first stack in `PROMOTION_PATH` | Stack to preview. Must be the first promotion stack. |
+| `release_id` | No | string | `vars.LTBASE_RELEASE_ID` | Official LTBase release tag to preview. |
+
+**Examples.**
+
+```bash
+# Preview the first promotion stack using the repo default release
+gh workflow run preview.yml --ref main
+
+# Preview the first stack explicitly and override the release
+gh workflow run preview.yml -f target_stack=devo -f release_id=v1.0.23 --ref main
+```
+
+**Config used.**
+- Variables: `PROMOTION_PATH` (or `STACKS`), `LTBASE_RELEASE_ID`, `PULUMI_BACKEND_URL`, `AWS_REGION_<STACK>`, `PULUMI_SECRETS_PROVIDER_<STACK>`, `SCHEMA_BUCKET_<STACK>`, `LTBASE_RELEASES_REPO`, `STACKS`.
+- Secrets: `AWS_ROLE_ARN_<STACK>`, `LTBASE_RELEASES_TOKEN`, `CLOUDFLARE_API_TOKEN`.
+
+**Notes.**
+- The mTLS audit reads per-stack values from `infra/Pulumi.<stack>.yaml` (`ltbase-infra:awsRegion`, `apiDomain`, `controlPlaneDomain`, `authDomain`, `runtimeBucket`, `cloudflareZoneId`). Keep that file complete or the audit fails.
+- `CLOUDFLARE_API_TOKEN` must be able to read zone settings, not just DNS records, for the audit to pass.
+
+---
+
+## `rollout.yml` — Rollout LTBase Release
+
+**What it does.** The recommended deployment entrypoint. It resolves the first stack in `PROMOTION_PATH` and calls `rollout-hop.yml` with `continue_chain: true`, so after each successful hop it automatically dispatches the next stack in the promotion path. Protected target environments still pause for GitHub environment approval before they deploy.
+
+**When to use it.**
+- To deploy a release across your entire promotion path in one action.
+- For routine upgrades: update `LTBASE_RELEASE_ID`, run `preview.yml`, then run `rollout.yml`.
+
+**When not to use it.**
+- When you want to deploy only the first stack and stop — use [`deploy-devo.yml`](#deploy-devoyml--deploy-ltbase-start-stack).
+- When you want to replay a single hop — use [`promote-prod.yml`](#promote-prodyml--promote-ltbase-between-stacks).
+- Do not change the release ID midway through a promotion path; keep the same release across all hops.
+
+**Trigger.** `workflow_dispatch` (manual).
+
+**Inputs.**
+
+| Input | Required | Type | Default | Description |
+|-------|----------|------|---------|-------------|
+| `release_id` | Yes | string | — | Official LTBase release tag to roll out across the full promotion path. |
+
+**Examples.**
+
+```bash
+# Roll out release v1.0.23 across the whole promotion path
+gh workflow run rollout.yml -f release_id=v1.0.23 --ref main
+```
+
+**Config used.**
+- Inherits all repository Variables and Secrets (`secrets: inherit`) and passes them down to `rollout-hop.yml`. See the `rollout-hop.yml` config list below for the full set.
+
+**Notes.**
+- The chain advances one hop at a time. Each protected stack requires you to approve its GitHub environment gate before it deploys.
+- Publishing OIDC discovery is separate; run [`publish-oidc-discovery.yml`](#publish-oidc-discoveryyml--publish-oidc-discovery-documents) after a stack's first rollout completes.
+
+---
+
+## `deploy-devo.yml` — Deploy LTBase Start Stack
+
+**What it does.** Deploys only the first stack in `PROMOTION_PATH` and then stops. It resolves the start stack and calls `rollout-hop.yml` with `continue_chain: false`, so no further hops are dispatched.
+
+**When to use it.**
+- When you want to deploy or redeploy just the start stack without triggering the full promotion chain.
+- During early setup or debugging of the first environment.
+
+**When not to use it.**
+- For a normal full deployment — use [`rollout.yml`](#rolloutyml--rollout-ltbase-release).
+- To deploy a non-start stack. Despite the historical `devo` name, it always targets whatever stack is first in `PROMOTION_PATH`, not a stack literally named `devo`.
+
+**Trigger.** `workflow_dispatch` (manual).
+
+**Inputs.**
+
+| Input | Required | Type | Default | Description |
+|-------|----------|------|---------|-------------|
+| `release_id` | Yes | string | — | Official LTBase release tag to deploy into the first promotion stack. |
+
+**Examples.**
+
+```bash
+# Deploy only the start stack with release v1.0.23
+gh workflow run deploy-devo.yml -f release_id=v1.0.23 --ref main
+```
+
+**Config used.**
+- Inherits all repository Variables and Secrets (`secrets: inherit`) and passes them to `rollout-hop.yml`.
+
+**Notes.**
+- The workflow file name is historical. The actual target is `PROMOTION_PATH[0]`, whatever it is named.
+
+---
+
+## `promote-prod.yml` — Promote LTBase Between Stacks
+
+**What it does.** Runs exactly one promotion hop between two adjacent stacks. It calls `rollout-hop.yml` with your explicit `from_stack` and `to_stack` and `continue_chain: false`. `rollout-hop.yml` validates that `from_stack → to_stack` is an adjacent, forward hop in `PROMOTION_PATH` and fails fast on invalid jumps.
+
+**When to use it.**
+- Recovery: a hop deployed but the automatic chain did not continue, and you want to advance one more hop.
+- To promote from one validated stack to the next adjacent stack only.
+
+**When not to use it.**
+- For the full path — use [`rollout.yml`](#rolloutyml--rollout-ltbase-release).
+- To skip environments. Non-adjacent jumps (e.g., skipping an intermediate stack) fail immediately.
+
+**Trigger.** `workflow_dispatch` (manual).
+
+**Inputs.**
+
+| Input | Required | Type | Default | Description |
+|-------|----------|------|---------|-------------|
+| `release_id` | Yes | string | — | Official LTBase release tag to promote. |
+| `from_stack` | Yes | string | — | Current deployed stack in `PROMOTION_PATH`. |
+| `to_stack` | Yes | string | — | Next stack in `PROMOTION_PATH` (must be adjacent to `from_stack`). |
+
+**Examples.**
+
+```bash
+# Promote from devo to prod using release v1.0.23
+gh workflow run promote-prod.yml \
+  -f release_id=v1.0.23 \
+  -f from_stack=devo \
+  -f to_stack=prod \
+  --ref main
+```
+
+**Config used.**
+- Inherits all repository Variables and Secrets (`secrets: inherit`) and passes them to `rollout-hop.yml`.
+
+**Notes.**
+- The target stack still requires its GitHub environment approval before deploying.
+
+---
+
+## `rollout-hop.yml` — Rollout LTBase Promotion Hop
+
+**What it does.** The single-hop deployment engine that every deploy/rollout/promote workflow above delegates to. For one target stack it: validates the Pulumi stack config, waits for approval on protected stacks, renders the Control Plane UI runtime config, runs the shared `rollout-hop.yml` reusable workflow (`pulumi up`, control-plane UI publish, managed DSQL reconcile + second apply), publishes customer schemas, invokes the control-plane `ensure-project` apply, advances the applied-schema pointer, audits mTLS, and — when `continue_chain` is true — dispatches the next hop.
+
+**When to use it.**
+- Normally you do not run this directly; use `rollout.yml`, `deploy-devo.yml`, or `promote-prod.yml`.
+- Run it directly only for advanced recovery when you need precise control over a single hop's inputs (including `continue_chain`).
+
+**When not to use it.**
+- For routine deployments. The wrapper workflows set the correct inputs for you.
+
+**Trigger.** `workflow_call` (used by other workflows) and `workflow_dispatch` (manual, advanced).
+
+**Inputs.**
+
+| Input | Required | Type | Default | Description |
+|-------|----------|------|---------|-------------|
+| `release_id` | Yes | string | `vars.LTBASE_RELEASE_ID` (dispatch) | Official LTBase release tag to deploy. |
+| `target_stack` | Yes | string | — | Stack to deploy in this hop. |
+| `from_stack` | No | string | `""` | Current stack before this hop; when set, the hop must be adjacent and forward. |
+| `continue_chain` | No | boolean | `false` | Dispatch the next hop automatically after success. |
+
+**Outputs (when called by another workflow).** `release_id`, `target_stack`, `next_stack`, `deployment_outputs_json`.
+
+**Examples.**
+
+```bash
+# Advanced: manually run a single hop into prod and continue the chain
+gh workflow run rollout-hop.yml \
+  -f release_id=v1.0.23 \
+  -f target_stack=prod \
+  -f from_stack=devo \
+  -f continue_chain=false \
+  --ref main
+```
+
+**Config used.**
+- Variables: `LTBASE_RELEASE_ID`, `STACKS`, `PROMOTION_PATH`, `PULUMI_BACKEND_URL`, `AWS_REGION_<STACK>`, `PULUMI_SECRETS_PROVIDER_<STACK>`, `SCHEMA_BUCKET_<STACK>`, `LTBASE_RELEASES_REPO`, `CLOUDFLARE_ACCOUNT_ID`, `CONTROLPLANE_UI_PAGES_PROJECT`, `CONTROLPLANE_UI_STACK_CONFIG`.
+- Secrets: `AWS_ROLE_ARN_<STACK>`, `LTBASE_RELEASES_TOKEN`, `CLOUDFLARE_API_TOKEN`.
+
+**Notes.**
+- Approval is required for every stack that is not the start stack (`approval_required=true`); a canary also runs for those hops.
+- Schema publish and schema apply are separate: `schemas/published/manifest.json` advances on publish, `schemas/applied/manifest.json` only advances after `ensure-project` succeeds.
+- When `continue_chain=true` and a `next_stack` exists, the workflow dispatches itself for the next hop.
+
+---
+
+## `publish-oidc-discovery.yml` — Publish OIDC Discovery Documents
+
+**What it does.** Generates the OIDC discovery documents for one or all stacks and publishes them to the OIDC discovery Cloudflare Pages project with `wrangler pages deploy`.
+
+**When to use it.**
+- After a stack completes its **first** rollout. The authservice signing KMS key is created by Pulumi during rollout, so discovery must be published afterward.
+- To refresh all stacks at once once they have all completed their first rollout.
+
+**When not to use it.**
+- Before a stack's first rollout — the signing key does not exist yet.
+- From a non-default branch. The per-stack OIDC discovery IAM roles trust only the default branch; dispatching from another branch fails role assumption.
+
+**Trigger.** `workflow_dispatch` (manual).
+
+**Inputs.**
+
+| Input | Required | Type | Default | Description |
+|-------|----------|------|---------|-------------|
+| `target_stack` | No | string | `all` | Stack to publish: `all` or a specific stack name. |
+
+**Examples.**
+
+```bash
+# Publish a single stack after its first rollout
+gh workflow run publish-oidc-discovery.yml -f target_stack=devo --ref main
+
+# Refresh all stacks once they have all completed their first rollout
+gh workflow run publish-oidc-discovery.yml -f target_stack=all --ref main
+```
+
+**Config used.**
+- Variables: `OIDC_DISCOVERY_DOMAIN`, `OIDC_DISCOVERY_STACK_CONFIG`, `OIDC_DISCOVERY_PAGES_PROJECT`, `CLOUDFLARE_ACCOUNT_ID`.
+- Secrets: `CLOUDFLARE_API_TOKEN`.
+
+**Notes.**
+- The workflow fails clearly if `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, or `OIDC_DISCOVERY_PAGES_PROJECT` is missing.
+- It uses a repository-level concurrency group, so runs do not overlap.
+
+---
+
+## `build-infra-binary.yml` — Build Infra Binary
+
+**What it does.** Builds the `ltbase-infra` Pulumi program for `linux-amd64` and `linux-arm64`, then publishes those prebuilt binaries plus a manifest (with a `build_fingerprint`) as a release in `Lychee-Technology/ltbase-private-deployment-binaries`.
+
+**When to use it.**
+- You almost never run this. It is guarded by `if: github.repository == 'Lychee-Technology/ltbase-private-deployment'` and is skipped in generated customer deployment repositories.
+- Only the upstream template repository publishes prebuilt infra binaries; customer repos consume them.
+
+**When not to use it.**
+- In a customer deployment repository. It will be skipped.
+
+**Trigger.** `workflow_dispatch` (manual) and `push` to `main` touching `infra/**` or the workflow file itself.
+
+**Inputs.** None.
+
+**Config used.**
+- Secrets: `LTBASE_PRIVATE_DEPLOYMENT_BINARIES_TOKEN` (only present in the upstream template repository).
+
+**Notes.**
+- Customer workflows only install a prebuilt binary when the synced `__ref__/template-provenance.json` and its `build_fingerprint` exactly match an upstream published manifest; otherwise `infra/scripts/pulumi-wrapper.sh` falls back to local source build.
+
+---
+
+## `test.yml` — Test
+
+**What it does.** Runs the repository's shell test suite (`test/*-test.sh`) after ensuring `jq` and `python3` are available.
+
+**When to use it.**
+- It runs automatically on `pull_request` and on `push` to `main`, and can be dispatched manually. It is guarded by `if: github.repository == 'Lychee-Technology/ltbase-private-deployment'`, so it is skipped in customer deployment repositories.
+
+**When not to use it.**
+- In a customer deployment repository. It will be skipped.
+
+**Trigger.** `workflow_dispatch` (manual), `pull_request`, and `push` to `main`.
+
+**Inputs.** None.
+
+**Config used.** None (read-only checkout).
+
+**Notes.**
+- Fails if no `test/*-test.sh` files are found or any test fails.
+
+---
+
+## Related Documents
+
+| Document | Purpose |
+|----------|---------|
+| [CUSTOMER_ONBOARDING.md](CUSTOMER_ONBOARDING.md) | Complete from-scratch deployment guide |
+| [BOOTSTRAP.md](BOOTSTRAP.md) | Quick bootstrap checklist |
+| [onboarding/04-prepare-env-file.md](onboarding/04-prepare-env-file.md) | `.env`, Variables, and Secrets reference |
+| [onboarding/07-first-deploy-and-managed-dsql.md](onboarding/07-first-deploy-and-managed-dsql.md) | First preview/rollout walkthrough |
+| [onboarding/08-day-2-operations.md](onboarding/08-day-2-operations.md) | Day-2 operations and upgrades |

--- a/docs/GITHUB_ACTIONS.zh.md
+++ b/docs/GITHUB_ACTIONS.zh.md
@@ -1,0 +1,325 @@
+> **English version: [GITHUB_ACTIONS.md](GITHUB_ACTIONS.md)**
+
+# GitHub Actions 参考
+
+本文档说明部署仓库 `.github/workflows/` 中的每一个 GitHub Actions 工作流：它做什么、什么时候应该用、接受哪些输入参数（含示例），以及依赖哪些 GitHub Variables 和 Secrets。
+
+如果你要了解完整的部署流程，请先阅读 [`CUSTOMER_ONBOARDING.zh.md`](CUSTOMER_ONBOARDING.zh.md)。本页是逐个工作流的参数速查表，需要精确输入时回到这里查阅即可。
+
+## 如何阅读本页
+
+- **触发方式** — 工作流如何启动（`workflow_dispatch` = 手动点击 "Run workflow" 或 `gh workflow run`，`workflow_call` = 被其他工作流调用，`push`/`pull_request` = 自动触发）。
+- **输入参数** — 你在触发时提供的参数。每个示例都同时给出 `gh workflow run` 命令。
+- **使用到的配置** — 工作流读取的 GitHub 仓库 Variables（`vars.*`）和 Secrets（`secrets.*`）。这些大多由 bootstrap 脚本自动写入，详见 [`onboarding/04-prepare-env-file.zh.md`](onboarding/04-prepare-env-file.zh.md)。
+- 所有 `gh workflow run` 命令都请加上 `--ref main`。多个 OIDC role 只信任默认分支，从其他分支触发会导致 AWS role assumption 失败。
+
+## 工作流一览
+
+| 工作流 | GitHub UI 中的名称 | 主要用途 | 你需要运行吗？ |
+|--------|-------------------|----------|---------------|
+| [`preview.yml`](#previewyml--preview-ltbase-blueprint) | Preview LTBase Blueprint | 部署前校验配置并生成 Pulumi diff | 需要 |
+| [`rollout.yml`](#rolloutyml--rollout-ltbase-release) | Rollout LTBase Release | 按整条 promotion path 部署一个 release | 需要（主入口） |
+| [`deploy-devo.yml`](#deploy-devoyml--deploy-ltbase-start-stack) | Deploy LTBase Start Stack | 只部署起点 stack 后停止 | 需要（偶尔） |
+| [`promote-prod.yml`](#promote-prodyml--promote-ltbase-between-stacks) | Promote LTBase Between Stacks | 手动执行一次相邻 promotion 跳转 | 需要（恢复用） |
+| [`rollout-hop.yml`](#rollout-hopyml--rollout-ltbase-promotion-hop) | Rollout LTBase Promotion Hop | 上述工作流复用的单跳引擎 | 极少直接运行 |
+| [`publish-oidc-discovery.yml`](#publish-oidc-discoveryyml--publish-oidc-discovery-documents) | Publish OIDC Discovery Documents | 首次 rollout 后发布 OIDC discovery 站点 | 需要 |
+| [`build-infra-binary.yml`](#build-infra-binaryyml--build-infra-binary) | Build Infra Binary | 发布预构建 infra 二进制（仅上游） | 不需要 |
+| [`test.yml`](#testyml--test) | Test | 运行仓库测试套件（仅上游） | 不需要 |
+
+---
+
+## `preview.yml` — Preview LTBase Blueprint
+
+**做什么。** 在任何部署之前校验目标 stack。它会检查 `infra/Pulumi.<stack>.yaml` 是否包含必需的 `ltbase-infra:*` 配置键，以 dry-run 方式针对 stack schema bucket 校验 `customer-owned/schemas/*.json`（不上传任何内容），调用共享的 `preview-stack.yml` 生成 Pulumi diff，最后审计 Cloudflare / API Gateway 的 mTLS 配置。
+
+**什么时候用。**
+- 每个 stack 首次 rollout 之前。
+- 每次修改 stack 配置、release 选择或其他部署输入时。先 preview，再 rollout。
+- 确认 Pulumi diff 在你预期范围内。
+
+**什么时候不该用。**
+- 用于实际部署。preview 只做基础设施预览：它不执行 `pulumi up`，不发布 Control Plane UI，也不上传 schema。
+- 用于预览后续 stack。手动 preview 只支持 `PROMOTION_PATH` 的第一个 stack；填其他值会直接失败。
+
+**触发方式。** `workflow_dispatch`（手动）。
+
+**输入参数。**
+
+| 参数 | 必填 | 类型 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| `target_stack` | 否 | string | `PROMOTION_PATH` 的第一个 stack | 要预览的 stack，必须是第一个 promotion stack。 |
+| `release_id` | 否 | string | `vars.LTBASE_RELEASE_ID` | 要预览的官方 LTBase release tag。 |
+
+**示例。**
+
+```bash
+# 使用仓库默认 release 预览第一个 promotion stack
+gh workflow run preview.yml --ref main
+
+# 显式指定第一个 stack，并覆盖 release
+gh workflow run preview.yml -f target_stack=devo -f release_id=v1.0.23 --ref main
+```
+
+**使用到的配置。**
+- Variables：`PROMOTION_PATH`（或 `STACKS`）、`LTBASE_RELEASE_ID`、`PULUMI_BACKEND_URL`、`AWS_REGION_<STACK>`、`PULUMI_SECRETS_PROVIDER_<STACK>`、`SCHEMA_BUCKET_<STACK>`、`LTBASE_RELEASES_REPO`、`STACKS`。
+- Secrets：`AWS_ROLE_ARN_<STACK>`、`LTBASE_RELEASES_TOKEN`、`CLOUDFLARE_API_TOKEN`。
+
+**注意事项。**
+- mTLS 审计从 `infra/Pulumi.<stack>.yaml` 读取每个 stack 的值（`ltbase-infra:awsRegion`、`apiDomain`、`controlPlaneDomain`、`authDomain`、`runtimeBucket`、`cloudflareZoneId`）。该文件必须完整，否则审计失败。
+- `CLOUDFLARE_API_TOKEN` 需要具备读取 zone settings 的权限，而不只是 DNS 记录，审计才能通过。
+
+---
+
+## `rollout.yml` — Rollout LTBase Release
+
+**做什么。** 推荐的部署入口。它解析 `PROMOTION_PATH` 的第一个 stack，并以 `continue_chain: true` 调用 `rollout-hop.yml`，因此每一跳成功后会自动派发下一个 stack。受保护目标环境在部署前仍会停在 GitHub environment 审批。
+
+**什么时候用。**
+- 一次性把一个 release 部署到整条 promotion path。
+- 常规升级：更新 `LTBASE_RELEASE_ID` → 运行 `preview.yml` → 运行 `rollout.yml`。
+
+**什么时候不该用。**
+- 只想部署第一个 stack 后停止时 —— 用 [`deploy-devo.yml`](#deploy-devoyml--deploy-ltbase-start-stack)。
+- 只想补跑某一跳时 —— 用 [`promote-prod.yml`](#promote-prodyml--promote-ltbase-between-stacks)。
+- 不要在 promotion path 中途切换 release ID；整条链路应保持同一个 release。
+
+**触发方式。** `workflow_dispatch`（手动）。
+
+**输入参数。**
+
+| 参数 | 必填 | 类型 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| `release_id` | 是 | string | — | 要在整条 promotion path 上部署的官方 LTBase release tag。 |
+
+**示例。**
+
+```bash
+# 把 release v1.0.23 部署到整条 promotion path
+gh workflow run rollout.yml -f release_id=v1.0.23 --ref main
+```
+
+**使用到的配置。**
+- 通过 `secrets: inherit` 继承所有仓库 Variables 和 Secrets，并向下传给 `rollout-hop.yml`。完整清单见下方 `rollout-hop.yml`。
+
+**注意事项。**
+- 链路一次推进一跳。每个受保护 stack 在部署前都需要你审批对应的 GitHub environment gate。
+- 发布 OIDC discovery 是独立步骤；在某个 stack 首次 rollout 完成后运行 [`publish-oidc-discovery.yml`](#publish-oidc-discoveryyml--publish-oidc-discovery-documents)。
+
+---
+
+## `deploy-devo.yml` — Deploy LTBase Start Stack
+
+**做什么。** 只部署 `PROMOTION_PATH` 的第一个 stack 然后停止。它解析起点 stack，并以 `continue_chain: false` 调用 `rollout-hop.yml`，因此不会派发后续 hop。
+
+**什么时候用。**
+- 只想部署或重新部署起点 stack，不触发整条 promotion 链时。
+- 首个环境的早期搭建或调试阶段。
+
+**什么时候不该用。**
+- 常规完整部署 —— 用 [`rollout.yml`](#rolloutyml--rollout-ltbase-release)。
+- 部署非起点 stack。尽管文件名沿用了历史名 `devo`，它始终以 `PROMOTION_PATH` 的第一个 stack 为目标，而不是字面名为 `devo` 的 stack。
+
+**触发方式。** `workflow_dispatch`（手动）。
+
+**输入参数。**
+
+| 参数 | 必填 | 类型 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| `release_id` | 是 | string | — | 要部署到第一个 promotion stack 的官方 LTBase release tag。 |
+
+**示例。**
+
+```bash
+# 仅用 release v1.0.23 部署起点 stack
+gh workflow run deploy-devo.yml -f release_id=v1.0.23 --ref main
+```
+
+**使用到的配置。**
+- 通过 `secrets: inherit` 继承所有仓库 Variables 和 Secrets，并传给 `rollout-hop.yml`。
+
+**注意事项。**
+- 工作流文件名属于历史遗留。实际目标是 `PROMOTION_PATH[0]`，无论它叫什么名字。
+
+---
+
+## `promote-prod.yml` — Promote LTBase Between Stacks
+
+**做什么。** 只执行两个相邻 stack 之间的一次 promotion 跳转。它以你显式提供的 `from_stack`、`to_stack` 和 `continue_chain: false` 调用 `rollout-hop.yml`。`rollout-hop.yml` 会校验 `from_stack → to_stack` 是否是 `PROMOTION_PATH` 中相邻且向前的一跳，非法跳转会直接失败。
+
+**什么时候用。**
+- 恢复场景：某一跳部署成功但自动链路没有继续，你想再推进一跳。
+- 只想从某个已验证 stack 推进到下一个相邻 stack。
+
+**什么时候不该用。**
+- 部署整条 path —— 用 [`rollout.yml`](#rolloutyml--rollout-ltbase-release)。
+- 跨过中间环境。非相邻跳转（如跳过中间 stack）会立即失败。
+
+**触发方式。** `workflow_dispatch`（手动）。
+
+**输入参数。**
+
+| 参数 | 必填 | 类型 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| `release_id` | 是 | string | — | 要 promote 的官方 LTBase release tag。 |
+| `from_stack` | 是 | string | — | `PROMOTION_PATH` 中当前已部署的 stack。 |
+| `to_stack` | 是 | string | — | `PROMOTION_PATH` 中的下一个 stack（必须与 `from_stack` 相邻）。 |
+
+**示例。**
+
+```bash
+# 用 release v1.0.23 从 devo promote 到 prod
+gh workflow run promote-prod.yml \
+  -f release_id=v1.0.23 \
+  -f from_stack=devo \
+  -f to_stack=prod \
+  --ref main
+```
+
+**使用到的配置。**
+- 通过 `secrets: inherit` 继承所有仓库 Variables 和 Secrets，并传给 `rollout-hop.yml`。
+
+**注意事项。**
+- 目标 stack 在部署前仍需要通过其 GitHub environment 审批。
+
+---
+
+## `rollout-hop.yml` — Rollout LTBase Promotion Hop
+
+**做什么。** 上面每个 deploy/rollout/promote 工作流都委托给它的单跳部署引擎。对一个目标 stack，它会：校验 Pulumi stack 配置、在受保护 stack 上等待审批、渲染 Control Plane UI 运行时配置、调用共享的 `rollout-hop.yml`（执行 `pulumi up`、发布 control-plane UI、managed DSQL reconcile 与二次 apply）、发布客户 schema、调用 control-plane 的 `ensure-project` apply、推进 applied schema 指针、审计 mTLS，并在 `continue_chain` 为 true 时派发下一跳。
+
+**什么时候用。**
+- 一般不直接运行它；请用 `rollout.yml`、`deploy-devo.yml` 或 `promote-prod.yml`。
+- 只有在高级恢复场景、需要精确控制单跳输入（包括 `continue_chain`）时才直接运行。
+
+**什么时候不该用。**
+- 常规部署。封装工作流会为你设置正确的输入。
+
+**触发方式。** `workflow_call`（被其他工作流调用）和 `workflow_dispatch`（手动，高级用途）。
+
+**输入参数。**
+
+| 参数 | 必填 | 类型 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| `release_id` | 是 | string | `vars.LTBASE_RELEASE_ID`（手动触发时） | 要部署的官方 LTBase release tag。 |
+| `target_stack` | 是 | string | — | 本跳要部署的 stack。 |
+| `from_stack` | 否 | string | `""` | 本跳之前的当前 stack；提供后本跳必须相邻且向前。 |
+| `continue_chain` | 否 | boolean | `false` | 成功后是否自动派发下一跳。 |
+
+**输出（被其他工作流调用时）。** `release_id`、`target_stack`、`next_stack`、`deployment_outputs_json`。
+
+**示例。**
+
+```bash
+# 高级：手动执行一次到 prod 的单跳，并不继续链路
+gh workflow run rollout-hop.yml \
+  -f release_id=v1.0.23 \
+  -f target_stack=prod \
+  -f from_stack=devo \
+  -f continue_chain=false \
+  --ref main
+```
+
+**使用到的配置。**
+- Variables：`LTBASE_RELEASE_ID`、`STACKS`、`PROMOTION_PATH`、`PULUMI_BACKEND_URL`、`AWS_REGION_<STACK>`、`PULUMI_SECRETS_PROVIDER_<STACK>`、`SCHEMA_BUCKET_<STACK>`、`LTBASE_RELEASES_REPO`、`CLOUDFLARE_ACCOUNT_ID`、`CONTROLPLANE_UI_PAGES_PROJECT`、`CONTROLPLANE_UI_STACK_CONFIG`。
+- Secrets：`AWS_ROLE_ARN_<STACK>`、`LTBASE_RELEASES_TOKEN`、`CLOUDFLARE_API_TOKEN`。
+
+**注意事项。**
+- 除起点 stack 外的每个 stack 都需要审批（`approval_required=true`）；这些跳转还会运行 canary。
+- schema 发布与 apply 是分离的：`schemas/published/manifest.json` 在发布时推进，`schemas/applied/manifest.json` 只在 `ensure-project` 成功后才推进。
+- 当 `continue_chain=true` 且存在 `next_stack` 时，工作流会为下一跳派发自己。
+
+---
+
+## `publish-oidc-discovery.yml` — Publish OIDC Discovery Documents
+
+**做什么。** 为一个或全部 stack 生成 OIDC discovery 文档，并用 `wrangler pages deploy` 发布到 OIDC discovery Cloudflare Pages 项目。
+
+**什么时候用。**
+- 在某个 stack 完成**首次** rollout 之后。authservice 的签名 KMS key 由 Pulumi 在 rollout 时创建，因此 discovery 必须在之后发布。
+- 当所有 stack 都完成首次 rollout 后，一次性刷新全部 stack。
+
+**什么时候不该用。**
+- 在 stack 首次 rollout 之前 —— 此时签名 key 还不存在。
+- 从非默认分支触发。每个 stack 的 OIDC discovery IAM role 只信任默认分支，从其他分支触发会导致 role assumption 失败。
+
+**触发方式。** `workflow_dispatch`（手动）。
+
+**输入参数。**
+
+| 参数 | 必填 | 类型 | 默认值 | 说明 |
+|------|------|------|--------|------|
+| `target_stack` | 否 | string | `all` | 要发布的 stack：`all` 或某个具体 stack 名称。 |
+
+**示例。**
+
+```bash
+# 某个 stack 首次 rollout 后单独发布
+gh workflow run publish-oidc-discovery.yml -f target_stack=devo --ref main
+
+# 所有 stack 都完成首次 rollout 后一次性刷新
+gh workflow run publish-oidc-discovery.yml -f target_stack=all --ref main
+```
+
+**使用到的配置。**
+- Variables：`OIDC_DISCOVERY_DOMAIN`、`OIDC_DISCOVERY_STACK_CONFIG`、`OIDC_DISCOVERY_PAGES_PROJECT`、`CLOUDFLARE_ACCOUNT_ID`。
+- Secrets：`CLOUDFLARE_API_TOKEN`。
+
+**注意事项。**
+- 当 `CLOUDFLARE_API_TOKEN`、`CLOUDFLARE_ACCOUNT_ID` 或 `OIDC_DISCOVERY_PAGES_PROJECT` 缺失时，工作流会明确报错。
+- 它使用仓库级 concurrency group，因此多次运行不会互相重叠。
+
+---
+
+## `build-infra-binary.yml` — Build Infra Binary
+
+**做什么。** 为 `linux-amd64` 和 `linux-arm64` 构建 `ltbase-infra` Pulumi 程序，然后把这些预构建二进制以及带 `build_fingerprint` 的 manifest 作为 release 发布到 `Lychee-Technology/ltbase-private-deployment-binaries`。
+
+**什么时候用。**
+- 你几乎不会运行它。它带有 `if: github.repository == 'Lychee-Technology/ltbase-private-deployment'` 守卫，在生成出来的客户部署仓库中会被跳过。
+- 只有上游模板仓库发布预构建 infra 二进制；客户仓库只负责消费。
+
+**什么时候不该用。**
+- 在客户部署仓库中。它会被跳过。
+
+**触发方式。** `workflow_dispatch`（手动）以及对 `main` 分支中 `infra/**` 或该工作流文件的 `push`。
+
+**输入参数。** 无。
+
+**使用到的配置。**
+- Secrets：`LTBASE_PRIVATE_DEPLOYMENT_BINARIES_TOKEN`（仅存在于上游模板仓库）。
+
+**注意事项。**
+- 只有当同步下来的 `__ref__/template-provenance.json` 及其 `build_fingerprint` 与上游已发布 manifest 完全匹配时，客户工作流才会安装预构建二进制；否则 `infra/scripts/pulumi-wrapper.sh` 会回退到本地源码构建。
+
+---
+
+## `test.yml` — Test
+
+**做什么。** 在确保 `jq` 和 `python3` 可用后，运行仓库的 shell 测试套件（`test/*-test.sh`）。
+
+**什么时候用。**
+- 它会在 `pull_request` 和对 `main` 的 `push` 时自动运行，也可手动触发。它带有 `if: github.repository == 'Lychee-Technology/ltbase-private-deployment'` 守卫，因此在客户部署仓库中会被跳过。
+
+**什么时候不该用。**
+- 在客户部署仓库中。它会被跳过。
+
+**触发方式。** `workflow_dispatch`（手动）、`pull_request`，以及对 `main` 的 `push`。
+
+**输入参数。** 无。
+
+**使用到的配置。** 无（只读 checkout）。
+
+**注意事项。**
+- 当找不到任何 `test/*-test.sh` 文件或任一测试失败时，工作流失败。
+
+---
+
+## 参考文档
+
+| 文档 | 用途 |
+|------|------|
+| [CUSTOMER_ONBOARDING.zh.md](CUSTOMER_ONBOARDING.zh.md) | 完整的从零部署指南 |
+| [BOOTSTRAP.zh.md](BOOTSTRAP.zh.md) | 快速 bootstrap 清单 |
+| [onboarding/04-prepare-env-file.zh.md](onboarding/04-prepare-env-file.zh.md) | `.env`、Variables 和 Secrets 参考 |
+| [onboarding/07-first-deploy-and-managed-dsql.zh.md](onboarding/07-first-deploy-and-managed-dsql.zh.md) | 首次 preview/rollout 操作说明 |
+| [onboarding/08-day-2-operations.zh.md](onboarding/08-day-2-operations.zh.md) | 日常运维与升级 |


### PR DESCRIPTION
## Summary

Adds a centralized, bilingual reference for every GitHub Actions workflow shipped in `.github/workflows/`, so operators can quickly see what each workflow does, when to run it, the exact inputs (with examples), and the GitHub Variables/Secrets it depends on.

### New docs
- `docs/GITHUB_ACTIONS.md` (English)
- `docs/GITHUB_ACTIONS.zh.md` (Chinese)

Each workflow section covers: what it does, when to use / when not to use, trigger, inputs table (required/type/default/description), `gh workflow run` examples, config used (vars/secrets), and notes.

Workflows documented:
- `preview.yml` — Preview LTBase Blueprint
- `rollout.yml` — Rollout LTBase Release (main entrypoint)
- `deploy-devo.yml` — Deploy LTBase Start Stack
- `promote-prod.yml` — Promote LTBase Between Stacks
- `rollout-hop.yml` — Rollout LTBase Promotion Hop (reusable engine)
- `publish-oidc-discovery.yml` — Publish OIDC Discovery Documents
- `build-infra-binary.yml` — Build Infra Binary (upstream-only)
- `test.yml` — Test (upstream-only)

### Wiring into existing entry points
- `README.md` / `README.zh.md` — added to the documentation map (Quick reference).
- `docs/CUSTOMER_ONBOARDING.md` / `.zh.md` — added to the Related Documents tables.
- `docs/BOOTSTRAP.md` / `.zh.md` — added "full inputs and examples" pointers in the Preview / Rollout / Publish OIDC Discovery sections, anchored to the matching workflow section.

### Notes
- Documentation-only change; no workflow behavior is modified.
- No directly-related open issue exists for this work, so the PR is intentionally not linked to one.