### PR TITLE
fix(gateway): lineage route declares both path segments

### DIFF
--- a/infra/internal/services/apigateway_routes.go
+++ b/infra/internal/services/apigateway_routes.go
@@ -100,7 +100,7 @@ func buildAPIRouteSpecs() []routeSpec {
 
 		"GET /api/v1/semantic/resources",
 		"GET /api/v1/semantic/resources/{resource_id}",
-		"GET /api/v1/semantic/lineage/{resource_id}",
+		"GET /api/v1/semantic/lineage/{entity_type}/{row_id}",
 	)
 	return append(business, preflightRoutes()...)
 }

--- a/infra/internal/services/apigateway_routes_test.go
+++ b/infra/internal/services/apigateway_routes_test.go
@@ -68,6 +68,7 @@ func TestAPIRouteSpecsCoverKeyRoutes(t *testing.T) {
 		"POST /api/ai/v1/compliance/decisions",
 		"GET /api/v1/deepping",
 		"GET /api/v1/semantic/resources",
+		"GET /api/v1/semantic/lineage/{entity_type}/{row_id}",
 		"POST /api/sys/v1/discovery/reachable",
 		"GET /api/sys/v1/ontology/object-types",
 		"GET /api/sys/v1/governance/claims",


### PR DESCRIPTION
Mirrors Lychee-Technology/ltbase.api#498 (route-table fix: Lychee-Technology/ltbase.api#559): the semantic lineage handler requires `{entity_type}/{row_id}`, so the explicit gateway route now declares both segments instead of a single `{resource_id}`.

Merge after Lychee-Technology/ltbase.api#559 lands (safe either way — the data plane serves the two-segment path in-process via prefix matching regardless of declared key).

- [x] `go test ./infra/internal/services/ -run TestAPIRouteSpecsCoverKeyRoutes -v` — RED on old spec, GREEN on new
- [x] `go test ./infra/...` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013hKcH4o4qVtBotgAUKccsZ